### PR TITLE
Take discovery URL from env or fallback to hard-coded one

### DIFF
--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -28,7 +28,7 @@ import './wasm_exec';
 
 const writeFileAsync = util.promisify(fs.writeFile);
 
-const DISCOVERY_URL = 'https://discover.spacemesh.io/networks.json';
+const DISCOVERY_URL = process.env.DISCOVERY_URL || 'https://discover.spacemesh.io/networks.json';
 
 (async function () {
   const filePath = path.resolve(app.getAppPath(), process.env.NODE_ENV === 'development' ? './' : 'desktop/', 'ed25519.wasm');


### PR DESCRIPTION
It closes #756.

Use the `DISCOVERY_URL` env variable to set the custom URL.
E.G. `DISCOVERY_URL=localhost yarn start`