### PR TITLE
Tweak Sentry integration in dev mode & PR builds

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -202,21 +202,21 @@ jobs:
 
       - if: steps.result.outputs.status != 'success' && matrix.os == 'macos-latest'
         name: upload macos build
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: ./release/Spacemesh-${{ steps.package-version.outputs.version }}.dmg
           destination: ${{ secrets.GCP_BUCKET }}/pr-${{ github.sha }}
 
       - if: steps.result.outputs.status != 'success' && matrix.os == 'windows-latest'
         name: upload windows build
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: ./release/Spacemesh Setup ${{ steps.package-version.outputs.version }}.exe
           destination: ${{ secrets.GCP_BUCKET }}/pr-${{ github.sha }}
 
       - if: steps.result.outputs.status != 'success' && matrix.os == 'ubuntu-latest'
         name: upload linux build
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: ./release/spacemesh_app_${{ steps.package-version.outputs.version }}_amd64.deb
           destination: ${{ secrets.GCP_BUCKET }}/pr-${{ github.sha }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -231,9 +231,9 @@ jobs:
     steps:
       - name: Links to artifacts
         run: |
-          echo "Windows: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/Spacemesh%20Setup%20${{ needs.build-and-upload.outputs.version }}.exe"
-          echo "macOS: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/Spacemesh-${{ needs.build-and-upload.outputs.version }}.dmg"
-          echo "Linux: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/spacemesh_app_${{ needs.build-and-upload.outputs.version }}_amd64.deb"
+          echo "Windows: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/release/Spacemesh%20Setup%20${{ needs.build-and-upload.outputs.version }}.exe"
+          echo "macOS: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/release/Spacemesh-${{ needs.build-and-upload.outputs.version }}.dmg"
+          echo "Linux: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/release/spacemesh_app_${{ needs.build-and-upload.outputs.version }}_amd64.deb"
       - name: Post links to PR
         if: github.event_name == 'pull_request'
         uses: mshick/add-pr-comment@v1
@@ -242,6 +242,6 @@ jobs:
         with:
           message: |
             ## Compiled Binaries
-            - Windows: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/Spacemesh%20Setup%20${{ needs.build-and-upload.outputs.version }}.exe
-            - macOS: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/Spacemesh-${{ needs.build-and-upload.outputs.version }}.dmg
-            - Linux: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/spacemesh_app_${{ needs.build-and-upload.outputs.version }}_amd64.deb
+            - Windows: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/release/Spacemesh%20Setup%20${{ needs.build-and-upload.outputs.version }}.exe
+            - macOS: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/release/Spacemesh-${{ needs.build-and-upload.outputs.version }}.dmg
+            - Linux: https://storage.googleapis.com/smapp/pr-${{ github.sha }}/release/spacemesh_app_${{ needs.build-and-upload.outputs.version }}_amd64.deb

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -71,9 +71,6 @@ jobs:
         run: |
           yarn config set network-timeout 300000
           yarn install --prefer-offline
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: yarn lint and build
         if: ${{ steps.result.outputs.status != 'success' }}
@@ -81,8 +78,6 @@ jobs:
           yarn lint
           yarn postinstall
         env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Download go-spacemesh
@@ -159,6 +154,7 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ENV: pr-builds
 
       # Create binaries
       - if: steps.result.outputs.status != 'success' && matrix.os == 'ubuntu-latest'
@@ -167,6 +163,7 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ENV: pr-builds
 
       - if: steps.result.outputs.status != 'success' && matrix.os == 'windows-latest'
         name: Build windows app
@@ -174,6 +171,7 @@ jobs:
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ENV: pr-builds
 
       - if: steps.result.outputs.status != 'success' && matrix.os == 'macos-latest'
         name: Build mac app
@@ -182,6 +180,7 @@ jobs:
           DONT_SIGN_APP: true # Do not sign the development artifacts
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ENV: pr-builds
 
       - name: ls ./release
         if: steps.result.outputs.status != 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,9 +298,9 @@ jobs:
           name: Release ${{ needs.build.outputs.tagName }}
           body: |
             ## Compiled Binaries
-            - Windows: https://storage.googleapis.com/smapp/${{ needs.build.outputs.tagName }}/Spacemesh%20Setup%20${{ needs.build.outputs.version }}.exe
-            - macOS: https://storage.googleapis.com/smapp/${{ needs.build.outputs.tagName }}/Spacemesh-${{ needs.build.outputs.version }}.dmg
-            - Linux: https://storage.googleapis.com/smapp/${{ needs.build.outputs.tagName }}/spacemesh_app_${{ needs.build.outputs.version }}_amd64.deb
+            - Windows: https://storage.googleapis.com/smapp/${{ needs.build.outputs.tagName }}/release/Spacemesh%20Setup%20${{ needs.build.outputs.version }}.exe
+            - macOS: https://storage.googleapis.com/smapp/${{ needs.build.outputs.tagName }}/release/Spacemesh-${{ needs.build.outputs.version }}.dmg
+            - Linux: https://storage.googleapis.com/smapp/${{ needs.build.outputs.tagName }}/release/spacemesh_app_${{ needs.build.outputs.version }}_amd64.deb
           draft: true
           prerelease: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,6 @@ jobs:
         run: |
           yarn config set network-timeout 300000
           yarn install --prefer-offline
-        env:
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Lint and Test
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,21 +269,21 @@ jobs:
           export_default_credentials: true
 
       - name: Upload macos artifact
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: ./release/macos-latest/
           destination: ${{ secrets.GCP_BUCKET }}/${{ needs.build.outputs.tagName }}
           parent: false
 
       - name: Upload windows build
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: ./release/windows-signed/
           destination: ${{ secrets.GCP_BUCKET }}/${{ needs.build.outputs.tagName }}
           parent: false
 
       - name: Upload linux build
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v0
         with:
           path: ./release/ubuntu-latest/
           destination: ${{ secrets.GCP_BUCKET }}/${{ needs.build.outputs.tagName }}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ DEV_NET_REMOTE_API=https://192.168.0.1:31030 DEV_NET_URL=https://.../config.json
 DEV_NET_REMOTE_API=https://192.168.0.1:31030,http://192.168.0.2:31035 DEV_NET_URL=https://.../config.json yarn start
 ```
 
+To run Smapp with turned on Sentry specify required env variables:
+```
+SENTRY_DSN
+SENTRY_AUTH_TOKEN
+```
+
 ### Building Artifacts in CI
 
 Smapp uses two workflows. Both of them builds an application for all supported platforms: windows, macOS, linux.

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ DEV_NET_REMOTE_API=https://192.168.0.1:31030 DEV_NET_URL=https://.../config.json
 DEV_NET_REMOTE_API=https://192.168.0.1:31030,http://192.168.0.2:31035 DEV_NET_URL=https://.../config.json yarn start
 ```
 
-To run Smapp with turned on Sentry specify required env variables:
+To run Smapp on dev with turned on Sentry specify required env variables:
 ```
-SENTRY_DSN
-SENTRY_AUTH_TOKEN
+SENTRY_DSN='collection errors/logs url taken from sentry'
+SENTRY_AUTH_TOKEN='special auth token for sentry cli integration'
+SENTRY_LOG_LEVEL=boolean # enables debug information
 ```
 
 ### Building Artifacts in CI

--- a/app/StyledApp.tsx
+++ b/app/StyledApp.tsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { ThemeProvider } from 'styled-components';
 import { Router, Route, Switch, Redirect, useHistory, matchPath } from 'react-router-dom';
 import { ipcRenderer } from 'electron';
-import * as Sentry from '@sentry/react';
+import { init, reactRouterV5Instrumentation } from '@sentry/react';
 import { BrowserTracing } from '@sentry/tracing';
 import { createBrowserHistory } from 'history';
 import routes from './routes';
@@ -18,23 +18,22 @@ import { goToSwitchNetwork } from './routeUtils';
 
 const history = createBrowserHistory();
 
-process.env.SENTRY_DSN &&
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
-    enabled: process.env.NODE_ENV === 'production',
-    integrations: [
-      new BrowserTracing({
-        routingInstrumentation: Sentry.reactRouterV5Instrumentation(
-          history,
-          Object.values(routes).reduce((prev, next) => [...prev, ...next], []),
-          matchPath
-        ),
-      }),
-    ],
-    tracesSampleRate: 1.0,
-    debug: process.env.SENTRY_LOG_LEVEL === 'debug',
-  });
+init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
+  enabled: process.env.NODE_ENV !== 'development',
+  integrations: [
+    new BrowserTracing({
+      routingInstrumentation: reactRouterV5Instrumentation(
+        history,
+        Object.values(routes).reduce((prev, next) => [...prev, ...next], []),
+        matchPath
+      ),
+    }),
+  ],
+  tracesSampleRate: 1.0,
+  debug: process.env.SENTRY_LOG_LEVEL === 'debug',
+});
 
 const EventRouter = () => {
   const history = useHistory();

--- a/app/StyledApp.tsx
+++ b/app/StyledApp.tsx
@@ -18,22 +18,23 @@ import { goToSwitchNetwork } from './routeUtils';
 
 const history = createBrowserHistory();
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-  enabled: process.env.NODE_ENV === 'production',
-  integrations: [
-    new BrowserTracing({
-      routingInstrumentation: Sentry.reactRouterV5Instrumentation(
-        history,
-        Object.values(routes).reduce((prev, next) => [...prev, ...next], []),
-        matchPath
-      ),
-    }),
-  ],
-  tracesSampleRate: 1.0,
-  debug: process.env.SENTRY_LOG_LEVEL === 'debug',
-});
+process.env.SENTRY_DSN &&
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
+    enabled: process.env.NODE_ENV === 'production',
+    integrations: [
+      new BrowserTracing({
+        routingInstrumentation: Sentry.reactRouterV5Instrumentation(
+          history,
+          Object.values(routes).reduce((prev, next) => [...prev, ...next], []),
+          matchPath
+        ),
+      }),
+    ],
+    tracesSampleRate: 1.0,
+    debug: process.env.SENTRY_LOG_LEVEL === 'debug',
+  });
 
 const EventRouter = () => {
   const history = useHistory();

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -36,21 +36,22 @@ export default {
   },
 
   plugins: [
-    ...(process.env.SENTRY_AUTH_TOKEN ? [new SentryWebpackPlugin({
-      include: '.',
-      ignoreFile: '.sentrycliignore',
-      ignore: ['node_modules', 'webpack.config.js'],
-      release: 'smashapp@' + process.env.npm_package_version,
-      org: 'spacemesh',
-      project: 'smapp',
-      authToken: process.env.SENTRY_AUTH_TOKEN
-    })] : []),
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'production'
     }),
