### PR TITLE
Rename *SMD symbol to Smidge and add a better input for amounts

### DIFF
--- a/app/basicComponents/AmountInput.tsx
+++ b/app/basicComponents/AmountInput.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { CoinUnits, toSMH, toSmidge } from '../infra/utils';
+import { smColors } from '../vars';
+
+const Wrapper = styled.div<{ isFocused: boolean; disabled: boolean }>`
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  height: 40px;
+  border: 1px solid ${({ isFocused }) => (isFocused ? smColors.purple : smColors.black)};
+  opacity: ${({ disabled }) => (disabled ? 0.2 : 1)};
+  ${({ disabled }) => !disabled && `&:hover { border: 1px solid ${smColors.purple}; `}
+  background-color: ${smColors.white};
+`;
+const Input = styled.input<{
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
+  disabled: boolean;
+}>`
+  flex: 1;
+  width: 100%;
+  height: 36px;
+  padding: 8px 10px;
+  border-radius: 0;
+  border: none;
+  color: ${({ disabled }) => (disabled ? smColors.darkGray : smColors.black)};
+  font-size: 14px;
+  line-height: 16px;
+  outline: none;
+`;
+
+const UnitButton = styled.button`
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+
+  padding: 0 1em;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  cursor: pointer;
+
+  :hover,
+  :active,
+  :focus {
+    color: ${smColors.green};
+  }
+`;
+
+type Props = {
+  onChange: (amountSmidge: number) => void;
+  disabled?: boolean;
+  value?: number;
+  style?: React.CSSProperties;
+};
+
+const AmountInput = ({ onChange, disabled, style, value }: Props) => {
+  const [curValue, setValue] = useState(value ? value.toString() : '');
+  const [units, setUnits] = useState<CoinUnits>(CoinUnits.SMH);
+  const [isFocused, setFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const changeAmount = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.validity.valid) return;
+    const newValue = e.target.value;
+    if (newValue === '') {
+      setValue('');
+      onChange(0);
+      return;
+    }
+    const parsedValue = parseFloat(newValue);
+    if (Number.isNaN(parsedValue)) return;
+
+    setValue(newValue);
+
+    // If User typed a decimal in Smidge -> switch to SMH without any conversion
+    const nextUnits = units === CoinUnits.Smidge && newValue.indexOf('.') !== -1 ? CoinUnits.SMH : units;
+    setUnits(nextUnits);
+
+    // Commit always in Smidge
+    onChange(nextUnits === CoinUnits.SMH ? toSmidge(parsedValue) : parsedValue);
+  };
+  const changeUnits = () => {
+    const nextUnits = units === CoinUnits.SMH ? CoinUnits.Smidge : CoinUnits.SMH;
+    setUnits(nextUnits);
+    // Convert amount to units
+    const parsedValue = parseFloat(curValue);
+    if (!Number.isNaN(parsedValue)) {
+      const nextValue = nextUnits === CoinUnits.Smidge ? toSmidge(parsedValue) : toSMH(parsedValue);
+      setValue(nextValue.toString());
+    }
+    // Switch focus back to the input
+    setTimeout(() => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+        inputRef.current.selectionStart = inputRef.current.value.length;
+        inputRef.current.selectionEnd = inputRef.current.value.length;
+      }
+    }, 0);
+  };
+
+  return (
+    <Wrapper isFocused={isFocused} disabled={!!disabled} style={style}>
+      <Input pattern="[0-9]*\.?[0-9]*" value={curValue} onChange={changeAmount} onFocus={() => setFocused(true)} onBlur={() => setFocused(false)} disabled={!!disabled} />
+      <UnitButton onClick={changeUnits}>{units}</UnitButton>
+    </Wrapper>
+  );
+};
+
+export default AmountInput;

--- a/app/basicComponents/AmountInput.tsx
+++ b/app/basicComponents/AmountInput.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { CoinUnits, toSMH, toSmidge } from '../infra/utils';
 import { smColors } from '../vars';
