### PR TITLE
Handle Node crashes on Node startup

### DIFF
--- a/app/redux/network/actions.ts
+++ b/app/redux/network/actions.ts
@@ -1,6 +1,5 @@
 import { eventsService } from '../../infra/eventsService';
 import { AppThDispatch } from '../../types';
-import { setNodeError } from '../node/actions';
 
 export const SET_NETWORK_DEFINITIONS = 'SET_NETWORK_DEFINITIONS';
 export const SET_CURRENT_LAYER = 'SET_CURRENT_LAYER';
@@ -13,18 +12,14 @@ export const getNetworkDefinitions = () => async (dispatch: AppThDispatch) => {
 
 export const getCurrentLayer = () => async (dispatch: AppThDispatch) => {
   const { currentLayer, error } = await eventsService.getCurrentLayer();
-  if (error) {
-    dispatch(setNodeError(error));
-  } else {
+  if (!error) {
     dispatch({ type: SET_CURRENT_LAYER, payload: { currentLayer } });
   }
 };
 
 export const getGlobalStateHash = () => async (dispatch: AppThDispatch) => {
   const { rootHash, error } = await eventsService.getGlobalStateHash();
-  if (error) {
-    dispatch(setNodeError(error));
-  } else {
+  if (!error) {
     dispatch({ type: SET_STATE_ROOT_HASH, payload: { rootHash } });
   }
 };

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -93,6 +93,7 @@ class NetServiceFactory<T extends { spacemesh: { v1: any; [k: string]: any }; [k
 
     let stream: ReturnType<typeof this.service[typeof method]>;
     let timeout: NodeJS.Timeout;
+
     const startStream = () => {
       if (!this.service) {
         throw new Error(`${this.serviceName} is not running`);

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -51,7 +51,6 @@ StoreService.init();
 
 // State
 const context = getDefaultAppContext();
-
 // App behaviors
 const onCloseHandler = promptBeforeClose(context);
 
@@ -89,5 +88,4 @@ app
   .then(() => Networks.update(context))
   .then(() => createTray(context))
   .then(() => createWindow(context, onCloseHandler))
-  // .then(() => createWindowOld())
   .catch(console.log); // eslint-disable-line no-console

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -58,7 +58,7 @@ const onCloseHandler = promptBeforeClose(context);
 const showMainWindow = () => {
   const { mainWindow } = context;
   if (mainWindow === null) {
-    createWindow();
+    createWindow(context, onCloseHandler);
   } else if (mainWindow) {
     mainWindow.show();
     mainWindow.focus();

--- a/desktop/main/Networks.ts
+++ b/desktop/main/Networks.ts
@@ -58,9 +58,10 @@ const hasNetwork = (context: AppContext, netId: number) => !!getNetwork(context,
 const spawnManagers = async (context: AppContext) => {
   const { mainWindow } = context;
   if (!mainWindow) throw new Error('Cannot spawn managers: MainWindow not found');
+  if (!context.currentNetwork) throw new Error('Cannot spawn managers: Network does not selected');
   if (!hasManagers(context)) {
     context.managers.smesher = new SmesherManager(mainWindow, NODE_CONFIG_FILE);
-    context.managers.node = new NodeManager(mainWindow, context.managers.smesher);
+    context.managers.node = new NodeManager(mainWindow, context.currentNetwork.netID, context.managers.smesher);
     context.managers.wallet = new WalletManager(mainWindow, context.managers.node);
   }
 };

--- a/desktop/main/Wallet.ts
+++ b/desktop/main/Wallet.ts
@@ -14,6 +14,7 @@ import StoreService from '../storeService';
 import { DOCUMENTS_DIR, MINUTE, USERDATA_DIR } from './constants';
 import { AppContext } from './context';
 import Networks from './Networks';
+import { getNodeLogsPath } from './utils';
 
 const logger = Logger({ className: 'WalletFiles' });
 
@@ -125,7 +126,7 @@ const showFileInDirectory = async (context: AppContext, { isBackupFile, isLogFil
       logger.error('showFileInDirectory', error);
     }
   } else if (isLogFile) {
-    const logFilePath = path.resolve(USERDATA_DIR, `spacemesh-log-${context.currentNetwork?.netID || 0}.txt`);
+    const logFilePath = getNodeLogsPath(context.currentNetwork?.netID);
     shell.showItemInFolder(logFilePath);
   } else {
     shell.openPath(USERDATA_DIR);

--- a/desktop/main/createWindow.ts
+++ b/desktop/main/createWindow.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { BrowserWindow, Event, shell } from 'electron';
 import MenuBuilder from '../menu';
+import { isDev } from '../utils';
 import { AppContext } from './context';
 
 export default async (context: AppContext, onCloseHandler: (e: Event) => void | Promise<void>) => {
@@ -40,7 +41,7 @@ export default async (context: AppContext, onCloseHandler: (e: Event) => void | 
   });
 
   // Load page after initialization complete
-  mainWindow.loadURL(`file://${path.resolve(__dirname, '..')}/index.html`);
+  mainWindow.loadURL(`file://${path.resolve(__dirname, isDev() ? '..' : '')}/index.html`);
 
   context.mainWindow = mainWindow;
   return mainWindow;

--- a/desktop/main/utils.ts
+++ b/desktop/main/utils.ts
@@ -1,5 +1,8 @@
+import path from 'path';
+import readFromBottom from 'fs-reverse';
 import { Notification } from 'electron';
 import { AppContext } from './context';
+import { USERDATA_DIR } from './constants';
 
 export const showMainWindow = (context: AppContext) => {
   const { mainWindow } = context;
@@ -16,3 +19,24 @@ export const showNotification = (context: AppContext, { title, body }: { title: 
     notification.once('click', () => showMainWindow(context));
   }
 };
+
+export const getNodeLogsPath = (netId?: number) => path.resolve(USERDATA_DIR, `spacemesh-log-${netId || 0}.txt`);
+
+//
+
+export const readLinesFromBottom = (filepath: string, amount: number) =>
+  new Promise<string[]>((resolve) => {
+    const str = readFromBottom(filepath);
+    const result: string[] = [];
+    let count = 0;
+    str.on('data', (line) => {
+      if (count >= amount) {
+        str.pause();
+        str.destroy();
+        resolve(result);
+        return;
+      }
+      result.push(line);
+      count += 1;
+    });
+  });

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "electron-log": "4.3.4",
     "electron-store": "7.0.3",
     "find-process": "1.4.4",
+    "fs-reverse": "^0.0.3",
     "js-xdr": "1.3.0",
     "pbkdf2": "3.1.2",
     "ramda": "^0.27.1",

--- a/scripts/packagerScript.js
+++ b/scripts/packagerScript.js
@@ -106,8 +106,10 @@ const getBuildOptions = ({ target, publish }) => {
         'package.json',
         'node_modules/',
         'proto/',
-        'resources/icons/*',
         'app/assets/**',
+      ],
+      extraResources: [
+        'resources/icons/*',
       ],
       extraFiles: [
         nodeFiles[target],

--- a/scripts/packagerScript.js
+++ b/scripts/packagerScript.js
@@ -108,7 +108,6 @@ const getBuildOptions = ({ target, publish }) => {
         'proto/',
         'resources/icons/*',
         'app/assets/**',
-        { from: path.resolve('desktop/prompt/static'), to: 'prompt/' },
       ],
       extraFiles: [
         nodeFiles[target],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5303,6 +5303,11 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+from@~0.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+  integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
+
 fs-extra@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
@@ -5330,6 +5335,13 @@ fs-extra@^9.0.1, fs-extra@^9.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
+
+fs-reverse@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/fs-reverse/-/fs-reverse-0.0.3.tgz#5ef1e180a65fc0ee3cfb972d376114814203b43d"
+  integrity sha512-zu+5yhmaWueDBAWm7y6ejj2PipVep3EQlQYdfS6r3zsfzIfTVkcdbrsqye2UovisDqogu5dJFxae/dUAOYQqBA==
+  dependencies:
+    from "~0.1"
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Rationale

When Node crashes right on startup, like in the case of NTP clock drift, it doesn't have time to launch GRPC API.
So the only way to find out the error message is to read the logs (or listen to stdout/stderr, but it seems not effective, since we will listen to it all the time).

---

This PR introduces another case of handling node errors in addition to previous ones.
Now it handles all possible errors, coming from different sources:
- GRPC error streams, like NodeErrorStream and NodeStatusStream
- GRPC API errors. Aka unexpected "can not establish connection" and so on
- can't run the node process. E.G. don't have permission / ENOENT / etc
- The node process exited with code > 0. This is the case handled by this PR.