### PR TITLE
Add workflow that combines dependabot PRs into one

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -1,0 +1,19 @@
+name: "Combine Dependabot PRs"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  combine-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+      - uses: maadhattah/combine-dependabot-prs@main
+        with:
+          branchPrefix: "dependabot"
+          mustBeGreen: false
+          combineBranchName: "combined-prs"
+          ignoreLabel: "nocombine"
+          baseBranch: "develop"
+          openPR: true
+          allowSkipped: false


### PR DESCRIPTION
I've already tested all proposed updates and it seems working well.

Now I want to:
1. combine all of them into one PR,
2. get PR build artifacts,
3. ensure that everything is fine,
4. merge

And then we can release v0.2.2 and start working over the new version with a clean board.