+import RefreshIcon from './Icons/RefreshIcon';
 
 const Wrapper = styled.div<{ isFocused: boolean; disabled: boolean }>`
   position: relative;
@@ -36,22 +37,34 @@ const Input = styled.input<{
 `;
 
 const UnitButton = styled.button`
-  position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
+  height: 100%;
 
   padding: 0 1em;
   border: 0;
   outline: 0;
-  background: transparent;
+  background: ${smColors.white};
   cursor: pointer;
+
+  svg {
+    fill: ${smColors.realBlack};
+  }
 
   :hover,
   :active,
   :focus {
     color: ${smColors.green};
+
+    svg {
+      fill: ${smColors.green};
+    }
   }
+`;
+
+const Toggle = styled(RefreshIcon)`
+  display: inline-block;
+  margin-left: 4px;
+  cursor: pointer;
+  vertical-align: bottom;
 `;
 
 type Props = {
@@ -108,8 +121,19 @@ const AmountInput = ({ onChange, disabled, style, value }: Props) => {
 
   return (
     <Wrapper isFocused={isFocused} disabled={!!disabled} style={style}>
-      <Input pattern="[0-9]*\.?[0-9]*" value={curValue} onChange={changeAmount} onFocus={() => setFocused(true)} onBlur={() => setFocused(false)} disabled={!!disabled} />
-      <UnitButton onClick={changeUnits}>{units}</UnitButton>
+      <Input
+        ref={inputRef}
+        pattern="[0-9]*\.?[0-9]*"
+        value={curValue}
+        onChange={changeAmount}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        disabled={!!disabled}
+      />
+      <UnitButton onClick={changeUnits}>
+        {units}
+        <Toggle />
+      </UnitButton>
     </Wrapper>
   );
 };

--- a/app/basicComponents/Icons/RefreshIcon.tsx
+++ b/app/basicComponents/Icons/RefreshIcon.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import Svg from './Svg';
+
+const RefreshIcon = ({ className }: { className?: string }) => (
+  <Svg width="13" height="17" viewBox="0 0 13 17" xmlns="http://www.w3.org/2000/svg" className={className}>
+    <rect x="9.60669" y="2.14201" width="0.979122" height="0.979122" />
+    <rect x="9.60669" y="3.12109" width="0.979122" height="0.979122" />
+    <rect x="8.62781" y="4.10028" width="0.979122" height="0.979122" />
+    <rect x="9.60669" y="4.10028" width="0.979122" height="0.979122" />
+    <rect x="10.5859" y="3.12109" width="0.979122" height="0.979122" />
+    <rect x="8.62781" y="5.07932" width="0.979122" height="0.979122" />
+    <rect x="7.64856" y="5.07932" width="0.979122" height="0.979122" />
+    <rect x="7.64856" y="6.0585" width="0.979122" height="0.979122" />
+    <rect x="8.62781" y="2.14201" width="0.979122" height="0.979122" />
+    <rect x="8.62781" y="1.16288" width="0.979122" height="0.979122" />
+    <rect x="7.64856" y="1.16288" width="0.979122" height="0.979122" />
+    <rect x="7.64893" y="0.183838" width="0.979122" height="0.979122" />
+    <rect x="3.4115" y="14.5449" width="0.979122" height="0.979122" transform="rotate(-180 3.4115 14.5449)" />
+    <rect x="3.4115" y="13.5658" width="0.979122" height="0.979122" transform="rotate(-180 3.4115 13.5658)" />
+    <rect x="4.39038" y="12.5866" width="0.979122" height="0.979122" transform="rotate(-180 4.39038 12.5866)" />
+    <rect x="3.4115" y="12.5866" width="0.979122" height="0.979122" transform="rotate(-180 3.4115 12.5866)" />
+    <rect x="2.43225" y="13.5658" width="0.979122" height="0.979122" transform="rotate(-180 2.43225 13.5658)" />
+    <rect x="4.39038" y="11.6076" width="0.979122" height="0.979122" transform="rotate(-180 4.39038 11.6076)" />
+    <rect x="5.36963" y="11.6076" width="0.979122" height="0.979122" transform="rotate(-180 5.36963 11.6076)" />
+    <rect x="5.36963" y="10.6284" width="0.979122" height="0.979122" transform="rotate(-180 5.36963 10.6284)" />
+    <rect x="4.39038" y="14.5449" width="0.979122" height="0.979122" transform="rotate(-180 4.39038 14.5449)" />
+    <rect x="4.39038" y="15.524" width="0.979122" height="0.979122" transform="rotate(-180 4.39038 15.524)" />
+    <rect x="5.36963" y="15.524" width="0.979122" height="0.979122" transform="rotate(-180 5.36963 15.524)" />
+    <rect x="5.36926" y="16.5031" width="0.979122" height="0.979122" transform="rotate(-180 5.36926 16.5031)" />
+    <rect x="11.5648" y="7.74084" width="0.979122" height="0.979122" />
+    <rect x="1.34656" y="8.94592" width="0.979122" height="0.979122" transform="rotate(-180 1.34656 8.94592)" />
+    <rect x="11.5648" y="6.76184" width="0.979122" height="0.979122" />
+    <rect x="1.34656" y="9.92505" width="0.979122" height="0.979122" transform="rotate(-180 1.34656 9.92505)" />
+    <rect x="11.5651" y="5.83273" width="0.979122" height="0.979122" />
+    <rect x="1.34668" y="10.854" width="0.979122" height="0.979122" transform="rotate(-180 1.34668 10.854)" />
+    <rect x="11.5648" y="8.67017" width="0.979122" height="0.979122" />
+    <rect x="1.34656" y="8.01672" width="0.979122" height="0.979122" transform="rotate(-180 1.34656 8.01672)" />
+    <rect x="10.5858" y="9.64929" width="0.979122" height="0.979122" />
+    <rect x="2.32556" y="7.0376" width="0.979122" height="0.979122" transform="rotate(-180 2.32556 7.0376)" />
+    <rect x="11.5648" y="9.64929" width="0.979122" height="0.979122" />
+    <rect x="1.34656" y="7.0376" width="0.979122" height="0.979122" transform="rotate(-180 1.34656 7.0376)" />
+    <rect x="10.5858" y="10.6284" width="0.979122" height="0.979122" />
+    <rect x="2.32556" y="6.05847" width="0.979122" height="0.979122" transform="rotate(-180 2.32556 6.05847)" />
+    <rect x="10.5858" y="11.6075" width="0.979122" height="0.979122" />
+    <rect x="2.32556" y="5.07935" width="0.979122" height="0.979122" transform="rotate(-180 2.32556 5.07935)" />
+    <rect x="9.60681" y="11.6075" width="0.979122" height="0.979122" />
+    <rect x="3.30457" y="5.07935" width="0.979122" height="0.979122" transform="rotate(-180 3.30457 5.07935)" />
+    <rect x="9.60681" y="12.5865" width="0.979122" height="0.979122" />
+    <rect x="3.30457" y="4.10022" width="0.979122" height="0.979122" transform="rotate(-180 3.30457 4.10022)" />
+    <rect x="8.62756" y="12.5865" width="0.979122" height="0.979122" />
+    <rect x="4.28381" y="4.10022" width="0.979122" height="0.979122" transform="rotate(-180 4.28381 4.10022)" />
+    <rect x="7.64856" y="12.5865" width="0.979122" height="0.979122" />
+    <rect x="5.26282" y="4.10022" width="0.979122" height="0.979122" transform="rotate(-180 5.26282 4.10022)" />
+    <rect x="6.66956" y="12.5865" width="0.979122" height="0.979122" />
+    <rect x="6.24182" y="4.10022" width="0.979122" height="0.979122" transform="rotate(-180 6.24182 4.10022)" />
+    <rect x="5.47668" y="12.5865" width="1.19294" height="0.979122" />
+    <rect x="7.43469" y="4.10022" width="1.19294" height="0.979122" transform="rotate(-180 7.43469 4.10022)" />
+    <rect x="3.30444" y="12.5865" width="2.17199" height="0.979122" />
+    <rect x="9.60657" y="4.10022" width="2.17187" height="0.979122" transform="rotate(-180 9.60657 4.10022)" />
+  </Svg>
+);
+
+export default RefreshIcon;

--- a/app/basicComponents/Icons/Svg.tsx
+++ b/app/basicComponents/Icons/Svg.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export default styled.svg.attrs({
+  version: '1.1',
+  xmlns: 'http://www.w3.org/2000/svg',
+  xmlnsXlink: 'http://www.w3.org/1999/xlink'
+})``;

--- a/app/components/wallet/TxParams.tsx
+++ b/app/components/wallet/TxParams.tsx
@@ -4,6 +4,7 @@ import { Link, Input, DropDown, Button, ErrorPopup, AutocompleteDropdown } from 
 import { getAbbreviatedText, getAddress } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { Contact } from '../../types';
+import AmountInput from '../../basicComponents/AmountInput';
 
 const Wrapper = styled.div`
   display: flex;
@@ -107,7 +108,7 @@ type Props = {
   updateTxAddress: ({ value }: { value: string }) => void;
   resetAddressError: () => void;
   amount: number;
-  updateTxAmount: ({ value }: { value: number }) => void;
+  updateTxAmount: (value: number) => void;
   hasAmountError: boolean;
   resetAmountError: () => void;
   updateFee: ({ fee }: { fee: number }) => void;
@@ -153,7 +154,7 @@ const TxParams = ({
 
   const navigateToGuide = () => window.open('https://testnet.spacemesh.io/#/send_coin');
 
-  const handleAmountChange = useCallback(({ value }) => updateTxAmount({ value: parseFloat(value) }), [updateTxAmount]);
+  const handleAmountChange = useCallback((value) => updateTxAmount(parseFloat(value)), [updateTxAmount]);
 
   return (
     <Wrapper>
@@ -187,7 +188,7 @@ const TxParams = ({
       <DetailsRow>
         <DetailsText>Amount</DetailsText>
         <Dots>....................................</Dots>
-        <Input value={amount} onChange={handleAmountChange} extraText="SMD" style={inputStyle} />
+        <AmountInput value={amount} onChange={updateTxAmount} style={inputStyle} />
         {hasAmountError && <ErrorPopup onClick={resetAmountError} text="You don't have enough Smidge in your wallet." style={errorPopupStyle1} />}
       </DetailsRow>
       <DetailsRow>

--- a/app/infra/utils.ts
+++ b/app/infra/utils.ts
@@ -26,32 +26,20 @@ export const formatBytes = (bytes: number) => {
   return `${parseFloat((bytes / 1073741824).toFixed(2))} GB`;
 };
 
+const packValueAndUnit = (value: number, unit: string) => ({
+  value: parseFloat(value.toFixed(3)).toString(),
+  unit
+});
+
 // Internal helper - returns the value and the unit of a smidge coin amount.
 // Used to format smidge strings
 export const getValueAndUnit = (amount: number) => {
-  let v = 0;
-  let unit = 'SMH';
-
-  if (amount >= 10 ** 9) {
-    v = amount / 10 ** 12;
-  } else if (amount >= 10 ** 6) {
-    v = amount / 10 ** 9;
-    unit = 'GSMD';
-  } else if (amount >= 10 ** 4) {
-    v = amount / 10 ** 6;
-    unit = 'MSMD';
-  } else if (amount === 0) {
-    // we want to show 0 balance in SMH units
-    v = 0;
-    unit = 'SMH';
-  } else if (!Number.isNaN(amount)) {
-    v = amount;
-    unit = 'SMD';
-  }
-
-  // truncate to 3 decimals and truncate trailing fractional 0s
-  const s = parseFloat(v.toFixed(3)).toString();
-  return { value: s, unit };
+  // Show `23.053 SMH` for big amount
+  if (amount >= 10 ** 9) return packValueAndUnit(amount / 10 ** 12, 'SMH');
+  // Or `6739412 Smidge` (without dot) for small amount
+  else if (!Number.isNaN(amount)) return packValueAndUnit(amount, 'Smidge');
+  // Show `0 SMH` for zero amount and NaN
+  else return packValueAndUnit(0, 'SMH');
 };
 
 // Returns formatted display string for a smidge amount.

--- a/app/infra/utils.ts
+++ b/app/infra/utils.ts
@@ -26,20 +26,32 @@ export const formatBytes = (bytes: number) => {
   return `${parseFloat((bytes / 1073741824).toFixed(2))} GB`;
 };
 
+// -------------------
+// Units
+// -------------------
+
+export enum CoinUnits {
+  SMH = 'SMH',
+  Smidge = 'Smidge'
+}
+
 const packValueAndUnit = (value: number, unit: string) => ({
   value: parseFloat(value.toFixed(3)).toString(),
   unit
 });
 
+export const toSMH = (smidge: number) => smidge / 10 ** 12;
+export const toSmidge = (smh: number) => Math.ceil(smh * 10 ** 12);
+
 // Internal helper - returns the value and the unit of a smidge coin amount.
 // Used to format smidge strings
 export const getValueAndUnit = (amount: number) => {
   // Show `23.053 SMH` for big amount
-  if (amount >= 10 ** 9) return packValueAndUnit(amount / 10 ** 12, 'SMH');
+  if (amount >= 10 ** 9) return packValueAndUnit(toSMH(amount), CoinUnits.SMH);
   // Or `6739412 Smidge` (without dot) for small amount
-  else if (!Number.isNaN(amount)) return packValueAndUnit(amount, 'Smidge');
+  else if (!Number.isNaN(amount)) return packValueAndUnit(amount, CoinUnits.Smidge);
   // Show `0 SMH` for zero amount and NaN
-  else return packValueAndUnit(0, 'SMH');
+  else return packValueAndUnit(0, CoinUnits.SMH);
 };
 
 // Returns formatted display string for a smidge amount.

--- a/app/screens/wallet/SendCoins.tsx
+++ b/app/screens/wallet/SendCoins.tsx
@@ -40,7 +40,7 @@ const SendCoins = ({ history, location }: Props) => {
     setHasAddressError(false);
   };
 
-  const updateTxAmount = ({ value }: { value: number }) => {
+  const updateTxAmount = (value: number) => {
     setAmount(value);
     setHasAmountError(false);
   };


### PR DESCRIPTION
It closes #738

The new amount input:
![It looks like this](https://user-images.githubusercontent.com/1897530/130623456-264a2911-5711-4ce9-9f81-9dc28b6dac47.gif)

And I think that we can use this until we have a better design for the input ;)

It does not include handling amounts with precision (using `BigInt`), and that's why:

1. It requires touching a lot of code and regenerate some JS files generated from proto files. I think it's better to do such a big thing within the separate PR, especially since it requires careful testing of everything.
2. Also, it seems (https://github.com/spacemeshos/go-spacemesh/issues/2718#issuecomment-905974522) that Node will have some fixes related to data types of the balance. As a consequence, the proto interface will change to something else, which can store such a big amount. So I'm sure that we should return to this issue when we will have a new interface to avoid doing the same job twice.

Anyway, I have saved all my developments in a separate branch, so we can return back to them in the future.

---

Also, I have a small separate commit, that constrains the maximum input to `Number.MAX_SAFE_INTEGER` (9007199254740991) or even to the balance (when you want to send something).
But I think that doesn't look nice: you typing some amount and then... BANG! there is another amount in the input. Or if you have 0 SMH on the balance it will always be zero regardless of what you type in.
It is confusing. If you want to see it in action, tell me — I'll push a commit / separate branch ;)