### PR TITLE
A couple of critical fixes

### DIFF
--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -225,8 +225,7 @@ class NodeManager {
     const logFilePath = path.resolve(`${userDataPath}`, `spacemesh-log-${nodeConfig.p2p['network-id']}.txt`);
 
     const logFileStream = fs.createWriteStream(logFilePath, { flags: 'a', encoding: 'utf-8' });
-    // TODO: Rename `test-mode` flag due to https://github.com/spacemeshos/go-spacemesh/issues/3026
-    const args = ['--config', NODE_CONFIG_FILE, '-d', nodeDataFilesPath, '--test-mode'];
+    const args = ['--config', NODE_CONFIG_FILE, '-d', nodeDataFilesPath, '--log-encoder', 'json'];
 
     logger.log('startNode', 'spawning node', [nodePath, ...args]);
     this.nodeProcess = spawn(nodePath, args, { cwd: nodeDir });

--- a/desktop/main/Networks.ts
+++ b/desktop/main/Networks.ts
@@ -2,7 +2,7 @@ import { app, ipcMain } from 'electron';
 import { ipcConsts } from '../../app/vars';
 import { PublicService } from '../../shared/types';
 import { delay, toPublicService } from '../../shared/utils';
-import { fetchJSON, isDev, isDevNet } from '../utils';
+import { fetchJSON, isDevNet } from '../utils';
 import SmesherManager from '../SmesherManager';
 import NodeManager from '../NodeManager';
 import WalletManager from '../WalletManager';
@@ -23,14 +23,14 @@ const getDevNet = async () => ({
   grpcAPI: process.env.DEV_NET_REMOTE_API?.split(',')[0] || '',
 });
 
-const getDiscoveryUrl = () => (isDev() ? process.env.DISCOVERY_URL : app.commandLine.getSwitchValue('discovery') || 'https://discover.spacemesh.io/networks.json');
+const getDiscoveryUrl = () => app.commandLine.getSwitchValue('discovery') || process.env.DISCOVERY_URL || 'https://discover.spacemesh.io/networks.json';
 
 const update = async (context: AppContext, retry = 2) => {
   try {
     const networks = await fetchJSON(getDiscoveryUrl());
     const result: Network[] = isDevNet() ? [await getDevNet(), ...networks] : networks;
-    context.networks = result;
-    return result;
+    context.networks = result || [];
+    return context.networks;
   } catch (err) {
     if (retry === 0) {
       context.networks = [];


### PR DESCRIPTION
- Fix the function that returns the discovery URL (`getDiscoveryUrl`).
   Introduced by me in #863 😞 
- Rename `test-mode` flag with `log-encoder`.
   Due to https://github.com/spacemeshos/go-spacemesh/pull/3056