-
     new webpack.IgnorePlugin(/^\.\/wordlists\/(?!english)/, /bip39\/src$/),
-
-  ]
+  ].concat(
+    process.env.SENTRY_AUTH_TOKEN ? (
+      new SentryWebpackPlugin({
+        include: '.',
+        ignoreFile: '.sentrycliignore',
+        ignore: ['node_modules', 'webpack.config.js'],
+        release: 'smashapp@' + process.env.npm_package_version,
+        org: 'spacemesh',
+        project: 'smapp',
+        authToken: process.env.SENTRY_AUTH_TOKEN
+      })
+    ) : false
+  ).filter(Boolean)
 };
 

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -36,7 +36,7 @@ export default {
   },
 
   plugins: [
-    new SentryWebpackPlugin({
+    ...(process.env.SENTRY_AUTH_TOKEN ? [new SentryWebpackPlugin({
       include: '.',
       ignoreFile: '.sentrycliignore',
       ignore: ['node_modules', 'webpack.config.js'],
@@ -44,7 +44,7 @@ export default {
       org: 'spacemesh',
       project: 'smapp',
       authToken: process.env.SENTRY_AUTH_TOKEN
-    }),
+    })] : []),
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'production'
     }),

--- a/configs/webpack.config.main.prod.babel.js
+++ b/configs/webpack.config.main.prod.babel.js
@@ -56,8 +56,9 @@ export default merge(baseConfig, {
       DEBUG_PROD: false,
       START_MINIMIZED: false,
       SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
-      SENTRY_DSN: process.env.SENTRY_DSN
-    })
+      SENTRY_DSN: process.env.SENTRY_DSN,
+      SENTRY_ENV: process.env.SENTRY_ENV,
+    }),
   ],
 
   /**

--- a/configs/webpack.config.renderer.dev.babel.js
+++ b/configs/webpack.config.renderer.dev.babel.js
@@ -85,7 +85,6 @@ export default merge(baseConfig, {
         use: {
           loader: 'url-loader',
           options: {
-            limit: 10000,
             mimetype: 'image/svg+xml'
           }
         }

--- a/configs/webpack.config.renderer.prod.babel.js
+++ b/configs/webpack.config.renderer.prod.babel.js
@@ -51,7 +51,6 @@ export default merge(baseConfig, {
         use: {
           loader: 'url-loader',
           options: {
-            limit: 10000,
             mimetype: 'image/svg+xml'
           }
         }
@@ -91,7 +90,8 @@ export default merge(baseConfig, {
       NODE_ENV: 'production',
       DEBUG_PROD: false,
       SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
-      SENTRY_DSN: process.env.SENTRY_DSN
+      SENTRY_DSN: process.env.SENTRY_DSN,
+      SENTRY_ENV: process.env.SENTRY_ENV,
     }),
 
     new BundleAnalyzerPlugin({

--- a/desktop/logger.ts
+++ b/desktop/logger.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { app } from 'electron';
 import { captureEvent } from '@sentry/electron';
-import { captureMessage } from '@sentry/react';
 
 const logger = require('electron-log');
 
@@ -15,12 +14,10 @@ const Logger = ({ className }: { className: string }) => ({
   log: (fn: string, res: any, args?: any) => {
     const msg = formatLogMessage(className, fn, res, args);
     logger.info?.(msg);
-    captureMessage(msg);
   },
   error: (fn: string, err: any, args?: any) => {
     const msg = formatErrorMessage(className, fn, err, args);
     logger.error?.(msg);
-    captureMessage(msg);
     captureEvent(err);
   },
 });

--- a/desktop/logger.ts
+++ b/desktop/logger.ts
@@ -18,7 +18,15 @@ const Logger = ({ className }: { className: string }) => ({
   error: (fn: string, err: any, args?: any) => {
     const msg = formatErrorMessage(className, fn, err, args);
     logger.error?.(msg);
-    captureEvent(err);
+
+    // because of timeouts in main process
+    // on force close
+    // we have an exception that cannot send to the Sentry
+    try {
+      captureEvent(err);
+    } catch (e) {
+      logger.error?.(e);
+    }
   },
 });
 

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -13,7 +13,7 @@ import fs from 'fs';
 import { app } from 'electron';
 import { captureEvent } from '@sentry/electron';
 import 'regenerator-runtime/runtime';
-import { init } from '@sentry/electron/main';
+import Sentry from '@sentry/electron/main';
 import { BrowserTracing } from '@sentry/tracing';
 import AutoStartManager from './autoStartManager';
 import StoreService from './storeService';
@@ -38,14 +38,15 @@ require('dotenv').config();
 isDebug() && require('electron-debug')();
 isProd() && require('source-map-support').install();
 
-init({
-  dsn: process.env.SENTRY_DSN,
-  integrations: [new BrowserTracing()],
-  tracesSampleRate: 1.0,
-  debug: process.env.SENTRY_LOG_LEVEL === 'debug',
-  environment: process.env.NODE_ENV,
-  enabled: isProd(),
-});
+process.env.SENTRY_DSN &&
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    integrations: [new BrowserTracing()],
+    tracesSampleRate: 1.0,
+    debug: process.env.SENTRY_LOG_LEVEL === 'debug',
+    environment: process.env.NODE_ENV,
+    enabled: isProd(),
+  });
 
 (async function () {
   const filePath = path.resolve(app.getAppPath(), isDev() ? './' : 'desktop/', 'ed25519.wasm');

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -11,9 +11,8 @@ import 'core-js/stable';
 import path from 'path';
 import fs from 'fs';
 import { app } from 'electron';
-import { captureEvent } from '@sentry/electron';
+import { init, captureEvent } from '@sentry/electron';
 import 'regenerator-runtime/runtime';
-import Sentry from '@sentry/electron/main';
 import { BrowserTracing } from '@sentry/tracing';
 import AutoStartManager from './autoStartManager';
 import StoreService from './storeService';
@@ -38,15 +37,14 @@ require('dotenv').config();
 isDebug() && require('electron-debug')();
 isProd() && require('source-map-support').install();
 
-process.env.SENTRY_DSN &&
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    integrations: [new BrowserTracing()],
-    tracesSampleRate: 1.0,
-    debug: process.env.SENTRY_LOG_LEVEL === 'debug',
-    environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
-    enabled: isProd(),
-  });
+init({
+  dsn: process.env.SENTRY_DSN,
+  integrations: [new BrowserTracing()],
+  tracesSampleRate: 1.0,
+  debug: process.env.SENTRY_LOG_LEVEL === 'debug',
+  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
+  enabled: process.env.NODE_ENV !== 'development',
+});
 
 (async function () {
   const filePath = path.resolve(app.getAppPath(), isDev() ? './' : 'desktop/', 'ed25519.wasm');

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -44,7 +44,7 @@ process.env.SENTRY_DSN &&
     integrations: [new BrowserTracing()],
     tracesSampleRate: 1.0,
     debug: process.env.SENTRY_LOG_LEVEL === 'debug',
-    environment: process.env.NODE_ENV,
+    environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
     enabled: isProd(),
   });
 

--- a/scripts/packagerScript.js
+++ b/scripts/packagerScript.js
@@ -100,8 +100,7 @@ const getBuildOptions = ({ target }) => {
         'desktop/config.json',
         'package.json',
         'node_modules/',
-        'proto/',
-        'app/assets/**',
+        'proto/'
       ],
       extraResources: [
         'resources/icons/*',


### PR DESCRIPTION
No issue.

Tweaks:
- make it possible to build and run Smapp in dev mode without having specified sentry secrets
- PR builds will have a different environment in Sentry log, but still with NODE_ENV=production