### PR TITLE
Fix starting up of bundled Smapp

### DIFF
--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -51,7 +51,6 @@ StoreService.init();
 
 // State
 const context = getDefaultAppContext();
-
 // App behaviors
 const onCloseHandler = promptBeforeClose(context);
 
@@ -89,5 +88,4 @@ app
   .then(() => Networks.update(context))
   .then(() => createTray(context))
   .then(() => createWindow(context, onCloseHandler))
-  // .then(() => createWindowOld())
   .catch(console.log); // eslint-disable-line no-console

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -58,7 +58,7 @@ const onCloseHandler = promptBeforeClose(context);
 const showMainWindow = () => {
   const { mainWindow } = context;
   if (mainWindow === null) {
-    createWindow();
+    createWindow(context, onCloseHandler);
   } else if (mainWindow) {
     mainWindow.show();
     mainWindow.focus();

--- a/desktop/main/createWindow.ts
+++ b/desktop/main/createWindow.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { BrowserWindow, Event, shell } from 'electron';
 import MenuBuilder from '../menu';
+import { isDev } from '../utils';
 import { AppContext } from './context';
 
 export default async (context: AppContext, onCloseHandler: (e: Event) => void | Promise<void>) => {
@@ -40,7 +41,7 @@ export default async (context: AppContext, onCloseHandler: (e: Event) => void | 
   });
 
   // Load page after initialization complete
-  mainWindow.loadURL(`file://${path.resolve(__dirname, '..')}/index.html`);
+  mainWindow.loadURL(`file://${path.resolve(__dirname, isDev() ? '..' : '')}/index.html`);
 
   context.mainWindow = mainWindow;
   return mainWindow;

--- a/scripts/packagerScript.js
+++ b/scripts/packagerScript.js
@@ -106,8 +106,10 @@ const getBuildOptions = ({ target, publish }) => {
         'package.json',
         'node_modules/',
         'proto/',
-        'resources/icons/*',
         'app/assets/**',
+      ],
+      extraResources: [
+        'resources/icons/*',
       ],
       extraFiles: [
         nodeFiles[target],

--- a/scripts/packagerScript.js
+++ b/scripts/packagerScript.js
@@ -108,7 +108,6 @@ const getBuildOptions = ({ target, publish }) => {
         'proto/',
         'resources/icons/*',
         'app/assets/**',
-        { from: path.resolve('desktop/prompt/static'), to: 'prompt/' },
       ],
       extraFiles: [
         nodeFiles[target],


### PR DESCRIPTION
I've introduced a bug in #851 which causes the wrong path to the `index.html` file.
And as a consequence latest build artifacts can't start.
It fixes it and also a couple of non-critical bugs.