### PR TITLE
Enlarge yarn install timeout for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
       # Install & Build
       - name: yarn install
         run: |
+          yarn config set network-timeout 300000
           yarn install --prefer-offline
       - name: yarn lint and build
         env:


### PR DESCRIPTION
It is required to ensure that every platform will install packages without dumb failure.
Also, I've checked that the notarization work on this fix ;)