### PR TITLE
fix: resolve white screen on reload or after enable background mode

### DIFF
--- a/app/StyledApp.tsx
+++ b/app/StyledApp.tsx
@@ -33,6 +33,8 @@ init({
   ],
   tracesSampleRate: 1.0,
   debug: process.env.SENTRY_LOG_LEVEL === 'debug',
+  maxValueLength: 20000,
+  attachStacktrace: true,
 });
 
 const EventRouter = () => {

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -44,6 +44,8 @@ init({
   debug: process.env.SENTRY_LOG_LEVEL === 'debug',
   environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
   enabled: process.env.NODE_ENV !== 'development',
+  maxValueLength: 20000,
+  attachStacktrace: true,
 });
 
 (async function () {

--- a/desktop/main/createWindow.ts
+++ b/desktop/main/createWindow.ts
@@ -5,6 +5,7 @@ import { isDev } from '../utils';
 import { AppContext } from './context';
 
 export default async (context: AppContext, onCloseHandler: (e: Event) => void | Promise<void>) => {
+  const pagePath = `file://${path.resolve(__dirname, isDev() ? '..' : '')}/index.html`;
   const mainWindow = new BrowserWindow({
     show: false,
     width: 1280,
@@ -42,6 +43,13 @@ export default async (context: AppContext, onCloseHandler: (e: Event) => void | 
 
   // Load page after initialization complete
   mainWindow.loadURL(`file://${path.resolve(__dirname, isDev() ? '..' : '')}/index.html`);
+  mainWindow.loadURL(pagePath);
+
+  /**
+   * fallback for page fail
+   * @see https://github.com/maximegris/angular-electron/issues/15
+   */
+  mainWindow.webContents.on('did-fail-load', () => mainWindow.loadURL(pagePath));
 
   context.mainWindow = mainWindow;
   return mainWindow;


### PR DESCRIPTION
fix for #899  

## Definition of done:
- [x] fallback from fail state to start page to unblock client to work with app.

## Additional: 
- [x] increase log limits that going to Sentry
- [x] add additional error stack trace for Sentry   

### How to test
1. Open Smapp
2. Setup Smeshing
3. Close the window
4. In prompt choose "Run in background"
5. Click on the app icon in docker / tray

### Before the fix
![image](https://user-images.githubusercontent.com/1897530/165795942-d2e05194-18c5-466a-aae3-be599be73ff3.png)

### After the fix

https://user-images.githubusercontent.com/54288612/165923495-81e3b6f0-415a-4d8f-a3bc-1a07397a4f2e.mov


