### PR TITLE
small improvements - submit on enter pressed

### DIFF
--- a/app/basicComponents/SmInput.js
+++ b/app/basicComponents/SmInput.js
@@ -46,6 +46,7 @@ const ErrorMsg = styled.div`
 
 type Props = {
   onChange?: ({ value: string }) => void,
+  onEnterPress?: () => void,
   defaultValue?: string,
   isDisabled?: boolean,
   placeholder?: string,
@@ -75,6 +76,7 @@ class SmInput extends PureComponent<Props> {
           hasError={errorMsg}
           readOnly={isDisabled}
           placeholder={placeholder || INPUT_PLACEHOLDER}
+          onKeyPress={this.onEnterPress}
           onChange={this.onChange}
           style={style}
           type={type}
@@ -88,6 +90,13 @@ class SmInput extends PureComponent<Props> {
     const { hasDebounce } = this.props;
     hasDebounce && clearTimeout(this.debounce);
   }
+
+  onEnterPress = ({ key }: { key: string }) => {
+    const { onEnterPress } = this.props;
+    if (key === 'Enter' && !!onEnterPress) {
+      onEnterPress();
+    }
+  };
 
   onChange = ({ target }: { target: { value: string } }) => {
     const { hasDebounce, debounceTime, onChange } = this.props;

--- a/app/components/auth/CreateWallet.js
+++ b/app/components/auth/CreateWallet.js
@@ -10,6 +10,9 @@ import { smColors } from '/vars';
 import type { Action } from '/types';
 import { shell } from 'electron';
 
+// TODO: For testing purposes, set to 1 minimum length. Should be changed back to 8 when ready.
+const passwordMinimumLentgth = 1;
+
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -122,9 +125,16 @@ class CreateWallet extends Component<Props, State> {
       <Wrapper>
         <UpperPart>
           <UpperPartHeader>Encrypt your Wallet</UpperPartHeader>
-          <GrayText>Must be at least 8 characters</GrayText>
-          <SmInput type="password" placeholder="Type passphrase" errorMsg={passphraseError} onChange={this.handlePasswordTyping} hasDebounce />
-          <SmInput type="password" placeholder="Verify passphrase" errorMsg={verifyPassphraseError} onChange={this.handlePasswordVerifyTyping} hasDebounce />
+          <GrayText>{`Must be at least ${passwordMinimumLentgth} character${passwordMinimumLentgth > 1 ? 's' : ''}`}</GrayText>
+          <SmInput type="password" placeholder="Type passphrase" errorMsg={passphraseError} onEnterPress={this.handleEnterPress} onChange={this.handlePasswordTyping} hasDebounce />
+          <SmInput
+            type="password"
+            placeholder="Verify passphrase"
+            errorMsg={verifyPassphraseError}
+            onEnterPress={this.handleEnterPress}
+            onChange={this.handlePasswordVerifyTyping}
+            hasDebounce
+          />
           <GrayText>
             Your Wallet file is encrypted and saved on your computer. <Link onClick={this.openWalletBackupDirectory}>Show me the file</Link>
           </GrayText>
@@ -155,6 +165,13 @@ class CreateWallet extends Component<Props, State> {
     );
   };
 
+  handleEnterPress = () => {
+    const { passphrase, verifiedPassphrase, passphraseError, verifyPassphraseError } = this.state;
+    if (!!passphrase || !!verifiedPassphrase || !passphraseError || !verifyPassphraseError) {
+      this.createWallet();
+    }
+  };
+
   handlePasswordTyping = ({ value }: { value: string }) => {
     this.setState({ passphrase: value, passphraseError: null });
   };
@@ -165,11 +182,9 @@ class CreateWallet extends Component<Props, State> {
 
   validate = () => {
     const { passphrase, verifiedPassphrase } = this.state;
-    // TODO: For testing purposes, set to 1 minimum length. Should be changed back to 8 when ready.
-    const passwordMinimumLentgth = 1;
     const hasPassphraseError = !passphrase || (!!passphrase && passphrase.length < passwordMinimumLentgth);
     const hasVerifyPassphraseError = !verifiedPassphrase || passphrase !== verifiedPassphrase;
-    const passphraseError = hasPassphraseError ? 'Passphrase has to be 8 characters or more.' : null;
+    const passphraseError = hasPassphraseError ? `Passphrase has to be ${passwordMinimumLentgth} characters or more.` : null;
     const verifyPassphraseError = hasVerifyPassphraseError ? 'Passphrase does not match.' : null;
     this.setState({ passphraseError, verifyPassphraseError });
     return !passphraseError && !verifyPassphraseError;

--- a/app/components/auth/UnlockWallet.js
+++ b/app/components/auth/UnlockWallet.js
@@ -97,7 +97,7 @@ class UnlockWallet extends Component<Props, State> {
             <Image src={welcomeBack} />
           </ImageWrapper>
           <UpperPartHeader>Enter your wallet passphrase</UpperPartHeader>
-          <SmInput type="password" placeholder="Type passphrase" errorMsg={errorMsg} onChange={this.handlePasswordTyping} />
+          <SmInput type="password" placeholder="Type passphrase" errorMsg={errorMsg} onEnterPress={this.handleEnterPress} onChange={this.handlePasswordTyping} />
         </UpperPart>
         <BottomPart>
           <SmButton text="Unlock" isDisabled={!passphrase || !!errorMsg} theme="orange" onPress={this.decryptWallet} />
@@ -109,6 +109,13 @@ class UnlockWallet extends Component<Props, State> {
       </Wrapper>
     );
   }
+
+  handleEnterPress = () => {
+    const { passphrase, errorMsg } = this.state;
+    if (!!passphrase || !errorMsg) {
+      this.decryptWallet();
+    }
+  };
 
   handlePasswordTyping = ({ value }: { value: string }) => {
     this.setState({ passphrase: value, errorMsg: null });
@@ -128,7 +135,7 @@ class UnlockWallet extends Component<Props, State> {
         this.setState({ errorMsg: 'Passphrase Incorrect.' });
       }
     } else {
-      this.setState({ errorMsg: 'Passphrase cannot be less than 8 characters.' });
+      this.setState({ errorMsg: `Passphrase cannot be less than ${passwordMinimumLentgth} character${passwordMinimumLentgth > 1 ? 's' : ''}.` });
     }
   };
 }

--- a/app/components/settings/ChangePassphrase.js
+++ b/app/components/settings/ChangePassphrase.js
@@ -8,6 +8,9 @@ import { fileSystemService } from '/infra/fileSystemService';
 import { smColors } from '/vars';
 import type { Action, Account } from '/types';
 
+// TODO: For testing purposes, set to 1 minimum length. Should be changed back to 8 when ready.
+const passwordMinimumLentgth = 1;
+
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -104,9 +107,23 @@ class ChangePassphrase extends Component<Props, State> {
       <Wrapper>
         <UpperPart>
           <UpperPartHeader>Encrypt your Wallet</UpperPartHeader>
-          <GrayText>Must be at least 8 characters</GrayText>
-          <SmInput type="password" placeholder="Type passphrase" errorMsg={passphraseError} onChange={this.handlePassphraseTyping} hasDebounce />
-          <SmInput type="password" placeholder="Verify passphrase" errorMsg={verifyPassphraseError} onChange={this.handlePassphraseVerifyTyping} hasDebounce />
+          <GrayText>{`Must be at least ${passwordMinimumLentgth} character${passwordMinimumLentgth > 1 ? 's' : ''}`}</GrayText>
+          <SmInput
+            type="password"
+            placeholder="Type passphrase"
+            errorMsg={passphraseError}
+            onEnterPress={this.handleEnterPress}
+            onChange={this.handlePassphraseTyping}
+            hasDebounce
+          />
+          <SmInput
+            type="password"
+            placeholder="Verify passphrase"
+            errorMsg={verifyPassphraseError}
+            onEnterPress={this.handleEnterPress}
+            onChange={this.handlePassphraseVerifyTyping}
+            hasDebounce
+          />
           <GrayText>
             Your Wallet file is encrypted and saved on your computer. <Link onClick={this.openWalletBackupDirectory}>Show me the file</Link>
           </GrayText>
@@ -116,6 +133,13 @@ class ChangePassphrase extends Component<Props, State> {
         </BottomPart>
       </Wrapper>
     );
+  };
+
+  handleEnterPress = () => {
+    const { passphrase, verifiedPassphrase, passphraseError, verifyPassphraseError } = this.state;
+    if (!!passphrase || !!verifiedPassphrase || !passphraseError || !verifyPassphraseError) {
+      this.updatePassphrase();
+    }
   };
 
   handlePassphraseTyping = ({ value }: { value: string }) => {
@@ -128,9 +152,9 @@ class ChangePassphrase extends Component<Props, State> {
 
   validate = () => {
     const { passphrase, verifiedPassphrase } = this.state;
-    const hasPassphraseError = !passphrase || (!!passphrase && passphrase.length < 8);
+    const hasPassphraseError = !passphrase || (!!passphrase && passphrase.length < passwordMinimumLentgth);
     const hasVerifyPassphraseError = !verifiedPassphrase || passphrase !== verifiedPassphrase;
-    const passphraseError = hasPassphraseError ? 'Passphrase has to be 8 characters or more.' : null;
+    const passphraseError = hasPassphraseError ? `Passphrase has to be ${passwordMinimumLentgth} characters or more.` : null;
     const verifyPassphraseError = hasVerifyPassphraseError ? 'Passphrase does not match.' : null;
     this.setState({ passphraseError, verifyPassphraseError });
     return !passphraseError && !verifyPassphraseError;


### PR DESCRIPTION
In this commit:

For the following components:
Unlock Wallet
Change Passphrase
Create Wallet

Allow for enter-press action for submitting the form