### PR TITLE
Refactor IPC flow: select PoST folder & create new wallet flows

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import store from './redux/store';
 import StyledApp from './StyledApp';
 import './assets/fonts/SourceCodePro-Regular.ttf';
 import './assets/fonts/SourceCodePro-Bold.ttf';
+import { subscribeOnIpcEvents } from './infra/eventsService/eventsService';
 
-const App = () => (
-  <Provider store={store}>
-    <StyledApp />
-  </Provider>
-);
+const App = () => {
+  useEffect(() => subscribeOnIpcEvents(store), []);
+
+  return (
+    <Provider store={store}>
+      <StyledApp />
+    </Provider>
+  );
+};
 
 export default App;

--- a/app/components/node/PoSDirectory.tsx
+++ b/app/components/node/PoSDirectory.tsx
@@ -83,16 +83,21 @@ const PoSDirectory = ({ nextAction, skipAction, dataDir, setDataDir, freeSpace, 
 
   const icon = isDarkMode ? posDirectoryWhite : posDirectoryBlack;
 
-  const openFolderSelectionDialog = async () => {
-    const { error, dataDir, calculatedFreeSpace } = await eventsService.selectPostFolder();
-    if (error) {
-      setHasPermissionError(true);
-    } else {
-      setDataDir(dataDir);
-      setFreeSpace(formatBytes(calculatedFreeSpace));
-      setHasPermissionError(false);
-    }
-  };
+  const openFolderSelectionDialog = () =>
+    eventsService
+      .selectPostFolder()
+      .then((selected) => {
+        if (selected) {
+          setDataDir(selected.dataDir);
+          setFreeSpace(formatBytes(selected.calculatedFreeSpace));
+          setHasPermissionError(false);
+        }
+        return selected;
+      })
+      .catch((err) => {
+        console.error(err); // eslint-disable-line no-console
+        setHasPermissionError(true);
+      });
 
   return (
     <>

--- a/app/infra/eventsService/eventsService.ts
+++ b/app/infra/eventsService/eventsService.ts
@@ -5,6 +5,7 @@ import { setNodeError, setNodeStatus } from '../../redux/node/actions';
 import { updateAccountData, setTransactions } from '../../redux/wallet/actions';
 import { setRewards, setPostStatus } from '../../redux/smesher/actions';
 import store from '../../redux/store';
+import SmesherManager from '../../../desktop/SmesherManager';
 
 class EventsService {
   static createWallet = ({ password, existingMnemonic, ip, port }: { password: string; existingMnemonic: string; ip?: string; port?: string }) =>
@@ -39,7 +40,7 @@ class EventsService {
   /** ************************************   SMESHER   ****************************************** */
   static getSmesherSettings = () => ipcRenderer.invoke(ipcConsts.SMESHER_GET_SETTINGS);
 
-  static selectPostFolder = () => ipcRenderer.invoke(ipcConsts.SMESHER_SELECT_POST_FOLDER);
+  static selectPostFolder = (): ReturnType<SmesherManager['selectPostFolder']> => ipcRenderer.invoke(ipcConsts.SMESHER_SELECT_POST_FOLDER);
 
   static checkFreeSpace = ({ dataDir }: { dataDir: string }) => ipcRenderer.invoke(ipcConsts.SMESHER_CHECK_FREE_SPACE, { dataDir });
 

--- a/app/infra/eventsService/eventsService.ts
+++ b/app/infra/eventsService/eventsService.ts
@@ -6,10 +6,26 @@ import { updateAccountData, setTransactions } from '../../redux/wallet/actions';
 import { setRewards, setPostStatus } from '../../redux/smesher/actions';
 import store from '../../redux/store';
 import SmesherManager from '../../../desktop/SmesherManager';
+import WalletManager from '../../../desktop/WalletManager';
 
 class EventsService {
-  static createWallet = ({ password, existingMnemonic, ip, port }: { password: string; existingMnemonic: string; ip?: string; port?: string }) =>
-    ipcRenderer.invoke(ipcConsts.W_M_CREATE_WALLET, { password, existingMnemonic, ip, port });
+  static createWallet = ({
+    password,
+    existingMnemonic,
+    ip,
+    port
+  }: {
+    password: string;
+    existingMnemonic: string;
+    ip?: string;
+    port?: string;
+  }): ReturnType<WalletManager['createWalletFile']> =>
+    ipcRenderer.invoke(ipcConsts.W_M_CREATE_WALLET, {
+      password,
+      existingMnemonic,
+      ip,
+      port
+    });
 
   static readWalletFiles = () => ipcRenderer.invoke(ipcConsts.W_M_READ_WALLET_FILES);
 

--- a/app/types/wallet.ts
+++ b/app/types/wallet.ts
@@ -1,6 +1,6 @@
 export interface Account {
   displayName: string;
-  created: number;
+  created: string;
   currentState: { balance: number; counter: number };
   projectedState: { balance: number; counter: number };
   path: string;


### PR DESCRIPTION
There is no issue.

I think that there are some anti-patterns in the code now and I decided to offer solutions for them.
If you approve them, then these changes can be quickly distributed to the rest of the code.

Please, review this PR commit by commit.

Here is a list of things that I tried to solve and we need to discuss.

## 1. Error propagation in Promises
First of all, good practice to catch errors as soon as possible. However, if it is impossible to provide reasonable defaults or some behavior that will keep the application in a consistent state, it's better to propagate the error.
This way there are more chances to catch errors and keep the application in a consistent state.

Moreover, I'm sure that combining valid data (or some defaults) with the error is a bad practice. It causes any data (valid or containing error) to look like a "kinda-valid", which leads to the need to check for existing `error` property, check everything on each step, and so on.

_I prefer `Maybe A` (also known as `Option`) instead of checking for `null` or `undefined`, `Either Error A` to be sure there is an error or valid data, and so on. I do not urge to put monads in the code, but this is a very convenient abstraction, that prevents from shooting in the foot. And the `Promise`s are very similar to `Either` already out of the box._

So the main idea of this part is to **separate errors from the data** and **propagate the error until someone can handle it properly**.

Take a look at the first commit ("Part 1...."), it's an example of how it can be separated without any pain.
So, what do you think about it?

_BTW, I removed the logging of the `checkDiskSpace` error. If it is necessary, we can return try-catch. Although I would prefer to let the error propagate and if it is necessary to log errors that will then be transmitted over IPC, then I would suggest writing a small function for this, through which to hang handlers for IPC events. I can make an example if you want._

## 2. TypeScript is for types
I found that despite the presence of declared types, they are not used everywhere. And the IPC event bus completely breaks this connection, so when we receive data through this bus, we lose knowledge about types.

Because sometimes these are intermediate types or they are not described anywhere, I used the utility type ' ReturnType`, referring to the function that gives values. I don't really like this approach (especially, that `app` imports `../../../../../desktop/..`), but so far I haven't found a more elegant solution. I will be glad to hear your ideas.

In any case, specifying the types immediately revealed some problems:
- a bug with using an unexisting property name (see `openFolderSelectionDialog` in the first commit)
- payload of dispatched actions does not match types (see commit "Part 2...")
- `Account.created` does not match types in the code

**I propose to use types when it is possible** and one day we can turn on strict mode and get rid of all `Any`s ;)

## 3. Atomic state changes
(Proposal for the future, does not touch it yet)

Also, I've revealed that there a frequent pattern in the code, where some event dispatches a bunch of actions. I didn't touch this yet (wrote a comment `TODO`), but I want to tell you why this is a bad practice and then we can discuss how we can solve it (there a few solutions).

Firstly, it may lead the app to an inconsistent state.
For example, the first action updates the state correctly, the second one throws an error, third is not dispatched at all. We've got an inconsistent state (partially updated).
If something should update multiple hunks of the state it should be done within one state update (atomic update). In this case, we can easily undo the last action (which updates a bunch of things), revert the app state to the last valid state (via ErrorBoundary), and so on.

Secondly, dispatching multiple actions one by one causes multiple re-renders of the application, which may hit performance. But for this point solution already exists in `react-redux@7`, called `batch`.

Possible solutions:
- "vanilla redux" — create separate action types and reducer handlers for everything,
- use https://github.com/tshelburne/redux-batched-actions
- leave it as is until it hurts :)

---
~~You may notice that I've added a `tap` utility function, which is very convenient for making side effects.~~
I'd prefer to import a utility library for such purposes. I like `ramda` and `lodash-fp`, but I do not insist on FP libraries :)