### PR TITLE
Tweak eslint and prettier rules and reformat the code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,20 @@
 module.exports = {
-  extends: 'erb',
+  extends: ['erb', 'plugin:prettier/recommended'],
   rules: {
     'class-methods-use-this': 0,
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+      'error',
+      {
+        printWidth: 80,
+        tabWidth: 2,
+        useTabs: false,
+        singleQuote: true,
+        arrowParens: 'always',
+        trailingComma: 'es5',
+        bracketSpacing: true,
+      },
+    ],
+    'no-unneeded-ternary': ['error'],
     'no-debugger': 2,
     'no-console': 2,
     radix: 0,
@@ -16,14 +28,6 @@ module.exports = {
     'react/state-in-constructor': 0,
     'react/static-property-placement': 0,
     'react/jsx-props-no-spreading': 0,
-    'max-len': [
-      'error',
-      {
-        code: 180,
-        ignoreUrls: true,
-        ignoreStrings: true,
-      },
-    ],
     'no-class-assign': 0,
     'no-else-return': 0,
     'no-underscore-dangle': 0,
@@ -44,7 +48,14 @@ module.exports = {
     'import/order': [
       'error',
       {
-        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+        ],
       },
     ],
     'react/sort-comp': [
@@ -116,4 +127,5 @@ module.exports = {
       '@typescript-eslint/parser': ['.ts', '.tsx'],
     },
   },
+  plugins: ['prettier'],
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "printWidth": 180,
-  "singleQuote": true,
-  "arrowParens": "always",
-  "trailingComma": "es5"
-}

--- a/app/ErrorBoundary.tsx
+++ b/app/ErrorBoundary.tsx
@@ -18,7 +18,8 @@ import { smColors } from './vars';
 const ButtonsWrapper = styled.div<{ hasSingleButton: boolean }>`
   display: flex;
   flex-direction: row;
-  justify-content: ${({ hasSingleButton }) => (hasSingleButton ? 'center' : 'space-between')};
+  justify-content: ${({ hasSingleButton }) =>
+    hasSingleButton ? 'center' : 'space-between'};
   margin: auto 0 15px 0;
   padding-top: 30px;
 `;
@@ -72,7 +73,10 @@ class ErrorBoundary extends Component<Props, State> {
     return { isRenderingError: true };
   }
 
-  componentDidCatch(error: Error, { componentStack }: { componentStack: string }) {
+  componentDidCatch(
+    error: Error,
+    { componentStack }: { componentStack: string }
+  ) {
     setContext(componentStack, null);
     captureEvent(error);
     console.log(`${error.message} ${componentStack}`); // eslint-disable-line no-console

--- a/app/StyledApp.tsx
+++ b/app/StyledApp.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { ThemeProvider } from 'styled-components';
-import { Router, Route, Switch, Redirect, useHistory, matchPath } from 'react-router-dom';
+import {
+  Router,
+  Route,
+  Switch,
+  Redirect,
+  useHistory,
+  matchPath,
+} from 'react-router-dom';
 import { ipcRenderer } from 'electron';
 import { init, reactRouterV5Instrumentation } from '@sentry/react';
 import { BrowserTracing } from '@sentry/tracing';
@@ -41,7 +48,12 @@ const EventRouter = () => {
   const history = useHistory();
 
   useEffect(() => {
-    ipcRenderer.on(ipcConsts.REQUEST_SWITCH_NETWORK, (_, { isWalletOnly }) => history.location.pathname !== AuthPath.SwitchNetwork && goToSwitchNetwork(history, isWalletOnly));
+    ipcRenderer.on(
+      ipcConsts.REQUEST_SWITCH_NETWORK,
+      (_, { isWalletOnly }) =>
+        history.location.pathname !== AuthPath.SwitchNetwork &&
+        goToSwitchNetwork(history, isWalletOnly)
+    );
   }, [history]);
 
   return <></>;
@@ -65,7 +77,11 @@ const StyledApp = () => {
           <EventRouter />
           <Switch>
             {routes.app.map((route) => (
-              <Route key={route.path} path={route.path} component={route.component} />
+              <Route
+                key={route.path}
+                path={route.path}
+                component={route.component}
+              />
             ))}
             <Redirect to="/auth" />
           </Switch>

--- a/app/basicComponents/AmountInput.tsx
+++ b/app/basicComponents/AmountInput.tsx
@@ -12,9 +12,11 @@ const Wrapper = styled.div<{ isFocused: boolean; disabled: boolean }>`
   position: relative;
   width: 100%;
   height: 40px;
-  border: 1px solid ${({ isFocused }) => (isFocused ? smColors.purple : smColors.black)};
+  border: 1px solid
+    ${({ isFocused }) => (isFocused ? smColors.purple : smColors.black)};
   opacity: ${({ disabled }) => (disabled ? 0.2 : 1)};
-  ${({ disabled }) => !disabled && `&:hover { border: 1px solid ${smColors.purple}; `}
+  ${({ disabled }) =>
+    !disabled && `&:hover { border: 1px solid ${smColors.purple}; `}
   background-color: ${smColors.white};
 `;
 const Input = styled.input<{
@@ -76,9 +78,22 @@ type Props = {
   style?: React.CSSProperties;
 };
 
-const AmountInput = ({ onChange, disabled, style, value, selectedUnits = CoinUnits.SMH, valueUnits = CoinUnits.Smidge }: Props) => {
-  // eslint-disable-next-line no-nested-ternary
-  const amount = valueUnits === selectedUnits ? value || 0 : valueUnits === CoinUnits.SMH ? toSmidge(value || 0) : toSMH(value || 0);
+const AmountInput = ({
+  onChange,
+  disabled,
+  style,
+  value,
+  selectedUnits = CoinUnits.SMH,
+  valueUnits = CoinUnits.Smidge,
+}: Props) => {
+  /* eslint-disable no-nested-ternary */
+  const amount =
+    valueUnits === selectedUnits
+      ? value || 0
+      : valueUnits === CoinUnits.SMH
+      ? toSmidge(value || 0)
+      : toSMH(value || 0);
+  /* eslint-enable no-nested-ternary */
   const [curValue, setValue] = useState(value ? amount.toString() : '');
   const [units, setUnits] = useState<CoinUnits>(selectedUnits);
   const [isFocused, setFocused] = useState(false);
@@ -98,19 +113,26 @@ const AmountInput = ({ onChange, disabled, style, value, selectedUnits = CoinUni
     setValue(newValue);
 
     // If User typed a decimal in Smidge -> switch to SMH without any conversion
-    const nextUnits = units === CoinUnits.Smidge && newValue.indexOf('.') !== -1 ? CoinUnits.SMH : units;
+    const nextUnits =
+      units === CoinUnits.Smidge && newValue.indexOf('.') !== -1
+        ? CoinUnits.SMH
+        : units;
     setUnits(nextUnits);
 
     // Commit always in Smidge
     onChange(nextUnits === CoinUnits.SMH ? toSmidge(parsedValue) : parsedValue);
   };
   const changeUnits = () => {
-    const nextUnits = units === CoinUnits.SMH ? CoinUnits.Smidge : CoinUnits.SMH;
+    const nextUnits =
+      units === CoinUnits.SMH ? CoinUnits.Smidge : CoinUnits.SMH;
     setUnits(nextUnits);
     // Convert amount to units
     const parsedValue = parseFloat(curValue);
     if (!Number.isNaN(parsedValue)) {
-      const nextValue = nextUnits === CoinUnits.Smidge ? toSmidge(parsedValue) : toSMH(parsedValue);
+      const nextValue =
+        nextUnits === CoinUnits.Smidge
+          ? toSmidge(parsedValue)
+          : toSMH(parsedValue);
       setValue(nextValue.toString());
     }
     // Switch focus back to the input

--- a/app/basicComponents/AutocompleteDropdown.tsx
+++ b/app/basicComponents/AutocompleteDropdown.tsx
@@ -15,9 +15,11 @@ const InputField = styled.div<{ isFocused?: boolean; isDisabled?: boolean }>`
   align-items: center;
   width: 100%;
   height: 40px;
-  border: 1px solid ${({ isFocused }) => (isFocused ? smColors.purple : smColors.black)};
+  border: 1px solid
+    ${({ isFocused }) => (isFocused ? smColors.purple : smColors.black)};
   opacity: ${({ isDisabled }) => (isDisabled ? 0.2 : 1)};
-  ${({ isDisabled }) => !isDisabled && `&:hover { border: 1px solid ${smColors.purple}; `}
+  ${({ isDisabled }) =>
+    !isDisabled && `&:hover { border: 1px solid ${smColors.purple}; `}
   background-color: ${smColors.white};
 `;
 
@@ -28,7 +30,8 @@ const ActualInput = styled.input<{ isDisabled?: boolean }>`
   padding: 8px 14px;
   border-radius: 0;
   border: none;
-  color: ${({ isDisabled }) => (isDisabled ? smColors.darkGray : smColors.black)};
+  color: ${({ isDisabled }) =>
+    isDisabled ? smColors.darkGray : smColors.black};
   font-size: 14px;
   line-height: 16px;
   outline: none;
@@ -113,7 +116,10 @@ const AutocompleteDropdown = (props: Props) => {
     let list: any = [];
 
     if (value && value.trim()) {
-      list = data.filter((d) => getItemValue(d).toLowerCase().indexOf(value.trim().toLowerCase()) > -1);
+      list = data.filter(
+        (d) =>
+          getItemValue(d).toLowerCase().indexOf(value.trim().toLowerCase()) > -1
+      );
     }
     return list;
   };
@@ -145,7 +151,9 @@ const AutocompleteDropdown = (props: Props) => {
 
   const handleIconClick = () => {
     const { data, getItemValue } = props;
-    const list = !isOpen ? data.filter((d) => getItemValue(d).toLowerCase()) : [];
+    const list = !isOpen
+      ? data.filter((d) => getItemValue(d).toLowerCase())
+      : [];
     setList(list);
     setIsOpen(!isOpen);
   };

--- a/app/basicComponents/Banner.tsx
+++ b/app/basicComponents/Banner.tsx
@@ -39,7 +39,12 @@ type Props = {
   color: string;
 };
 
-const Banner = ({ children, visibility = true, margin = '0', color }: Props) => (
+const Banner = ({
+  children,
+  visibility = true,
+  margin = '0',
+  color,
+}: Props) => (
   <Wrapper margin={margin} visible={visibility}>
     <UpperPart color={color}>{children}</UpperPart>
     <LowerPart color={color} />

--- a/app/basicComponents/Button.tsx
+++ b/app/basicComponents/Button.tsx
@@ -4,7 +4,13 @@ import { smColors } from '../vars';
 
 const GAP = 4;
 
-const UpperPart = styled.div<{ width: number; height: number; isContainerFullWidth: boolean; isDisabled: boolean; isPrimary: boolean }>`
+const UpperPart = styled.div<{
+  width: number;
+  height: number;
+  isContainerFullWidth: boolean;
+  isDisabled: boolean;
+  isPrimary: boolean;
+}>`
   position: absolute;
   z-index: 1;
   top: 0;
@@ -25,7 +31,9 @@ const UpperPart = styled.div<{ width: number; height: number; isContainerFullWid
       ? `background-color: ${smColors.disabledGray};`
       : `background-color: ${isPrimary ? smColors.green : smColors.purple};
         &:hover {
-          background-color: ${isPrimary ? smColors.darkerGreen : smColors.darkerPurple};
+          background-color: ${
+            isPrimary ? smColors.darkerGreen : smColors.darkerPurple
+          };
         }
       `}
   cursor: inherit;
@@ -55,7 +63,13 @@ const Image = styled.img`
   cursor: inherit;
 `;
 
-const LowerPart = styled.div<{ width: number; height: number; isContainerFullWidth: boolean; isDisabled: boolean; isPrimary: boolean }>`
+const LowerPart = styled.div<{
+  width: number;
+  height: number;
+  isContainerFullWidth: boolean;
+  isDisabled: boolean;
+  isPrimary: boolean;
+}>`
   position: absolute;
   z-index: 0;
   top: ${GAP}px;
@@ -75,13 +89,22 @@ const LowerPart = styled.div<{ width: number; height: number; isContainerFullWid
       : `
         border: 1px solid ${isPrimary ? smColors.green : smColors.purple};
         &:hover {
-          border: 1px solid ${isPrimary ? smColors.darkerGreen : smColors.darkerPurple};
+          border: 1px solid ${
+            isPrimary ? smColors.darkerGreen : smColors.darkerPurple
+          };
         }
       `}
   cursor: inherit;
 `;
 
-const Wrapper = styled.div<{ onClick: (e?: React.MouseEvent) => void; width: number; height: number; isContainerFullWidth: boolean; isDisabled: boolean; style: any }>`
+const Wrapper = styled.div<{
+  onClick: (e?: React.MouseEvent) => void;
+  width: number;
+  height: number;
+  isContainerFullWidth: boolean;
+  isDisabled: boolean;
+  style: any;
+}>`
   position: relative;
   width: ${({ width }) => width + GAP}px;
   ${({ isContainerFullWidth }) =>
@@ -118,9 +141,33 @@ type Props = {
   style?: any;
 };
 
-const Button = ({ onClick, isPrimary = true, isDisabled = false, width = 100, height = 40, text, img, imgPosition, style = {}, isContainerFullWidth = false }: Props) => (
-  <Wrapper onClick={isDisabled ? () => {} : onClick} width={width} height={height} isDisabled={isDisabled} isContainerFullWidth={isContainerFullWidth} style={style}>
-    <UpperPart width={width} height={height} isPrimary={isPrimary} isContainerFullWidth={isContainerFullWidth} isDisabled={isDisabled}>
+const Button = ({
+  onClick,
+  isPrimary = true,
+  isDisabled = false,
+  width = 100,
+  height = 40,
+  text,
+  img,
+  imgPosition,
+  style = {},
+  isContainerFullWidth = false,
+}: Props) => (
+  <Wrapper
+    onClick={isDisabled ? () => {} : onClick}
+    width={width}
+    height={height}
+    isDisabled={isDisabled}
+    isContainerFullWidth={isContainerFullWidth}
+    style={style}
+  >
+    <UpperPart
+      width={width}
+      height={height}
+      isPrimary={isPrimary}
+      isContainerFullWidth={isContainerFullWidth}
+      isDisabled={isDisabled}
+    >
       {img && imgPosition === 'before' && (
         <ImageWrapper>
           <Image src={img} />
@@ -133,7 +180,13 @@ const Button = ({ onClick, isPrimary = true, isDisabled = false, width = 100, he
         </ImageWrapper>
       )}
     </UpperPart>
-    <LowerPart width={width} height={height} isPrimary={isPrimary} isContainerFullWidth={isContainerFullWidth} isDisabled={isDisabled} />
+    <LowerPart
+      width={width}
+      height={height}
+      isPrimary={isPrimary}
+      isContainerFullWidth={isContainerFullWidth}
+      isDisabled={isDisabled}
+    />
   </Wrapper>
 );
 

--- a/app/basicComponents/CorneredWrapper.tsx
+++ b/app/basicComponents/CorneredWrapper.tsx
@@ -53,7 +53,11 @@ type Props = {
   isDarkMode?: boolean;
 };
 
-const CorneredWrapper = ({ children, className = '', isDarkMode = false }: Props) => {
+const CorneredWrapper = ({
+  children,
+  className = '',
+  isDarkMode = false,
+}: Props) => {
   const topLeft = isDarkMode ? topLeftCornerWhite : topLeftCorner;
   const topRight = isDarkMode ? topRightCornerWhite : topRightCorner;
   const bottomLeft = isDarkMode ? bottomLeftCornerWhite : bottomLeftCorner;

--- a/app/basicComponents/Dots.tsx
+++ b/app/basicComponents/Dots.tsx
@@ -7,7 +7,8 @@ const Dot = styled.div`
   flex-shrink: 1;
   overflow: hidden;
   margin-right: 28px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
   }
   ::before {
       float: left;

--- a/app/basicComponents/DropDown.tsx
+++ b/app/basicComponents/DropDown.tsx
@@ -20,7 +20,12 @@ const Wrapper = styled.div<{ isDisabled: boolean }>`
   `};
 `;
 
-const HeaderWrapper = styled.div<{ onClick: (e?: React.MouseEvent) => void; rowHeight: number; bgColor: string; isOpened: boolean }>`
+const HeaderWrapper = styled.div<{
+  onClick: (e?: React.MouseEvent) => void;
+  rowHeight: number;
+  bgColor: string;
+  isOpened: boolean;
+}>`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -55,14 +60,24 @@ const ItemsWrapper = styled.div<{ rowHeight: number; bgColor?: string }>`
   overflow-y: scroll;
   box-sizing: content-box;
   box-shadow: 0 3px 6px ${smColors.black02Alpha};
-  border: 1px solid ${({ theme, bgColor }) => bgColor || (theme.isDarkMode ? smColors.white : smColors.black)};
+  border: 1px solid
+    ${({ theme, bgColor }) =>
+      bgColor || (theme.isDarkMode ? smColors.white : smColors.black)};
   margin-left: -1px;
-  background-color: ${({ theme, bgColor }) => bgColor || (theme.isDarkMode ? smColors.white : smColors.black)};
+  background-color: ${({ theme, bgColor }) =>
+    bgColor || (theme.isDarkMode ? smColors.white : smColors.black)};
 `;
 
-const DropdownRow = styled.div<{ onClick: (e?: React.MouseEvent) => void; rowContentCentered: boolean; height: number; isDisabled: boolean; key: string }>`
+const DropdownRow = styled.div<{
+  onClick: (e?: React.MouseEvent) => void;
+  rowContentCentered: boolean;
+  height: number;
+  isDisabled: boolean;
+  key: string;
+}>`
   display: flex;
-  ${({ rowContentCentered }) => rowContentCentered && `justify-content: center;`}
+  ${({ rowContentCentered }) =>
+    rowContentCentered && `justify-content: center;`}
   align-items: center;
   height: ${({ height }) => height}px;
   cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
@@ -109,9 +124,20 @@ const DropDown = <T extends ADataItem>({
   }, []);
 
   const isDisabledComputed = isDisabled || !data || !data.length;
-  const icon = whiteIcon || isDarkMode ? chevronBottomWhite : chevronBottomBlack;
+  const icon =
+    whiteIcon || isDarkMode ? chevronBottomWhite : chevronBottomBlack;
 
-  const renderRow = ({ item, index, rowHeight = 44, rowContentCentered }: { item: Partial<T>; index: number; rowHeight?: number; rowContentCentered: boolean }) => (
+  const renderRow = ({
+    item,
+    index,
+    rowHeight = 44,
+    rowContentCentered,
+  }: {
+    item: Partial<T>;
+    index: number;
+    rowHeight?: number;
+    rowContentCentered: boolean;
+  }) => (
     <DropdownRow
       rowContentCentered={rowContentCentered}
       isDisabled={item.isDisabled || false}
@@ -145,13 +171,20 @@ const DropDown = <T extends ADataItem>({
         e.stopPropagation();
       }}
     >
-      <HeaderWrapper isOpened={isOpened} bgColor={bgColor} onClick={isDisabledComputed ? () => {} : handleToggle} rowHeight={rowHeight}>
+      <HeaderWrapper
+        isOpened={isOpened}
+        bgColor={bgColor}
+        onClick={isDisabledComputed ? () => {} : handleToggle}
+        rowHeight={rowHeight}
+      >
         <DdElement {...data[selectedItemIndex]} isMain />
         <Icon isOpened={isOpened} src={icon} />
       </HeaderWrapper>
       {isOpened && data && (
         <ItemsWrapper bgColor={bgColor} rowHeight={rowHeight}>
-          {data.map((item, index: number) => renderRow({ item, index, rowHeight, rowContentCentered }))}
+          {data.map((item, index: number) =>
+            renderRow({ item, index, rowHeight, rowContentCentered })
+          )}
         </ItemsWrapper>
       )}
     </Wrapper>

--- a/app/basicComponents/ErrorMessage.tsx
+++ b/app/basicComponents/ErrorMessage.tsx
@@ -15,7 +15,8 @@ const ErrorMessage = styled.span<ErrorMessageProps>`
   display: -webkit-box;
   overflow: hidden;
   text-align: ${({ align }) => align};
-  ${({ oneLine }) => oneLine && `-webkit-line-clamp: 1; -webkit-box-orient: vertical;`}
+  ${({ oneLine }) =>
+    oneLine && `-webkit-line-clamp: 1; -webkit-box-orient: vertical;`}
 `;
 
 ErrorMessage.defaultProps = {

--- a/app/basicComponents/Icons/RefreshIcon.tsx
+++ b/app/basicComponents/Icons/RefreshIcon.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import Svg from './Svg';
 
 const RefreshIcon = ({ className }: { className?: string }) => (
-  <Svg width="13" height="17" viewBox="0 0 13 17" xmlns="http://www.w3.org/2000/svg" className={className}>
+  <Svg
+    width="13"
+    height="17"
+    viewBox="0 0 13 17"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
     <rect x="9.60669" y="2.14201" width="0.979122" height="0.979122" />
     <rect x="9.60669" y="3.12109" width="0.979122" height="0.979122" />
     <rect x="8.62781" y="4.10028" width="0.979122" height="0.979122" />
@@ -15,48 +21,210 @@ const RefreshIcon = ({ className }: { className?: string }) => (
     <rect x="8.62781" y="1.16288" width="0.979122" height="0.979122" />
     <rect x="7.64856" y="1.16288" width="0.979122" height="0.979122" />
     <rect x="7.64893" y="0.183838" width="0.979122" height="0.979122" />
-    <rect x="3.4115" y="14.5449" width="0.979122" height="0.979122" transform="rotate(-180 3.4115 14.5449)" />
-    <rect x="3.4115" y="13.5658" width="0.979122" height="0.979122" transform="rotate(-180 3.4115 13.5658)" />
-    <rect x="4.39038" y="12.5866" width="0.979122" height="0.979122" transform="rotate(-180 4.39038 12.5866)" />
-    <rect x="3.4115" y="12.5866" width="0.979122" height="0.979122" transform="rotate(-180 3.4115 12.5866)" />
-    <rect x="2.43225" y="13.5658" width="0.979122" height="0.979122" transform="rotate(-180 2.43225 13.5658)" />
-    <rect x="4.39038" y="11.6076" width="0.979122" height="0.979122" transform="rotate(-180 4.39038 11.6076)" />
-    <rect x="5.36963" y="11.6076" width="0.979122" height="0.979122" transform="rotate(-180 5.36963 11.6076)" />
-    <rect x="5.36963" y="10.6284" width="0.979122" height="0.979122" transform="rotate(-180 5.36963 10.6284)" />
-    <rect x="4.39038" y="14.5449" width="0.979122" height="0.979122" transform="rotate(-180 4.39038 14.5449)" />
-    <rect x="4.39038" y="15.524" width="0.979122" height="0.979122" transform="rotate(-180 4.39038 15.524)" />
-    <rect x="5.36963" y="15.524" width="0.979122" height="0.979122" transform="rotate(-180 5.36963 15.524)" />
-    <rect x="5.36926" y="16.5031" width="0.979122" height="0.979122" transform="rotate(-180 5.36926 16.5031)" />
+    <rect
+      x="3.4115"
+      y="14.5449"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 3.4115 14.5449)"
+    />
+    <rect
+      x="3.4115"
+      y="13.5658"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 3.4115 13.5658)"
+    />
+    <rect
+      x="4.39038"
+      y="12.5866"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 4.39038 12.5866)"
+    />
+    <rect
+      x="3.4115"
+      y="12.5866"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 3.4115 12.5866)"
+    />
+    <rect
+      x="2.43225"
+      y="13.5658"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 2.43225 13.5658)"
+    />
+    <rect
+      x="4.39038"
+      y="11.6076"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 4.39038 11.6076)"
+    />
+    <rect
+      x="5.36963"
+      y="11.6076"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 5.36963 11.6076)"
+    />
+    <rect
+      x="5.36963"
+      y="10.6284"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 5.36963 10.6284)"
+    />
+    <rect
+      x="4.39038"
+      y="14.5449"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 4.39038 14.5449)"
+    />
+    <rect
+      x="4.39038"
+      y="15.524"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 4.39038 15.524)"
+    />
+    <rect
+      x="5.36963"
+      y="15.524"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 5.36963 15.524)"
+    />
+    <rect
+      x="5.36926"
+      y="16.5031"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 5.36926 16.5031)"
+    />
     <rect x="11.5648" y="7.74084" width="0.979122" height="0.979122" />
-    <rect x="1.34656" y="8.94592" width="0.979122" height="0.979122" transform="rotate(-180 1.34656 8.94592)" />
+    <rect
+      x="1.34656"
+      y="8.94592"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 1.34656 8.94592)"
+    />
     <rect x="11.5648" y="6.76184" width="0.979122" height="0.979122" />
-    <rect x="1.34656" y="9.92505" width="0.979122" height="0.979122" transform="rotate(-180 1.34656 9.92505)" />
+    <rect
+      x="1.34656"
+      y="9.92505"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 1.34656 9.92505)"
+    />
     <rect x="11.5651" y="5.83273" width="0.979122" height="0.979122" />
-    <rect x="1.34668" y="10.854" width="0.979122" height="0.979122" transform="rotate(-180 1.34668 10.854)" />
+    <rect
+      x="1.34668"
+      y="10.854"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 1.34668 10.854)"
+    />
     <rect x="11.5648" y="8.67017" width="0.979122" height="0.979122" />
-    <rect x="1.34656" y="8.01672" width="0.979122" height="0.979122" transform="rotate(-180 1.34656 8.01672)" />
+    <rect
+      x="1.34656"
+      y="8.01672"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 1.34656 8.01672)"
+    />
     <rect x="10.5858" y="9.64929" width="0.979122" height="0.979122" />
-    <rect x="2.32556" y="7.0376" width="0.979122" height="0.979122" transform="rotate(-180 2.32556 7.0376)" />
+    <rect
+      x="2.32556"
+      y="7.0376"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 2.32556 7.0376)"
+    />
     <rect x="11.5648" y="9.64929" width="0.979122" height="0.979122" />
-    <rect x="1.34656" y="7.0376" width="0.979122" height="0.979122" transform="rotate(-180 1.34656 7.0376)" />
+    <rect
+      x="1.34656"
+      y="7.0376"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 1.34656 7.0376)"
+    />
     <rect x="10.5858" y="10.6284" width="0.979122" height="0.979122" />
-    <rect x="2.32556" y="6.05847" width="0.979122" height="0.979122" transform="rotate(-180 2.32556 6.05847)" />
+    <rect
+      x="2.32556"
+      y="6.05847"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 2.32556 6.05847)"
+    />
     <rect x="10.5858" y="11.6075" width="0.979122" height="0.979122" />
-    <rect x="2.32556" y="5.07935" width="0.979122" height="0.979122" transform="rotate(-180 2.32556 5.07935)" />
+    <rect
+      x="2.32556"
+      y="5.07935"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 2.32556 5.07935)"
+    />
     <rect x="9.60681" y="11.6075" width="0.979122" height="0.979122" />
-    <rect x="3.30457" y="5.07935" width="0.979122" height="0.979122" transform="rotate(-180 3.30457 5.07935)" />
+    <rect
+      x="3.30457"
+      y="5.07935"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 3.30457 5.07935)"
+    />
     <rect x="9.60681" y="12.5865" width="0.979122" height="0.979122" />
-    <rect x="3.30457" y="4.10022" width="0.979122" height="0.979122" transform="rotate(-180 3.30457 4.10022)" />
+    <rect
+      x="3.30457"
+      y="4.10022"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 3.30457 4.10022)"
+    />
     <rect x="8.62756" y="12.5865" width="0.979122" height="0.979122" />
-    <rect x="4.28381" y="4.10022" width="0.979122" height="0.979122" transform="rotate(-180 4.28381 4.10022)" />
+    <rect
+      x="4.28381"
+      y="4.10022"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 4.28381 4.10022)"
+    />
     <rect x="7.64856" y="12.5865" width="0.979122" height="0.979122" />
-    <rect x="5.26282" y="4.10022" width="0.979122" height="0.979122" transform="rotate(-180 5.26282 4.10022)" />
+    <rect
+      x="5.26282"
+      y="4.10022"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 5.26282 4.10022)"
+    />
     <rect x="6.66956" y="12.5865" width="0.979122" height="0.979122" />
-    <rect x="6.24182" y="4.10022" width="0.979122" height="0.979122" transform="rotate(-180 6.24182 4.10022)" />
+    <rect
+      x="6.24182"
+      y="4.10022"
+      width="0.979122"
+      height="0.979122"
+      transform="rotate(-180 6.24182 4.10022)"
+    />
     <rect x="5.47668" y="12.5865" width="1.19294" height="0.979122" />
-    <rect x="7.43469" y="4.10022" width="1.19294" height="0.979122" transform="rotate(-180 7.43469 4.10022)" />
+    <rect
+      x="7.43469"
+      y="4.10022"
+      width="1.19294"
+      height="0.979122"
+      transform="rotate(-180 7.43469 4.10022)"
+    />
     <rect x="3.30444" y="12.5865" width="2.17199" height="0.979122" />
-    <rect x="9.60657" y="4.10022" width="2.17187" height="0.979122" transform="rotate(-180 9.60657 4.10022)" />
+    <rect
+      x="9.60657"
+      y="4.10022"
+      width="2.17187"
+      height="0.979122"
+      transform="rotate(-180 9.60657 4.10022)"
+    />
   </Svg>
 );
 

--- a/app/basicComponents/Input.tsx
+++ b/app/basicComponents/Input.tsx
@@ -11,9 +11,11 @@ const Wrapper = styled.div<{ isFocused: boolean; isDisabled: boolean }>`
   position: relative;
   width: 100%;
   height: 40px;
-  border: 1px solid ${({ isFocused }) => (isFocused ? smColors.purple : smColors.black)};
+  border: 1px solid
+    ${({ isFocused }) => (isFocused ? smColors.purple : smColors.black)};
   opacity: ${({ isDisabled }) => (isDisabled ? 0.2 : 1)};
-  ${({ isDisabled }) => !isDisabled && `&:hover { border: 1px solid ${smColors.purple}; `}
+  ${({ isDisabled }) =>
+    !isDisabled && `&:hover { border: 1px solid ${smColors.purple}; `}
   background-color: ${smColors.white};
 `;
 
@@ -31,7 +33,8 @@ const ActualInput = styled.input<{
   padding: 8px 10px;
   border-radius: 0;
   border: none;
-  color: ${({ isDisabled }) => (isDisabled ? smColors.darkGray : smColors.black)};
+  color: ${({ isDisabled }) =>
+    isDisabled ? smColors.darkGray : smColors.black};
   font-size: 14px;
   line-height: 16px;
   outline: none;
@@ -102,7 +105,10 @@ const Input = ({
       if (!value) {
         onChangeDebounced({ value });
       } else {
-        debounce = setTimeout(() => onChangeDebounced({ value }), debounceTime || DEFAULT_DEBOUNCE_TIME);
+        debounce = setTimeout(
+          () => onChangeDebounced({ value }),
+          debounceTime || DEFAULT_DEBOUNCE_TIME
+        );
       }
     }
   };

--- a/app/basicComponents/Link.tsx
+++ b/app/basicComponents/Link.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 import styled from 'styled-components';
 import { smColors } from '../vars';
 
-const Wrapper = styled.div<{ onClick: (e?: React.MouseEvent) => void; isPrimary: boolean; isDisabled: boolean }>`
+const Wrapper = styled.div<{
+  onClick: (e?: React.MouseEvent) => void;
+  isPrimary: boolean;
+  isDisabled: boolean;
+}>`
   font-size: 14px;
   line-height: 17px;
-  font-family: ${({ isPrimary }) => (isPrimary ? 'SourceCodePro' : 'SourceCodeProBold')};
+  font-family: ${({ isPrimary }) =>
+    isPrimary ? 'SourceCodePro' : 'SourceCodeProBold'};
   text-decoration: underline;
   ${({ isDisabled, isPrimary }) =>
     isDisabled
@@ -30,8 +35,19 @@ type Props = {
   style?: any;
 };
 
-const Link = ({ onClick, isPrimary = true, isDisabled = false, text, style }: Props) => (
-  <Wrapper onClick={isDisabled ? () => {} : onClick} isPrimary={isPrimary} isDisabled={isDisabled} style={style}>
+const Link = ({
+  onClick,
+  isPrimary = true,
+  isDisabled = false,
+  text,
+  style,
+}: Props) => (
+  <Wrapper
+    onClick={isDisabled ? () => {} : onClick}
+    isPrimary={isPrimary}
+    isDisabled={isDisabled}
+    style={style}
+  >
     {text}
   </Wrapper>
 );

--- a/app/basicComponents/Loader.tsx
+++ b/app/basicComponents/Loader.tsx
@@ -15,7 +15,8 @@ const Wrapper = styled.div`
   align-items: center;
   width: 100%;
   height: 100%;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.black : smColors.background)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.black : smColors.background};
   z-index: 100;
 `;
 
@@ -41,7 +42,11 @@ type Props = {
 
 const Loader = ({ size = 50, isDarkMode = false, note }: Props) => (
   <Wrapper>
-    <AnimatedIcon size={size || Loader.sizes.SMALL} src={isDarkMode ? loaderWhite : loader} alt="Loading" />
+    <AnimatedIcon
+      size={size || Loader.sizes.SMALL}
+      src={isDarkMode ? loaderWhite : loader}
+      alt="Loading"
+    />
     <Note>{note}</Note>
   </Wrapper>
 );

--- a/app/basicComponents/NavTooltip.tsx
+++ b/app/basicComponents/NavTooltip.tsx
@@ -13,7 +13,8 @@ const Text = styled.div`
   font-size: 10px;
   line-height: 13px;
   text-transform: uppercase;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
   text-align: center;
 `;
 

--- a/app/basicComponents/ProgressBar.tsx
+++ b/app/basicComponents/ProgressBar.tsx
@@ -8,7 +8,8 @@ const Progress = styled.div<{ progress: number }>`
   top: 0;
   left: 0;
   height: 100%;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const Base = styled.div`
@@ -18,7 +19,8 @@ const Base = styled.div`
   font-size: 20px;
   line-height: 20px;
   height: 20px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.darkGray : smColors.disabledGray)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.darkGray : smColors.disabledGray};
 `;
 
 type Props = {

--- a/app/basicComponents/SecondaryButton.tsx
+++ b/app/basicComponents/SecondaryButton.tsx
@@ -4,7 +4,13 @@ import { smColors } from '../vars';
 
 const GAP = 3;
 
-const UpperPart = styled.div<{ width: number; height: number; isDisabled: boolean; isPrimary: boolean; bgColor: string }>`
+const UpperPart = styled.div<{
+  width: number;
+  height: number;
+  isDisabled: boolean;
+  isPrimary: boolean;
+  bgColor: string;
+}>`
   position: absolute;
   z-index: 1;
   top: 0;
@@ -33,7 +39,13 @@ const Image = styled.img<{ imgWidth: number; imgHeight: number }>`
   cursor: inherit;
 `;
 
-const LowerPart = styled.div<{ width: number; height: number; isDisabled: boolean; isPrimary: boolean; bgColor: string }>`
+const LowerPart = styled.div<{
+  width: number;
+  height: number;
+  isDisabled: boolean;
+  isPrimary: boolean;
+  bgColor: string;
+}>`
   position: absolute;
   z-index: 0;
   top: ${GAP}px;
@@ -54,7 +66,13 @@ const LowerPart = styled.div<{ width: number; height: number; isDisabled: boolea
   cursor: inherit;
 `;
 
-const Wrapper = styled.div<{ onClick: (e?: React.MouseEvent) => void; width: number; height: number; isDisabled: boolean; bgColor: string }>`
+const Wrapper = styled.div<{
+  onClick: (e?: React.MouseEvent) => void;
+  width: number;
+  height: number;
+  isDisabled: boolean;
+  bgColor: string;
+}>`
   position: relative;
   width: ${({ width }) => width + GAP}px;
   height: ${({ height }) => height + GAP}px;
@@ -86,12 +104,42 @@ type Props = {
   style?: any;
 };
 
-const SecondaryButton = ({ onClick, width = 25, height = 25, isPrimary = true, isDisabled = false, imgWidth, imgHeight, img, style = {}, bgColor = smColors.black }: Props) => (
-  <Wrapper onClick={isDisabled ? () => {} : onClick} width={width} height={height} isDisabled={isDisabled} style={style} bgColor={bgColor}>
-    <UpperPart isPrimary={isPrimary} width={width} height={height} isDisabled={isDisabled} bgColor={bgColor}>
+const SecondaryButton = ({
+  onClick,
+  width = 25,
+  height = 25,
+  isPrimary = true,
+  isDisabled = false,
+  imgWidth,
+  imgHeight,
+  img,
+  style = {},
+  bgColor = smColors.black,
+}: Props) => (
+  <Wrapper
+    onClick={isDisabled ? () => {} : onClick}
+    width={width}
+    height={height}
+    isDisabled={isDisabled}
+    style={style}
+    bgColor={bgColor}
+  >
+    <UpperPart
+      isPrimary={isPrimary}
+      width={width}
+      height={height}
+      isDisabled={isDisabled}
+      bgColor={bgColor}
+    >
       <Image src={img} imgWidth={imgWidth} imgHeight={imgHeight} />
     </UpperPart>
-    <LowerPart isPrimary={isPrimary} width={width} height={height} isDisabled={isDisabled} bgColor={bgColor} />
+    <LowerPart
+      isPrimary={isPrimary}
+      width={width}
+      height={height}
+      isDisabled={isDisabled}
+      bgColor={bgColor}
+    />
   </Wrapper>
 );
 

--- a/app/basicComponents/SmallHorizontalPanel.tsx
+++ b/app/basicComponents/SmallHorizontalPanel.tsx
@@ -15,6 +15,8 @@ type Props = {
   isDarkMode: boolean;
 };
 
-const SmallHorizontalPanel = ({ isDarkMode }: Props) => <Wrapper src={isDarkMode ? horizontalPanelBlack : horizontalPanelWhite} />;
+const SmallHorizontalPanel = ({ isDarkMode }: Props) => (
+  <Wrapper src={isDarkMode ? horizontalPanelBlack : horizontalPanelWhite} />
+);
 
 export default SmallHorizontalPanel;

--- a/app/basicComponents/StepsContainer.tsx
+++ b/app/basicComponents/StepsContainer.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
-import { sidePanelRightMed, sidePanelRightMedWhite, sidePanelLeftMed, sidePanelLeftMedWhite, checkBlack, checkWhite } from '../assets/images';
+import {
+  sidePanelRightMed,
+  sidePanelRightMedWhite,
+  sidePanelLeftMed,
+  sidePanelLeftMedWhite,
+  checkBlack,
+  checkWhite,
+} from '../assets/images';
 import { smColors } from '../vars';
 
 const Wrapper = styled.div`
@@ -8,7 +15,8 @@ const Wrapper = styled.div`
   flex-direction: row;
   width: 290px;
   margin-right: 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dMBlack1 : smColors.black10Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dMBlack1 : smColors.black10Alpha};
 `;
 
 const SideBar = styled.img`
@@ -43,7 +51,8 @@ const StepText = styled.div<{ isCompleted: boolean; isCurrent: boolean }>`
       return smColors.purple;
     }
   }};
-  font-family: ${({ isCompleted }) => (isCompleted ? 'SourceCodePro' : 'SourceCodeProBold')};
+  font-family: ${({ isCompleted }) =>
+    isCompleted ? 'SourceCodePro' : 'SourceCodeProBold'};
   text-align: right;
 `;
 
@@ -54,7 +63,8 @@ const Indicator = styled.div<{ isCurrent: boolean }>`
   width: 15px;
   height: 15px;
   margin-left: 10px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.dMBlack1 : smColors.white)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dMBlack1 : smColors.white};
   font-size: 11px;
   background-color: ${({ isCurrent, theme }) => {
     if (isCurrent) {
@@ -87,10 +97,19 @@ const StepsContainer = ({ steps, currentStep, isDarkMode }: Props) => {
       <InnerWrapper>
         {steps.map((step, index) => (
           <StepContainer key={`step${index}`} isFuture={index > currentStep}>
-            <StepText isCompleted={index < currentStep} isCurrent={index === currentStep}>
+            <StepText
+              isCompleted={index < currentStep}
+              isCurrent={index === currentStep}
+            >
               {step}
             </StepText>
-            {index < currentStep ? <Icon src={checkIcon} /> : <Indicator isCurrent={index === currentStep}>{index + 1}</Indicator>}
+            {index < currentStep ? (
+              <Icon src={checkIcon} />
+            ) : (
+              <Indicator isCurrent={index === currentStep}>
+                {index + 1}
+              </Indicator>
+            )}
           </StepContainer>
         ))}
       </InnerWrapper>

--- a/app/basicComponents/Tooltip.tsx
+++ b/app/basicComponents/Tooltip.tsx
@@ -54,7 +54,14 @@ type Props = {
   isDarkMode: boolean;
 };
 
-const Tooltip = ({ top = -2, left = -3, width, text, marginTop = 2, isDarkMode }: Props) => (
+const Tooltip = ({
+  top = -2,
+  left = -3,
+  width,
+  text,
+  marginTop = 2,
+  isDarkMode,
+}: Props) => (
   <Wrapper marginTop={marginTop}>
     <OuterIcon src={isDarkMode ? tooltipWhite : tooltip} />
     <InnerWrapper top={top} left={left} width={width}>

--- a/app/basicComponents/WrapperWith2SideBars.tsx
+++ b/app/basicComponents/WrapperWith2SideBars.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { sidePanelRightLong, sidePanelRightLongWhite, sidePanelLeftLong, sidePanelLeftLongWhite } from '../assets/images';
+import {
+  sidePanelRightLong,
+  sidePanelRightLongWhite,
+  sidePanelLeftLong,
+  sidePanelLeftLongWhite,
+} from '../assets/images';
 import { smColors } from '../vars';
 
 const Wrapper = styled.div<{ width: number; height: number | string }>`
@@ -8,8 +13,10 @@ const Wrapper = styled.div<{ width: number; height: number | string }>`
   flex-direction: row;
   position: relative;
   width: ${({ width }) => width}px;
-  height: ${({ height }) => (typeof height === 'string' ? height : `${height}px`)};
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black10Alpha)};
+  height: ${({ height }) =>
+    typeof height === 'string' ? height : `${height}px`};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black10Alpha};
 `;
 
 const SideBar = styled.img`
@@ -41,7 +48,8 @@ const HeaderIcon = styled.img`
 const Header = styled.div`
   font-size: 32px;
   line-height: 40px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const SubHeader = styled.div`
@@ -61,7 +69,16 @@ type Props = {
   isDarkMode: boolean;
 };
 
-const WrapperWith2SideBars = ({ width, height = '100%', header, headerIcon, subHeader, children, style, isDarkMode }: Props) => {
+const WrapperWith2SideBars = ({
+  width,
+  height = '100%',
+  header,
+  headerIcon,
+  subHeader,
+  children,
+  style,
+  isDarkMode,
+}: Props) => {
   const leftImg = isDarkMode ? sidePanelLeftLongWhite : sidePanelLeftLong;
   const rightImg = isDarkMode ? sidePanelRightLongWhite : sidePanelRightLong;
 

--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -24,10 +24,17 @@ type Props = {
   isWalletMode: boolean;
 };
 
-const NetworkStatus = ({ status, error, isRestarting, isWalletMode }: Props) => {
+const NetworkStatus = ({
+  status,
+  error,
+  isRestarting,
+  isWalletMode,
+}: Props) => {
   const getSyncLabelPercentage = (): number => {
     if (status && status.syncedLayer && status.topLayer) {
-      const percentage = Math.floor((status.syncedLayer * 100) / status.topLayer);
+      const percentage = Math.floor(
+        (status.syncedLayer * 100) / status.topLayer
+      );
       const maxPercentage = status.isSynced ? 100 : 99;
       return constrain(0, maxPercentage, percentage);
     }
@@ -45,10 +52,14 @@ const NetworkStatus = ({ status, error, isRestarting, isWalletMode }: Props) => 
           </>
         ) : (
           <>
-            <NetworkIndicator color={status?.isSynced ? smColors.green : smColors.orange} />
+            <NetworkIndicator
+              color={status?.isSynced ? smColors.green : smColors.orange}
+            />
             <ProgressLabel>syncing</ProgressLabel>
             <ProgressLabel>{progress}%</ProgressLabel>
-            <ProgressLabel>{`${status?.syncedLayer || 0} / ${status?.topLayer || 0}`}</ProgressLabel>
+            <ProgressLabel>{`${status?.syncedLayer || 0} / ${
+              status?.topLayer || 0
+            }`}</ProgressLabel>
             <Progress>
               <ProgressBar progress={progress} />
             </Progress>
@@ -61,7 +72,13 @@ const NetworkStatus = ({ status, error, isRestarting, isWalletMode }: Props) => 
   const renderError = () => (
     <>
       <NetworkIndicator color={smColors.red} />
-      {isWalletMode ? <ProgressLabel>Connection error</ProgressLabel> : <ProgressLabel>{isRestarting ? 'Restarting node...' : 'Please restart node'}</ProgressLabel>}
+      {isWalletMode ? (
+        <ProgressLabel>Connection error</ProgressLabel>
+      ) : (
+        <ProgressLabel>
+          {isRestarting ? 'Restarting node...' : 'Please restart node'}
+        </ProgressLabel>
+      )}
     </>
   );
 

--- a/app/components/auth/DragAndDrop.tsx
+++ b/app/components/auth/DragAndDrop.tsx
@@ -18,7 +18,12 @@ const Wrapper = styled.div<{
   width: 100%;
   border: 1px dashed ${smColors.darkGray};
   border-radius: 2px;
-  ${({ isDragging, hasError }) => (hasError ? `background-color: rgba(236, 92, 61, 0.1);` : `background-color: ${isDragging ? `rgba(101, 176, 66, 0.1)` : 'transparent'}`)}
+  ${({ isDragging, hasError }) =>
+    hasError
+      ? `background-color: rgba(236, 92, 61, 0.1);`
+      : `background-color: ${
+          isDragging ? `rgba(101, 176, 66, 0.1)` : 'transparent'
+        }`}
 `;
 
 const MsgWrapper = styled.div`
@@ -37,7 +42,8 @@ const Image = styled.img`
 const Text = styled.span`
   font-size: 15px;
   line-height: 17px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
   margin-bottom: 10px;
 `;
 
@@ -47,20 +53,34 @@ const LinkWrapper = styled.div`
 `;
 
 type Props = {
-  onFilesAdded: ({ fileName, filePath }: { fileName: string; filePath: string }) => void;
+  onFilesAdded: ({
+    fileName,
+    filePath,
+  }: {
+    fileName: string;
+    filePath: string;
+  }) => void;
   fileName: string;
   hasError: boolean;
   isDarkMode: boolean;
 };
 
-const DragAndDrop = ({ onFilesAdded, fileName, hasError, isDarkMode }: Props) => {
+const DragAndDrop = ({
+  onFilesAdded,
+  fileName,
+  hasError,
+  isDarkMode,
+}: Props) => {
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     if (e.dataTransfer?.files) {
-      onFilesAdded({ fileName: e.dataTransfer.files[0].name, filePath: e.dataTransfer.files[0].path });
+      onFilesAdded({
+        fileName: e.dataTransfer.files[0].name,
+        filePath: e.dataTransfer.files[0].path,
+      });
       setIsDragging(false);
     }
   };
@@ -104,11 +124,24 @@ const DragAndDrop = ({ onFilesAdded, fileName, hasError, isDarkMode }: Props) =>
 
   const uploadImg = isDarkMode ? uploadWhite : upload;
   return (
-    <Wrapper onDragOver={onDragOver} onDragLeave={onDragLeave} onDrop={onDrop} isDragging={isDragging} hasError={hasError}>
-      <input ref={fileInputRef} type="file" onChange={onFilesAddedHandler} style={{ display: 'none' }} />
+    <Wrapper
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      isDragging={isDragging}
+      hasError={hasError}
+    >
+      <input
+        ref={fileInputRef}
+        type="file"
+        onChange={onFilesAddedHandler}
+        style={{ display: 'none' }}
+      />
       <MsgWrapper>
         {!fileName && <Image src={hasError ? incorrectFile : uploadImg} />}
-        <Text>{hasError ? 'incorrect file' : fileName || 'Drop a wallet file here,'}</Text>
+        <Text>
+          {hasError ? 'incorrect file' : fileName || 'Drop a wallet file here,'}
+        </Text>
         <LinkWrapper>
           <Text>{preLinkText}&nbsp;</Text>
           <Link onClick={openFileDialog} text={linkText} />

--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -6,7 +6,12 @@ import { HexString } from '../../../shared/types';
 import { ensure0x, getAbbreviatedText, getAddress } from '../../infra/utils';
 import { RootState } from '../../types';
 import { smColors } from '../../vars';
-import { addContact, explorer, copyBlack, copyWhite } from '../../assets/images';
+import {
+  addContact,
+  explorer,
+  copyBlack,
+  copyWhite,
+} from '../../assets/images';
 
 const Wrapper = styled.div`
   position: relative;
@@ -87,13 +92,24 @@ type Props = {
 };
 
 const Address = (props: Props) => {
-  const { address, suffix, overlapText, type, full, hideCopy, hideExplorer, addToContacts } = props;
+  const {
+    address,
+    suffix,
+    overlapText,
+    type,
+    full,
+    hideCopy,
+    hideExplorer,
+    addToContacts,
+  } = props;
 
   const isAccount = type === AddressType.ACCOUNT;
   const addr = ensure0x(isAccount ? getAddress(address) : address);
 
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
-  const explorerUrl = useSelector((state: RootState) => state.network.explorerUrl);
+  const explorerUrl = useSelector(
+    (state: RootState) => state.network.explorerUrl
+  );
   const [isCopied, setIsCopied] = useState(false);
 
   const addressToShow = full ? addr : getAbbreviatedText(addr);
@@ -108,7 +124,9 @@ const Address = (props: Props) => {
   };
   const handleExplorer = (e: React.MouseEvent) => {
     e.stopPropagation();
-    window.open(explorerUrl.concat(`${type}/${addr}${isDarkMode ? '?dark' : ''}`));
+    window.open(
+      explorerUrl.concat(`${type}/${addr}${isDarkMode ? '?dark' : ''}`)
+    );
   };
 
   const handleAddToContacts = (e: React.MouseEvent) => {
@@ -116,7 +134,8 @@ const Address = (props: Props) => {
     addToContacts && addToContacts({ address: addr });
   };
 
-  const textToShow = overlapText || (suffix ? `${addressToShow} ${suffix}` : addressToShow);
+  const textToShow =
+    overlapText || (suffix ? `${addressToShow} ${suffix}` : addressToShow);
 
   return (
     <Wrapper>
@@ -124,9 +143,18 @@ const Address = (props: Props) => {
         {isCopied && <CopiedBanner>Copied</CopiedBanner>}
         <span>{textToShow}</span>
       </PublicKey>
-      {!hideCopy && <CopyIcon src={isDarkMode ? copyWhite : copyBlack} onClick={handleCopy} />}
-      {!hideExplorer && <ExplorerIcon src={explorer} onClick={handleExplorer} />}
-      {addToContacts && isAccount && <AddToContactsImg src={addContact} onClick={handleAddToContacts} />}
+      {!hideCopy && (
+        <CopyIcon
+          src={isDarkMode ? copyWhite : copyBlack}
+          onClick={handleCopy}
+        />
+      )}
+      {!hideExplorer && (
+        <ExplorerIcon src={explorer} onClick={handleExplorer} />
+      )}
+      {addToContacts && isAccount && (
+        <AddToContactsImg src={addContact} onClick={handleAddToContacts} />
+      )}
     </Wrapper>
   );
 };

--- a/app/components/common/BackButton.tsx
+++ b/app/components/common/BackButton.tsx
@@ -10,6 +10,14 @@ type Props = {
 
 const style = { position: 'absolute', bottom: 0, left: -45 };
 
-const BackButton = ({ action, width = 10, height = 15 }: Props) => <SecondaryButton onClick={action} img={chevronLeftWhite} imgWidth={width} imgHeight={height} style={style} />;
+const BackButton = ({ action, width = 10, height = 15 }: Props) => (
+  <SecondaryButton
+    onClick={action}
+    img={chevronLeftWhite}
+    imgWidth={width}
+    imgHeight={height}
+    style={style}
+  />
+);
 
 export default BackButton;

--- a/app/components/common/CorneredContainer.tsx
+++ b/app/components/common/CorneredContainer.tsx
@@ -11,8 +11,10 @@ const Wrapper = styled(CorneredWrapper)<{ width: number; height: number }>`
   height: ${({ height }) => height}px;
   padding: 20px;
   margin-left: 8px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.lightGray)};
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.lightGray};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey};
 `;
 
 const DivWrapper = styled.div<{ width: number; height: number }>`
@@ -24,8 +26,10 @@ const DivWrapper = styled.div<{ width: number; height: number }>`
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
   padding: 20px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.lightGray)};
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.lightGray};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey};
 `;
 
 const HeaderWrapper = styled.div`
@@ -52,7 +56,8 @@ export const SubHeader = styled.div`
   padding-bottom: 20px;
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey};
 `;
 
 type Props = {
@@ -81,7 +86,8 @@ const CorneredContainer = ({
   isDarkMode = false,
 }: Props) => {
   const ResolvedWrapper: any = useEmptyWrap ? DivWrapper : Wrapper;
-  const color = headerColor || (isDarkMode ? smColors.white : smColors.realBlack);
+  const color =
+    headerColor || (isDarkMode ? smColors.white : smColors.realBlack);
   return (
     <ResolvedWrapper width={width} height={height} isDarkMode={isDarkMode}>
       {header && (
@@ -95,7 +101,9 @@ const CorneredContainer = ({
           --
           <br />
           {subHeader}
-          {tooltipMessage && <Tooltip text={tooltipMessage} isDarkMode width={200} />}
+          {tooltipMessage && (
+            <Tooltip text={tooltipMessage} isDarkMode width={200} />
+          )}
         </SubHeader>
       )}
       {children}

--- a/app/components/common/Logo.tsx
+++ b/app/components/common/Logo.tsx
@@ -15,6 +15,11 @@ type Props = {
   isDarkMode: boolean;
 };
 
-const Logo = ({ isDarkMode }: Props) => <LogoImg src={isDarkMode ? logoWhite : logo} onClick={() => window.open('https://spacemesh.io')} />;
+const Logo = ({ isDarkMode }: Props) => (
+  <LogoImg
+    src={isDarkMode ? logoWhite : logo}
+    onClick={() => window.open('https://spacemesh.io')}
+  />
+);
 
 export default Logo;

--- a/app/components/common/Modal.tsx
+++ b/app/components/common/Modal.tsx
@@ -37,12 +37,27 @@ type Props = {
   children: any;
 };
 
-const Modal = ({ header, subHeader = '', headerColor, indicatorColor, children, width = 520, height = 310 }: Props) => {
+const Modal = ({
+  header,
+  subHeader = '',
+  headerColor,
+  indicatorColor,
+  children,
+  width = 520,
+  height = 310,
+}: Props) => {
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
   const color = isDarkMode ? smColors.white : smColors.black;
   return (
     <Wrapper>
-      <CorneredContainer width={width} height={height} header={header} subHeader={subHeader} headerColor={headerColor} isDarkMode={isDarkMode}>
+      <CorneredContainer
+        width={width}
+        height={height}
+        header={header}
+        subHeader={subHeader}
+        headerColor={headerColor}
+        isDarkMode={isDarkMode}
+      >
         <Indicator indColor={indicatorColor || headerColor || color} />
         {children}
       </CorneredContainer>

--- a/app/components/common/Version.tsx
+++ b/app/components/common/Version.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import styled, { css } from 'styled-components';
 
-import { getError, getProgressInfo, getUpdateInfo, isUpdateDownloaded, isUpdateDownloading } from '../../redux/updater/selectors';
+import {
+  getError,
+  getProgressInfo,
+  getUpdateInfo,
+  isUpdateDownloaded,
+  isUpdateDownloading,
+} from '../../redux/updater/selectors';
 import { eventsService } from '../../infra/eventsService';
 import { smColors } from '../../vars';
 import packageInfo from '../../../package.json';
@@ -12,7 +18,8 @@ const Container = styled.div`
   left: 32px;
   bottom: 15px;
   font-size: 11px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.lightGray : smColors.darkGray)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.lightGray : smColors.darkGray};
   display: flex;
   align-items: baseline;
 `;
@@ -77,8 +84,13 @@ const UpdateInfo = ({ info }) => {
     <>
       <Attractor />
       <Chunk>Update available: v{info.version}</Chunk>
-      <PrimaryAction onClick={() => eventsService.downloadUpdate()}>Download</PrimaryAction>
-      <SecondaryAction href={`https://github.com/spacemeshos/smapp/releases/tag/v${info.version}`} target="_blank">
+      <PrimaryAction onClick={() => eventsService.downloadUpdate()}>
+        Download
+      </PrimaryAction>
+      <SecondaryAction
+        href={`https://github.com/spacemeshos/smapp/releases/tag/v${info.version}`}
+        target="_blank"
+      >
         Release notes
       </SecondaryAction>
     </>
@@ -90,7 +102,9 @@ const ProgressInfo = () => {
   const isDownloaded = useSelector(isUpdateDownloaded);
   if (!progress && !isDownloaded) return null;
   const line = (() => {
-    const downloaded = Math.round((isDownloaded ? 100 : progress?.percent || 0) / 10);
+    const downloaded = Math.round(
+      (isDownloaded ? 100 : progress?.percent || 0) / 10
+    );
     let line = '';
     for (let i = 0; i < 10; i += 1) {
       const suffix = downloaded > i ? '□' : '■';
@@ -102,7 +116,11 @@ const ProgressInfo = () => {
     <>
       <ProgressChunk>{line}</ProgressChunk>
       <ProgressChunk>{progress?.percent || 0}%</ProgressChunk>
-      {isDownloaded && <PrimaryAction onClick={() => eventsService.installUpdate()}>Restart Smapp</PrimaryAction>}
+      {isDownloaded && (
+        <PrimaryAction onClick={() => eventsService.installUpdate()}>
+          Restart Smapp
+        </PrimaryAction>
+      )}
     </>
   );
 };
@@ -124,7 +142,9 @@ const UpdateStatus = () => {
       {isDownloaded && (
         <>
           <ProgressChunk>Update is ready to install</ProgressChunk>
-          <PrimaryAction onClick={() => eventsService.installUpdate()}>Restart Smapp</PrimaryAction>
+          <PrimaryAction onClick={() => eventsService.installUpdate()}>
+            Restart Smapp
+          </PrimaryAction>
         </>
       )}
     </>

--- a/app/components/contacts/CreateNewContact.tsx
+++ b/app/components/contacts/CreateNewContact.tsx
@@ -13,7 +13,8 @@ const Wrapper = styled.div<{ isStandalone: boolean }>`
   flex-direction: column;
   width: ${({ isStandalone }) => (isStandalone ? '215px' : '100%')};
   height: ${({ isStandalone }) => (isStandalone ? '100%' : '140px')};
-  ${({ isStandalone }) => isStandalone && `background-color: ${smColors.purple}; padding: 15px;`}
+  ${({ isStandalone }) =>
+    isStandalone && `background-color: ${smColors.purple}; padding: 15px;`}
 `;
 
 const Header = styled.div<{ isStandalone: boolean }>`
@@ -72,7 +73,12 @@ type Props = {
   onCancel: () => void;
 };
 
-const CreateNewContact = ({ isStandalone = false, initialAddress = '', onCompleteAction, onCancel }: Props) => {
+const CreateNewContact = ({
+  isStandalone = false,
+  initialAddress = '',
+  onCompleteAction,
+  onCancel,
+}: Props) => {
   const [address, setAddress] = useState(initialAddress || '');
   // const [initialAddress, setIn] = useState(initialAddress || '');
   const [nickname, setNickname] = useState('');
@@ -159,15 +165,34 @@ const CreateNewContact = ({ isStandalone = false, initialAddress = '', onComplet
             style={isStandalone ? inputStyle3 : inputStyle1}
             onFocus={handleFocus}
           />
-          {hasError && <ErrorPopup onClick={() => setHasError(false)} text={errorMsg} style={{ bottom: 60, left: 'calc(50% - 90px)' }} />}
+          {hasError && (
+            <ErrorPopup
+              onClick={() => setHasError(false)}
+              text={errorMsg}
+              style={{ bottom: 60, left: 'calc(50% - 90px)' }}
+            />
+          )}
         </InputWrapperUpperPart>
         <InputWrapperLowerPart />
       </InputsWrapper>
       <ButtonsWrapper>
-        <Link onClick={preCreateContact} text="CREATE" style={{ color: smColors.green, marginRight: 15 }} />
-        <Link onClick={onCancel} text="CANCEL" style={{ color: smColors.orange }} />
+        <Link
+          onClick={preCreateContact}
+          text="CREATE"
+          style={{ color: smColors.green, marginRight: 15 }}
+        />
+        <Link
+          onClick={onCancel}
+          text="CANCEL"
+          style={{ color: smColors.orange }}
+        />
       </ButtonsWrapper>
-      {shouldShowPasswordModal && <EnterPasswordModal submitAction={createContact} closeModal={() => setShouldShowPasswordModal(false)} />}
+      {shouldShowPasswordModal && (
+        <EnterPasswordModal
+          submitAction={createContact}
+          closeModal={() => setShouldShowPasswordModal(false)}
+        />
+      )}
     </Wrapper>
   );
 };

--- a/app/components/contacts/CreatedNewContact.tsx
+++ b/app/components/contacts/CreatedNewContact.tsx
@@ -15,7 +15,8 @@ const Header = styled.div`
   font-family: SourceCodeProBold;
   font-size: 16px;
   line-height: 22px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const MainWrapper = styled.div`
@@ -35,7 +36,8 @@ const MainWrapperUpperPart = styled.div`
   align-items: center;
   width: calc(100% - 5px);
   padding: 10px 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.black)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.black};
   z-index: 1;
 `;
 
@@ -45,7 +47,8 @@ const MainWrapperLowerPart = styled.div`
   left: 0;
   width: calc(100% - 5px);
   height: 65px;
-  border: ${({ theme }) => `1px solid ${theme.isDarkMode ? smColors.white : smColors.black}`};
+  border: ${({ theme }) =>
+    `1px solid ${theme.isDarkMode ? smColors.white : smColors.black}`};
 `;
 
 const Text = styled.div`

--- a/app/components/node/Carousel.tsx
+++ b/app/components/node/Carousel.tsx
@@ -1,8 +1,20 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { chevronLeftBlack, chevronLeftGray, chevronRightBlack, chevronRightGray, posCpuActive, posCpuGrey, posGpuActive, posGpuGrey } from '../../assets/images';
+import {
+  chevronLeftBlack,
+  chevronLeftGray,
+  chevronRightBlack,
+  chevronRightGray,
+  posCpuActive,
+  posCpuGrey,
+  posGpuActive,
+  posGpuGrey,
+} from '../../assets/images';
 import { smColors } from '../../vars';
-import { ComputeApiClass, PostSetupComputeProvider } from '../../../shared/types';
+import {
+  ComputeApiClass,
+  PostSetupComputeProvider,
+} from '../../../shared/types';
 import { formatWithCommas } from '../../infra/utils';
 
 const SLIDE_WIDTH = 170;
@@ -34,14 +46,22 @@ const OuterWrapper = styled.div`
   overflow-x: hidden;
 `;
 
-const InnerWrapper = styled.div<{ slidesCount: number; leftSlideIndex: number }>`
+const InnerWrapper = styled.div<{
+  slidesCount: number;
+  leftSlideIndex: number;
+}>`
   position: relative;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  width: ${({ slidesCount }) => slidesCount * SLIDE_WIDTH + (slidesCount - 1) * SLIDE_MARGIN}px;
+  width: ${({ slidesCount }) =>
+    slidesCount * SLIDE_WIDTH + (slidesCount - 1) * SLIDE_MARGIN}px;
   height: 100%;
-  transform: translate3d(-${({ leftSlideIndex }) => leftSlideIndex * SLIDE_WIDTH + (leftSlideIndex - 1) * SLIDE_MARGIN}px, 0, 0);
+  transform: translate3d(
+    -${({ leftSlideIndex }) => leftSlideIndex * SLIDE_WIDTH + (leftSlideIndex - 1) * SLIDE_MARGIN}px,
+    0,
+    0
+  );
   transition: transform 0.6s linear;
 `;
 
@@ -59,12 +79,22 @@ const SlideUpperPart = styled.div<{ isSelected: boolean }>`
   width: 165px;
   height: 165px;
   padding: 10px 15px 20px;
-  background-color: ${({ isSelected }) => (isSelected ? smColors.white : smColors.mediumGraySecond)};
+  background-color: ${({ isSelected }) =>
+    isSelected ? smColors.white : smColors.mediumGraySecond};
   cursor: inherit;
   &:hover {
     background-color: ${smColors.white};
   }
-  clip-path: polygon(0% 0%, 0% 0%, 0% 0%, 100% 0%, 100% 100%, 0% 100%, 15% 100%, 0% 85%);
+  clip-path: polygon(
+    0% 0%,
+    0% 0%,
+    0% 0%,
+    100% 0%,
+    100% 100%,
+    0% 100%,
+    15% 100%,
+    0% 85%
+  );
 `;
 
 const SlideMiddlePart = styled.div`
@@ -78,7 +108,16 @@ const SlideMiddlePart = styled.div`
   height: 163px;
   background-color: ${smColors.realBlack};
   cursor: inherit;
-  clip-path: polygon(0% 0%, 0% 0%, 0% 0%, 100% 0%, 100% 100%, 0% 100%, 15% 100%, 0% 85%);
+  clip-path: polygon(
+    0% 0%,
+    0% 0%,
+    0% 0%,
+    100% 0%,
+    100% 100%,
+    0% 100%,
+    15% 100%,
+    0% 85%
+  );
 `;
 
 const SlideLowerPart = styled.div<{ isSelected: boolean }>`
@@ -90,12 +129,22 @@ const SlideLowerPart = styled.div<{ isSelected: boolean }>`
   right: 5px;
   width: 165px;
   height: 165px;
-  background-color: ${({ isSelected }) => (isSelected ? smColors.white : smColors.white)};
+  background-color: ${({ isSelected }) =>
+    isSelected ? smColors.white : smColors.white};
   cursor: inherit;
   &:hover {
     background-color: ${smColors.white};
   }
-  clip-path: polygon(0% 0%, 0% 0%, 0% 0%, 100% 0%, 100% 100%, 0% 100%, 15% 100%, 0% 85%);
+  clip-path: polygon(
+    0% 0%,
+    0% 0%,
+    0% 0%,
+    100% 0%,
+    100% 100%,
+    0% 100%,
+    15% 100%,
+    0% 85%
+  );
 `;
 
 const SlideWrapper = styled.div`
@@ -150,7 +199,11 @@ type Props = {
 };
 
 const Carousel = ({ data, selectedItemIndex, onClick, style }: Props) => {
-  const [carouselState, setCarouselState] = useState({ leftSlideIndex: 0, isLeftBtnEnabled: false, isRightBtnEnabled: data.length > 3 });
+  const [carouselState, setCarouselState] = useState({
+    leftSlideIndex: 0,
+    isLeftBtnEnabled: false,
+    isRightBtnEnabled: data.length > 3,
+  });
 
   const handleSelection = ({ index }: { index: number }) => {
     onClick({ index });
@@ -159,47 +212,93 @@ const Carousel = ({ data, selectedItemIndex, onClick, style }: Props) => {
   const slideLeft = () => {
     const { leftSlideIndex } = carouselState;
     if (carouselState.leftSlideIndex > 0) {
-      setCarouselState({ leftSlideIndex: leftSlideIndex - 2, isLeftBtnEnabled: leftSlideIndex - 2 > 0, isRightBtnEnabled: data.length > 3 });
+      setCarouselState({
+        leftSlideIndex: leftSlideIndex - 2,
+        isLeftBtnEnabled: leftSlideIndex - 2 > 0,
+        isRightBtnEnabled: data.length > 3,
+      });
     }
   };
 
   const slideRight = () => {
     const { leftSlideIndex } = carouselState;
     if (leftSlideIndex + 2 < data.length - 1) {
-      setCarouselState({ leftSlideIndex: leftSlideIndex + 2, isLeftBtnEnabled: true, isRightBtnEnabled: data.length - 1 < leftSlideIndex + 2 });
+      setCarouselState({
+        leftSlideIndex: leftSlideIndex + 2,
+        isLeftBtnEnabled: true,
+        isRightBtnEnabled: data.length - 1 < leftSlideIndex + 2,
+      });
     } else if (leftSlideIndex + 1 < data.length - 1) {
-      setCarouselState({ leftSlideIndex: leftSlideIndex + 1, isLeftBtnEnabled: true, isRightBtnEnabled: data.length - 1 < leftSlideIndex + 1 });
+      setCarouselState({
+        leftSlideIndex: leftSlideIndex + 1,
+        isLeftBtnEnabled: true,
+        isRightBtnEnabled: data.length - 1 < leftSlideIndex + 1,
+      });
     }
   };
 
   return (
     <Wrapper>
       <Button
-        src={carouselState.isLeftBtnEnabled ? chevronLeftBlack : chevronLeftGray}
+        src={
+          carouselState.isLeftBtnEnabled ? chevronLeftBlack : chevronLeftGray
+        }
         onClick={carouselState.isLeftBtnEnabled ? slideLeft : () => {}}
         isDisabled={!carouselState.isLeftBtnEnabled}
       />
       <OuterWrapper style={style}>
-        <InnerWrapper leftSlideIndex={carouselState.leftSlideIndex} slidesCount={data.length}>
+        <InnerWrapper
+          leftSlideIndex={carouselState.leftSlideIndex}
+          slidesCount={data.length}
+        >
           {data.map((provider, index) => (
-            <SlideWrapper onClick={() => handleSelection({ index })} key={provider.id}>
+            <SlideWrapper
+              onClick={() => handleSelection({ index })}
+              key={provider.id}
+            >
               <SlideUpperPart isSelected={selectedItemIndex === index}>
                 <TextWrapper>
                   <Text>{provider.model}</Text>
-                  {provider.computeApi === ComputeApiClass.COMPUTE_API_CLASS_UNSPECIFIED && <Text>(UNSPECIFIED)</Text>}
-                  {provider.computeApi === ComputeApiClass.COMPUTE_API_CLASS_CPU && null}
-                  {provider.computeApi === ComputeApiClass.COMPUTE_API_CLASS_CUDA && <Text>(CUDA)</Text>}
-                  {provider.computeApi === ComputeApiClass.COMPUTE_API_CLASS_VULKAN && <Text>(VULCAN)</Text>}
+                  {provider.computeApi ===
+                    ComputeApiClass.COMPUTE_API_CLASS_UNSPECIFIED && (
+                    <Text>(UNSPECIFIED)</Text>
+                  )}
+                  {provider.computeApi ===
+                    ComputeApiClass.COMPUTE_API_CLASS_CPU && null}
+                  {provider.computeApi ===
+                    ComputeApiClass.COMPUTE_API_CLASS_CUDA && (
+                    <Text>(CUDA)</Text>
+                  )}
+                  {provider.computeApi ===
+                    ComputeApiClass.COMPUTE_API_CLASS_VULKAN && (
+                    <Text>(VULCAN)</Text>
+                  )}
                   <Text>--</Text>
                 </TextWrapper>
                 <TextWrapper>
-                  <Text>~{formatWithCommas(provider.performance)} hashes per second</Text>
+                  <Text>
+                    ~{formatWithCommas(provider.performance)} hashes per second
+                  </Text>
                   {/* <Text>TO SAVE DATA</Text> */}
                   {/* TODO: Return it back when estimated time will be available */}
                 </TextWrapper>
-                {provider.computeApi === ComputeApiClass.COMPUTE_API_CLASS_CPU && <CpuIcon src={selectedItemIndex === index ? posCpuActive : posCpuGrey} />}
-                {[ComputeApiClass.COMPUTE_API_CLASS_CUDA, ComputeApiClass.COMPUTE_API_CLASS_VULKAN].includes(provider.computeApi) && (
-                  <GpuIcon src={selectedItemIndex === index ? posGpuActive : posGpuGrey} />
+                {provider.computeApi ===
+                  ComputeApiClass.COMPUTE_API_CLASS_CPU && (
+                  <CpuIcon
+                    src={
+                      selectedItemIndex === index ? posCpuActive : posCpuGrey
+                    }
+                  />
+                )}
+                {[
+                  ComputeApiClass.COMPUTE_API_CLASS_CUDA,
+                  ComputeApiClass.COMPUTE_API_CLASS_VULKAN,
+                ].includes(provider.computeApi) && (
+                  <GpuIcon
+                    src={
+                      selectedItemIndex === index ? posGpuActive : posGpuGrey
+                    }
+                  />
                 )}
               </SlideUpperPart>
               <SlideMiddlePart />
@@ -209,7 +308,9 @@ const Carousel = ({ data, selectedItemIndex, onClick, style }: Props) => {
         </InnerWrapper>
       </OuterWrapper>
       <Button
-        src={carouselState.isRightBtnEnabled ? chevronRightBlack : chevronRightGray}
+        src={
+          carouselState.isRightBtnEnabled ? chevronRightBlack : chevronRightGray
+        }
         onClick={carouselState.isRightBtnEnabled ? slideRight : () => {}}
         isDisabled={!carouselState.isRightBtnEnabled}
       />

--- a/app/components/node/Checkbox.tsx
+++ b/app/components/node/Checkbox.tsx
@@ -9,7 +9,8 @@ const Wrapper = styled.div`
   align-items: center;
   width: 18px;
   height: 18px;
-  border: ${({ theme }) => `2px solid ${theme.isDarkMode ? smColors.white : smColors.realBlack}`};
+  border: ${({ theme }) =>
+    `2px solid ${theme.isDarkMode ? smColors.white : smColors.realBlack}`};
   margin-right: 5px;
   cursor: pointer;
 `;
@@ -26,6 +27,8 @@ type Props = {
   check: () => void;
 };
 
-const Checkbox = ({ isChecked, check }: Props) => <Wrapper onClick={check}>{isChecked && <InnerWrapper />}</Wrapper>;
+const Checkbox = ({ isChecked, check }: Props) => (
+  <Wrapper onClick={check}>{isChecked && <InnerWrapper />}</Wrapper>
+);
 
 export default Checkbox;

--- a/app/components/node/PoSDirectory.tsx
+++ b/app/components/node/PoSDirectory.tsx
@@ -12,8 +12,18 @@ const Wrapper = styled.div`
   flex-direction: row;
   padding: 15px 25px;
   background-color: ${smColors.disabledGray10Alpha};
-  border-top: ${({ theme }) => `1px solid ${theme.isDarkMode ? smColors.white : smColors.realBlack}`};
-  clip-path: polygon(0% 0%, 0% 0%, 0% 0%, 100% 0%, 100% 100%, 0% 100%, 5% 100%, 0% 85%);
+  border-top: ${({ theme }) =>
+    `1px solid ${theme.isDarkMode ? smColors.white : smColors.realBlack}`};
+  clip-path: polygon(
+    0% 0%,
+    0% 0%,
+    0% 0%,
+    100% 0%,
+    100% 100%,
+    0% 100%,
+    5% 100%,
+    0% 85%
+  );
 `;
 
 const HeaderWrapper = styled.div`
@@ -78,13 +88,27 @@ type Props = {
   skipAction: () => void;
 };
 
-const PoSDirectory = ({ nextAction, skipAction, dataDir, setDataDir, freeSpace, setFreeSpace, minCommitmentSize, status, isDarkMode }: Props) => {
+const PoSDirectory = ({
+  nextAction,
+  skipAction,
+  dataDir,
+  setDataDir,
+  freeSpace,
+  setFreeSpace,
+  minCommitmentSize,
+  status,
+  isDarkMode,
+}: Props) => {
   const [hasPermissionError, setHasPermissionError] = useState(false);
 
   const icon = isDarkMode ? posDirectoryWhite : posDirectoryBlack;
 
   const openFolderSelectionDialog = async () => {
-    const { error, dataDir, calculatedFreeSpace } = await eventsService.selectPostFolder();
+    const {
+      error,
+      dataDir,
+      calculatedFreeSpace,
+    } = await eventsService.selectPostFolder();
     if (error) {
       setHasPermissionError(true);
     } else {
@@ -101,14 +125,26 @@ const PoSDirectory = ({ nextAction, skipAction, dataDir, setDataDir, freeSpace, 
           <HeaderIcon src={icon} />
           <Header>Proof of space data directory:</Header>
         </HeaderWrapper>
-        <Link onClick={openFolderSelectionDialog} text={dataDir || 'SELECT DIRECTORY'} style={linkStyle} />
-        {hasPermissionError && <ErrorText>SELECT FOLDER WITH MINIMUM {minCommitmentSize} FREE TO PROCEED</ErrorText>}
+        <Link
+          onClick={openFolderSelectionDialog}
+          text={dataDir || 'SELECT DIRECTORY'}
+          style={linkStyle}
+        />
+        {hasPermissionError && (
+          <ErrorText>
+            SELECT FOLDER WITH MINIMUM {minCommitmentSize} FREE TO PROCEED
+          </ErrorText>
+        )}
         {!!freeSpace && <FreeSpaceHeader>FREE SPACE...</FreeSpaceHeader>}
         <FreeSpace error={hasPermissionError} selected={!!freeSpace}>
           {freeSpace || ''}
         </FreeSpace>
       </Wrapper>
-      <PoSFooter action={nextAction} skipAction={skipAction} isDisabled={!dataDir || hasPermissionError || !status} />
+      <PoSFooter
+        action={nextAction}
+        skipAction={skipAction}
+        isDisabled={!dataDir || hasPermissionError || !status}
+      />
     </>
   );
 };

--- a/app/components/node/PoSFooter.tsx
+++ b/app/components/node/PoSFooter.tsx
@@ -33,8 +33,15 @@ class PoSFooter extends PureComponent<Props> {
       <Footer>
         <Link onClick={this.navigateToExplanation} text="POST SETUP GUIDE" />
         <ButtonWrap>
-          {skipAction && <Button isPrimary={false} onClick={skipAction} text={'SKIP'} />}
-          <Button style={{ marginLeft: '20px' }} onClick={action} text={isLastMode ? 'CREATE DATA' : 'NEXT'} isDisabled={isDisabled} />
+          {skipAction && (
+            <Button isPrimary={false} onClick={skipAction} text={'SKIP'} />
+          )}
+          <Button
+            style={{ marginLeft: '20px' }}
+            onClick={action}
+            text={isLastMode ? 'CREATE DATA' : 'NEXT'}
+            isDisabled={isDisabled}
+          />
         </ButtonWrap>
       </Footer>
     );

--- a/app/components/node/PoSProvider.tsx
+++ b/app/components/node/PoSProvider.tsx
@@ -36,30 +36,67 @@ type Props = {
   isDarkMode: boolean;
 };
 
-const getFastestProvider = (providers: PostSetupComputeProvider[]): PostSetupComputeProvider => providers.sort((a, b) => b.performance - a.performance)[0];
+const getFastestProvider = (
+  providers: PostSetupComputeProvider[]
+): PostSetupComputeProvider =>
+  providers.sort((a, b) => b.performance - a.performance)[0];
 
-const findProviderIndexEqTo = (eqProps: Partial<PostSetupComputeProvider>, providers: PostSetupComputeProvider[]): number =>
-  providers.findIndex((provider) => provider.id === eqProps.id && provider.model === eqProps.model);
-
-const PoSProvider = ({ providers, provider, setProvider, throttle, setThrottle, nextAction, status, isDarkMode }: Props) => {
-  const [selectedProviderIndex, setSelectedProviderIndex] = useState(
-    provider ? findProviderIndexEqTo(provider, providers) : findProviderIndexEqTo(getFastestProvider(providers), providers)
+const findProviderIndexEqTo = (
+  eqProps: Partial<PostSetupComputeProvider>,
+  providers: PostSetupComputeProvider[]
+): number =>
+  providers.findIndex(
+    (provider) => provider.id === eqProps.id && provider.model === eqProps.model
   );
 
-  useEffect(() => setProvider(providers[selectedProviderIndex]), [providers, selectedProviderIndex, setProvider]);
+const PoSProvider = ({
+  providers,
+  provider,
+  setProvider,
+  throttle,
+  setThrottle,
+  nextAction,
+  status,
+  isDarkMode,
+}: Props) => {
+  const [selectedProviderIndex, setSelectedProviderIndex] = useState(
+    provider
+      ? findProviderIndexEqTo(provider, providers)
+      : findProviderIndexEqTo(getFastestProvider(providers), providers)
+  );
 
-  const handleSetProcessor = ({ index }: { index: number }) => setSelectedProviderIndex(index);
+  useEffect(() => setProvider(providers[selectedProviderIndex]), [
+    providers,
+    selectedProviderIndex,
+    setProvider,
+  ]);
+
+  const handleSetProcessor = ({ index }: { index: number }) =>
+    setSelectedProviderIndex(index);
 
   return (
     <>
-      {!providers ? <Text>CALCULATING POS PROCESSORS</Text> : <Carousel data={providers} onClick={handleSetProcessor} selectedItemIndex={selectedProviderIndex} />}
-      {providers && providers.length === 0 && <ErrorText>NO SUPPORTED PROCESSOR DETECTED</ErrorText>}
+      {!providers ? (
+        <Text>CALCULATING POS PROCESSORS</Text>
+      ) : (
+        <Carousel
+          data={providers}
+          onClick={handleSetProcessor}
+          selectedItemIndex={selectedProviderIndex}
+        />
+      )}
+      {providers && providers.length === 0 && (
+        <ErrorText>NO SUPPORTED PROCESSOR DETECTED</ErrorText>
+      )}
       <PauseSelector>
         <Checkbox isChecked={throttle} check={() => setThrottle(!throttle)} />
         <Text>PAUSE WHEN SOMEONE IS USING THIS COMPUTER</Text>
         <Tooltip width={200} text="Some text" isDarkMode={isDarkMode} />
       </PauseSelector>
-      <PoSFooter action={nextAction} isDisabled={selectedProviderIndex === -1 || !status} />
+      <PoSFooter
+        action={nextAction}
+        isDisabled={selectedProviderIndex === -1 || !status}
+      />
     </>
   );
 };

--- a/app/components/node/PoSSize.tsx
+++ b/app/components/node/PoSSize.tsx
@@ -2,7 +2,12 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Tooltip, DropDown } from '../../basicComponents';
 // import { eventsService } from '../../infra/eventsService';
-import { posSpace, posRewardEst, posDirectoryBlack, posDirectoryWhite } from '../../assets/images';
+import {
+  posSpace,
+  posRewardEst,
+  posDirectoryBlack,
+  posDirectoryWhite,
+} from '../../assets/images';
 import { smColors } from '../../vars';
 import { NodeStatus } from '../../../shared/types';
 import PoSFooter from './PoSFooter';
@@ -71,7 +76,8 @@ const CommitmentWrapper = styled.div<{ isInDropDown: boolean }>`
   color: ${smColors.realBlack};
   &:hover {
     opacity: 1;
-    color: ${({ theme }) => (theme.isDarkMode ? smColors.lightGray : smColors.darkGray50Alpha)};
+    color: ${({ theme }) =>
+      theme.isDarkMode ? smColors.lightGray : smColors.darkGray50Alpha};
   }
   ${({ isInDropDown }) =>
     isInDropDown &&
@@ -99,7 +105,8 @@ const Commitment = styled.div`
   font-size: 16px;
   line-height: 22px;
   cursor: inherit;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const Link = styled.div`
@@ -116,7 +123,8 @@ const Link = styled.div`
     text-decoration: underline;
     color: ${smColors.blue};
     &:hover {
-      color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.black)};
+      color: ${({ theme }) =>
+        theme.isDarkMode ? smColors.white : smColors.black};
     }
   }
 `;
@@ -138,8 +146,19 @@ type Props = {
   isDarkMode: boolean;
 };
 
-const PoSSize = ({ commitments, dataDir, numUnits, setNumUnit, freeSpace, nextAction, status, isDarkMode }: Props) => {
-  const [selectedCommitmentIndex, setSelectedCommitmentIndex] = useState(numUnits ? commitments.findIndex((com) => com.numUnits === numUnits) : 0);
+const PoSSize = ({
+  commitments,
+  dataDir,
+  numUnits,
+  setNumUnit,
+  freeSpace,
+  nextAction,
+  status,
+  isDarkMode,
+}: Props) => {
+  const [selectedCommitmentIndex, setSelectedCommitmentIndex] = useState(
+    numUnits ? commitments.findIndex((com) => com.numUnits === numUnits) : 0
+  );
   const [hasErrorFetchingEstimatedRewards] = useState(false);
   // const [loadedEstimatedRewards, setLoadedEstimatedRewards] = useState({ amount: 0 });
 
@@ -156,7 +175,13 @@ const PoSSize = ({ commitments, dataDir, numUnits, setNumUnit, freeSpace, nextAc
   //   loadEstimatedRewards();
   // }, [setHasErrorFetchingEstimatedRewards, setLoadedEstimatedRewards]);
 
-  const renderDDRow = ({ label, isInDropDown }: { label: string; isInDropDown: boolean }) => (
+  const renderDDRow = ({
+    label,
+    isInDropDown,
+  }: {
+    label: string;
+    isInDropDown: boolean;
+  }) => (
     <CommitmentWrapper isInDropDown={isInDropDown}>
       <Commitment>{label}</Commitment>
     </CommitmentWrapper>
@@ -184,7 +209,9 @@ const PoSSize = ({ commitments, dataDir, numUnits, setNumUnit, freeSpace, nextAc
         <Dots>.....................................................</Dots>
         <DropDown
           data={commitments}
-          DdElement={({ label, isMain }) => renderDDRow({ label, isInDropDown: !isMain })}
+          DdElement={({ label, isMain }) =>
+            renderDDRow({ label, isInDropDown: !isMain })
+          }
           onClick={selectCommitment}
           selectedItemIndex={selectedCommitmentIndex}
           rowHeight={40}
@@ -200,9 +227,15 @@ const PoSSize = ({ commitments, dataDir, numUnits, setNumUnit, freeSpace, nextAc
         <Tooltip width={200} text="Some text" isDarkMode={isDarkMode} />
         <Dots>.....................................................</Dots>
         {hasErrorFetchingEstimatedRewards ? (
-          <ErrorText>Failed to load estimated rewards. Please return to previous step</ErrorText>
+          <ErrorText>
+            Failed to load estimated rewards. Please return to previous step
+          </ErrorText>
         ) : (
-          <RewardText selected={selectedCommitmentIndex !== -1}>{selectedCommitmentIndex !== -1 ? `10 SMESH / EPOCH` : '0 SMESH / EPOCH'}</RewardText>
+          <RewardText selected={selectedCommitmentIndex !== -1}>
+            {selectedCommitmentIndex !== -1
+              ? `10 SMESH / EPOCH`
+              : '0 SMESH / EPOCH'}
+          </RewardText>
         )}
       </Row>
       <BottomRow>
@@ -214,7 +247,10 @@ const PoSSize = ({ commitments, dataDir, numUnits, setNumUnit, freeSpace, nextAc
       <BottomRow>
         <Text>Free space: {freeSpace}</Text>
       </BottomRow>
-      <PoSFooter action={nextAction} isDisabled={selectedCommitmentIndex === -1 || !status} />
+      <PoSFooter
+        action={nextAction}
+        isDisabled={selectedCommitmentIndex === -1 || !status}
+      />
     </>
   );
 };

--- a/app/components/node/PoSSummary.tsx
+++ b/app/components/node/PoSSummary.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { smColors } from '../../vars';
 import { Tooltip } from '../../basicComponents';
-import { ComputeApiClass, NodeStatus, PostSetupComputeProvider } from '../../../shared/types';
+import {
+  ComputeApiClass,
+  NodeStatus,
+  PostSetupComputeProvider,
+} from '../../../shared/types';
 import PoSFooter from './PoSFooter';
 
 const Row = styled.div`
@@ -19,7 +23,8 @@ const Row = styled.div`
     left: 0;
     width: 100%;
     height: 1px;
-    background: ${({ theme }) => (theme.isDarkMode ? smColors.disabledGray10Alpha : smColors.black)};
+    background: ${({ theme }) =>
+      theme.isDarkMode ? smColors.disabledGray10Alpha : smColors.black};
   }
   &:first-child {
     margin-bottom: 10px;
@@ -54,7 +59,8 @@ const Link = styled.div<{ isDisabled: boolean }>`
     text-decoration: underline;
     color: ${smColors.blue};
     &:hover {
-      color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.black)};
+      color: ${({ theme }) =>
+        theme.isDarkMode ? smColors.white : smColors.black};
     }
   }
 `;
@@ -70,7 +76,16 @@ type Props = {
   isDarkMode: boolean;
 };
 
-const PoSSummary = ({ dataDir, commitmentSize, provider, throttle, nextAction, switchMode, status, isDarkMode }: Props) => {
+const PoSSummary = ({
+  dataDir,
+  commitmentSize,
+  provider,
+  throttle,
+  nextAction,
+  switchMode,
+  status,
+  isDarkMode,
+}: Props) => {
   const [isProcessing, setIsProcessing] = useState(false);
 
   const handleNextAction = () => {
@@ -83,7 +98,9 @@ const PoSSummary = ({ dataDir, commitmentSize, provider, throttle, nextAction, s
     providerType = 'CPU';
   } else if (provider?.computeApi === ComputeApiClass.COMPUTE_API_CLASS_CUDA) {
     providerType = 'CUDA';
-  } else if (provider?.computeApi === ComputeApiClass.COMPUTE_API_CLASS_VULKAN) {
+  } else if (
+    provider?.computeApi === ComputeApiClass.COMPUTE_API_CLASS_VULKAN
+  ) {
     providerType = 'VULKAN';
   }
 
@@ -91,7 +108,11 @@ const PoSSummary = ({ dataDir, commitmentSize, provider, throttle, nextAction, s
     <>
       <Row>
         <Text>data directory</Text>
-        <Link className="blue" onClick={() => switchMode({ mode: 1 })} isDisabled={isProcessing}>
+        <Link
+          className="blue"
+          onClick={() => switchMode({ mode: 1 })}
+          isDisabled={isProcessing}
+        >
           {dataDir}
         </Link>
       </Row>
@@ -110,7 +131,11 @@ const PoSSummary = ({ dataDir, commitmentSize, provider, throttle, nextAction, s
       <Row>
         <TooltipWrap>
           <Text>estimated setup time</Text>
-          <Tooltip width={100} text="Placeholder text" isDarkMode={isDarkMode} />
+          <Tooltip
+            width={100}
+            text="Placeholder text"
+            isDarkMode={isDarkMode}
+          />
         </TooltipWrap>
         <Link onClick={() => switchMode({ mode: 3 })} isDisabled={isProcessing}>
           {`${provider?.performance} hashes per second`}
@@ -122,7 +147,11 @@ const PoSSummary = ({ dataDir, commitmentSize, provider, throttle, nextAction, s
           {throttle ? 'on' : 'off'}
         </Link>
       </Row>
-      <PoSFooter action={handleNextAction} isDisabled={isProcessing || !status} isLastMode />
+      <PoSFooter
+        action={handleNextAction}
+        isDisabled={isProcessing || !status}
+        isLastMode
+      />
     </>
   );
 };

--- a/app/components/node/SmesherIntro.tsx
+++ b/app/components/node/SmesherIntro.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link, Button } from '../../basicComponents';
-import { posIcon, fireworks, fireworksWhite, posNotification, posComputer, posAwake } from '../../assets/images';
+import {
+  posIcon,
+  fireworks,
+  fireworksWhite,
+  posNotification,
+  posComputer,
+  posAwake,
+} from '../../assets/images';
 import { smColors } from '../../vars';
 import { ExternalLinks } from '../../../shared/constants';
 
@@ -21,7 +28,8 @@ const TextWrapper = styled.div`
 const Text = styled.div`
   font-size: 13px;
   line-height: 15px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const GreenText = styled.div`
@@ -72,7 +80,11 @@ const PosAwakeIcon = styled.img`
   margin-right: 10px;
 `;
 
-const inlineLinkStyle = { display: 'inline', fontSize: '13px', lineHeight: '20px' };
+const inlineLinkStyle = {
+  display: 'inline',
+  fontSize: '13px',
+  lineHeight: '20px',
+};
 
 type Props = {
   hideIntro: () => void;
@@ -82,7 +94,8 @@ type Props = {
 const SmesherIntro = ({ hideIntro, isDarkMode }: Props) => {
   const navigateToMiningGuide = () => window.open(ExternalLinks.SetupGuide);
 
-  const navigateToPreventComputerSleep = () => window.open(ExternalLinks.NoSleepGuide);
+  const navigateToPreventComputerSleep = () =>
+    window.open(ExternalLinks.NoSleepGuide);
 
   return (
     <>
@@ -90,22 +103,32 @@ const SmesherIntro = ({ hideIntro, isDarkMode }: Props) => {
       <GreenText>Your proof of space data is being created!</GreenText>
       <TextWrapper>
         <PosNotificationIcon src={posNotification} />
-        <Text>You will get a desktop notification when the setup is complete</Text>
+        <Text>
+          You will get a desktop notification when the setup is complete
+        </Text>
       </TextWrapper>
       <TextWrapper>
         <PosIcon src={posIcon} />
-        <Text>Your app will start smeshing automatically when the setup is complete</Text>
+        <Text>
+          Your app will start smeshing automatically when the setup is complete
+        </Text>
       </TextWrapper>
       <br />
       <RedText>Important</RedText>
       <TextWrapper>
         <PosComputerIcon src={posComputer} />
-        <Text>Leave your computer on 24/7 to finish setup and start smeshing</Text>
+        <Text>
+          Leave your computer on 24/7 to finish setup and start smeshing
+        </Text>
       </TextWrapper>
       <TextWrapper>
         <PosAwakeIcon src={posAwake} />
         <Text>
-          <Link onClick={navigateToPreventComputerSleep} text="Disable your computer from going to sleep" style={inlineLinkStyle} />
+          <Link
+            onClick={navigateToPreventComputerSleep}
+            text="Disable your computer from going to sleep"
+            style={inlineLinkStyle}
+          />
         </Text>
       </TextWrapper>
       <Footer>

--- a/app/components/node/SmesherLog.tsx
+++ b/app/components/node/SmesherLog.tsx
@@ -5,7 +5,14 @@ import { getFormattedTimestamp, formatSmidge } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { Reward } from '../../types';
 import { SmallHorizontalPanel } from '../../basicComponents';
-import { bottomRightCorner, bottomRightCornerWhite, leftSideTIcon, leftSideTIconWhite, topRightCorner, topRightCornerWhite } from '../../assets/images';
+import {
+  bottomRightCorner,
+  bottomRightCornerWhite,
+  leftSideTIcon,
+  leftSideTIconWhite,
+  topRightCorner,
+  topRightCornerWhite,
+} from '../../assets/images';
 
 const Wrapper = styled.div`
   display: flex;
@@ -76,12 +83,23 @@ type Props = {
   isDarkMode: boolean;
 };
 
-const SmesherLog = ({ initTimestamp, smeshingTimestamp, rewards, isDarkMode }: Props) => {
+const SmesherLog = ({
+  initTimestamp,
+  smeshingTimestamp,
+  rewards,
+  isDarkMode,
+}: Props) => {
   const icon = isDarkMode ? leftSideTIconWhite : leftSideTIcon;
   const topRight = isDarkMode ? topRightCornerWhite : topRightCorner;
   const bottomRight = isDarkMode ? bottomRightCornerWhite : bottomRightCorner;
   return (
-    <CorneredContainer useEmptyWrap width={310} height={450} header="SMESHER LOG" isDarkMode={isDarkMode}>
+    <CorneredContainer
+      useEmptyWrap
+      width={310}
+      height={450}
+      header="SMESHER LOG"
+      isDarkMode={isDarkMode}
+    >
       <FullCrossIcon className="top" src={icon} />
       <FullCrossIcon className="bottom" src={icon} />
       <TopRightCorner src={topRight} />
@@ -113,8 +131,12 @@ const SmesherLog = ({ initTimestamp, smeshingTimestamp, rewards, isDarkMode }: P
             <div key={`reward${index}`}>
               <LogEntry>
                 <LogText>{getFormattedTimestamp(reward.timestamp)}</LogText>
-                <AwardText>Smeshing reward: {formatSmidge(reward.total)}</AwardText>
-                <AwardText>Smeshing fee reward: {formatSmidge(reward.layerReward)}</AwardText>
+                <AwardText>
+                  Smeshing reward: {formatSmidge(reward.total)}
+                </AwardText>
+                <AwardText>
+                  Smeshing fee reward: {formatSmidge(reward.layerReward)}
+                </AwardText>
               </LogEntry>
               <LogEntrySeparator>...</LogEntrySeparator>
             </div>

--- a/app/components/settings/ChangePassword.tsx
+++ b/app/components/settings/ChangePassword.tsx
@@ -41,7 +41,9 @@ const ChangePassword = () => {
     };
   });
 
-  const walletFiles = useSelector((state: RootState) => state.wallet.walletFiles);
+  const walletFiles = useSelector(
+    (state: RootState) => state.wallet.walletFiles
+  );
   const mnemonic = useSelector((state: RootState) => state.wallet.mnemonic);
   const accounts = useSelector((state: RootState) => state.wallet.accounts);
   const contacts = useSelector((state: RootState) => state.wallet.contacts);
@@ -70,10 +72,16 @@ const ChangePassword = () => {
 
   const validate = () => {
     const pasMinLength = 1; // TODO: Changed to 8 before testnet.
-    const hasPasswordError = !password || (!!password && password.length < pasMinLength);
-    const hasVerifyPasswordError = !verifiedPassword || password !== verifiedPassword;
-    const passwordError = hasPasswordError ? `Password has to be ${pasMinLength} characters or more.` : '';
-    const verifyPasswordError = hasVerifyPasswordError ? "these passwords don't match, please try again " : '';
+    const hasPasswordError =
+      !password || (!!password && password.length < pasMinLength);
+    const hasVerifyPasswordError =
+      !verifiedPassword || password !== verifiedPassword;
+    const passwordError = hasPasswordError
+      ? `Password has to be ${pasMinLength} characters or more.`
+      : '';
+    const verifyPasswordError = hasVerifyPasswordError
+      ? "these passwords don't match, please try again "
+      : '';
     setPasswordError(password);
     setVerifyPasswordError(verifiedPassword);
     return !passwordError && !verifyPasswordError;
@@ -83,7 +91,11 @@ const ChangePassword = () => {
     if (validate() && !isLoaderVisible && walletFiles && walletFiles[0]) {
       setIsLoaderVisible(false);
       timeOut = await setTimeout(async () => {
-        await eventsService.updateWalletSecrets(walletFiles[0].path, password, { mnemonic, accounts, contacts });
+        await eventsService.updateWalletSecrets(walletFiles[0].path, password, {
+          mnemonic,
+          accounts,
+          contacts,
+        });
         clearFields();
       }, 500);
     }
@@ -97,8 +109,22 @@ const ChangePassword = () => {
       <LeftPart>
         {isEditMode ? (
           [
-            <Input value={password} type="password" placeholder="Type password" onChange={handlePasswordTyping} style={{ marginBottom: 15 }} key="pass" autofocus />,
-            <Input value={verifiedPassword} type="password" placeholder="Verify password" onChange={handlePasswordVerifyTyping} key="passRetype" />,
+            <Input
+              value={password}
+              type="password"
+              placeholder="Type password"
+              onChange={handlePasswordTyping}
+              style={{ marginBottom: 15 }}
+              key="pass"
+              autofocus
+            />,
+            <Input
+              value={verifiedPassword}
+              type="password"
+              placeholder="Verify password"
+              onChange={handlePasswordVerifyTyping}
+              key="passRetype"
+            />,
           ]
         ) : (
           <Input value="***********" type="password" isDisabled />
@@ -117,8 +143,18 @@ const ChangePassword = () => {
       <RightPart>
         {isEditMode ? (
           [
-            <Link onClick={updatePassword} text="SAVE" style={{ marginRight: 15 }} key="change" />,
-            <Link onClick={clearFields} text="CANCEL" style={{ color: smColors.darkGray }} key="cancel" />,
+            <Link
+              onClick={updatePassword}
+              text="SAVE"
+              style={{ marginRight: 15 }}
+              key="change"
+            />,
+            <Link
+              onClick={clearFields}
+              text="CANCEL"
+              style={{ color: smColors.darkGray }}
+              key="cancel"
+            />,
           ]
         ) : (
           <Button onClick={startUpdatingPassword} text="CHANGE" width={180} />

--- a/app/components/settings/EnterPasswordModal.tsx
+++ b/app/components/settings/EnterPasswordModal.tsx
@@ -40,7 +40,11 @@ type Props = {
   walletName?: string;
 };
 
-const EnterPasswordModal = ({ submitAction, closeModal, walletName }: Props) => {
+const EnterPasswordModal = ({
+  submitAction,
+  closeModal,
+  walletName,
+}: Props) => {
   const [password, setPassword] = useState('');
   const [hasError, setHasError] = useState(false);
   const [isActive, setIsActive] = useState(true);
@@ -72,14 +76,38 @@ const EnterPasswordModal = ({ submitAction, closeModal, walletName }: Props) => 
   };
 
   return (
-    <Modal header="PASSWORD" subHeader={`Enter wallet ${walletName || ''} password to complete this action.`}>
+    <Modal
+      header="PASSWORD"
+      subHeader={`Enter wallet ${
+        walletName || ''
+      } password to complete this action.`}
+    >
       <InputSection>
         <Chevron src={chevronIcon} />
-        <Input type="password" placeholder="ENTER PASSWORD" value={password} onEnterPress={submitActionWrapper} onChange={handlePasswordTyping} autofocus isDisabled={!isActive} />
-        <ErrorSection>{hasError && <ErrorPopup onClick={reset} text="sorry, this password doesn't ring a bell, please try again" />}</ErrorSection>
+        <Input
+          type="password"
+          placeholder="ENTER PASSWORD"
+          value={password}
+          onEnterPress={submitActionWrapper}
+          onChange={handlePasswordTyping}
+          autofocus
+          isDisabled={!isActive}
+        />
+        <ErrorSection>
+          {hasError && (
+            <ErrorPopup
+              onClick={reset}
+              text="sorry, this password doesn't ring a bell, please try again"
+            />
+          )}
+        </ErrorSection>
       </InputSection>
       <ButtonsWrapper>
-        <Button text="UNLOCK" isDisabled={!password.trim() || !!hasError || !isActive} onClick={submitActionWrapper} />
+        <Button
+          text="UNLOCK"
+          isDisabled={!password.trim() || !!hasError || !isActive}
+          onClick={submitActionWrapper}
+        />
         <Button text="CANCEL" isPrimary={false} onClick={closeModal} />
       </ButtonsWrapper>
     </Modal>

--- a/app/components/settings/SettingRow.tsx
+++ b/app/components/settings/SettingRow.tsx
@@ -13,15 +13,18 @@ const UpperPart = styled.div`
   flex-direction: row;
   margin-bottom: 10px;
   padding: 10px 0;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
-  border-bottom: ${({ theme }) => `1px solid ${theme.isDarkMode ? smColors.white : smColors.realBlack}`};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
+  border-bottom: ${({ theme }) =>
+    `1px solid ${theme.isDarkMode ? smColors.white : smColors.realBlack}`};
 `;
 
 const UpperPartLeft = styled.div`
   display: flex;
   align-items: center;
   flex: 2;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const UpperPartRight = styled.div`
@@ -35,7 +38,8 @@ const UpperPartRight = styled.div`
 const Name = styled.div`
   font-size: 16px;
   line-height: 22px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const Text = styled.div`
@@ -53,12 +57,21 @@ type Props = {
   bottomPart?: any;
 };
 
-const SettingRow = ({ upperPart = null, upperPartLeft = null, isUpperPartLeftText = false, upperPartRight = null, rowName, bottomPart = null }: Props) => (
+const SettingRow = ({
+  upperPart = null,
+  upperPartLeft = null,
+  isUpperPartLeftText = false,
+  upperPartRight = null,
+  rowName,
+  bottomPart = null,
+}: Props) => (
   <Wrapper>
     <UpperPart>
       {upperPart || (
         <>
-          <UpperPartLeft>{isUpperPartLeftText ? <Text>{upperPartLeft}</Text> : upperPartLeft}</UpperPartLeft>
+          <UpperPartLeft>
+            {isUpperPartLeftText ? <Text>{upperPartLeft}</Text> : upperPartLeft}
+          </UpperPartLeft>
           {upperPartRight && <UpperPartRight>{upperPartRight}</UpperPartRight>}
         </>
       )}

--- a/app/components/settings/SettingsSection.tsx
+++ b/app/components/settings/SettingsSection.tsx
@@ -18,7 +18,8 @@ const Wrapper = styled.div<{ ref: any }>`
   flex-direction: column;
   margin-bottom: 12px;
   padding: 30px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const TopLeftCorner = styled.img`
@@ -56,13 +57,15 @@ const BottomRightCorner = styled.img`
 const Header = styled.div`
   font-size: 42px;
   line-height: 55px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const SubHeader = styled.div`
   font-size: 20px;
   line-height: 30px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
   margin-bottom: 20px;
 `;
 

--- a/app/components/settings/SideMenu.tsx
+++ b/app/components/settings/SideMenu.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { sidePanelRightMed, sidePanelRightMedWhite, sidePanelLeftMed, sidePanelLeftMedWhite } from '../../assets/images';
+import {
+  sidePanelRightMed,
+  sidePanelRightMedWhite,
+  sidePanelLeftMed,
+  sidePanelLeftMedWhite,
+} from '../../assets/images';
 import { smColors } from '../../vars';
 
 const Wrapper = styled.div`
@@ -9,7 +14,8 @@ const Wrapper = styled.div`
   width: 250px;
   height: 190px;
   margin-right: 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dMBlack1 : smColors.black10Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dMBlack1 : smColors.black10Alpha};
 `;
 
 const SideBar = styled.img`
@@ -23,7 +29,8 @@ const InnerWrapper = styled.div`
   flex-direction: column;
   flex: 1;
   padding: 25px 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dMBlack1 : smColors.black10Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dMBlack1 : smColors.black10Alpha};
 `;
 
 const Container = styled.div`
@@ -45,7 +52,8 @@ const Text = styled.div<{ isCurrent: boolean }>`
       return smColors.purple;
     }
   }};
-  font-family: ${({ isCurrent }) => (isCurrent ? 'SourceCodeProBold' : 'SourceCodePro')};
+  font-family: ${({ isCurrent }) =>
+    isCurrent ? 'SourceCodeProBold' : 'SourceCodePro'};
   text-align: right;
   cursor: pointer;
 `;
@@ -57,7 +65,8 @@ const Indicator = styled.div<{ isCurrent: boolean }>`
   width: 15px;
   height: 15px;
   margin-left: 10px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.dMBlack1 : smColors.white)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dMBlack1 : smColors.white};
   font-size: 11px;
   background-color: ${({ isCurrent, theme }) => {
     if (isCurrent) {

--- a/app/components/settings/SignMessage.tsx
+++ b/app/components/settings/SignMessage.tsx
@@ -44,18 +44,40 @@ const SignMessage = ({ index, close }: Props) => {
   const accounts = useSelector((state: RootState) => state.wallet.accounts);
 
   const signText = async () => {
-    const signedMessage = await eventsService.signMessage({ message: message.trim(), accountIndex: index });
+    const signedMessage = await eventsService.signMessage({
+      message: message.trim(),
+      accountIndex: index,
+    });
     copiedTimeout && clearTimeout(copiedTimeout);
-    await navigator.clipboard.writeText(`{ "text": "${message}", "signature": "0x${signedMessage}", "publicKey": "0x${accounts[index].publicKey}" }`);
+    await navigator.clipboard.writeText(
+      `{ "text": "${message}", "signature": "0x${signedMessage}", "publicKey": "0x${accounts[index].publicKey}" }`
+    );
     copiedTimeout = setTimeout(() => setIsCopied(false), 10000);
     setIsCopied(true);
   };
 
   return (
-    <Modal header="SIGN TEXT" subHeader={`sign text with account ${getAbbreviatedText(getAddress(accounts[index].publicKey))}`}>
-      <Input value={message} placeholder="ENTER TEXT TO SIGN" onChange={({ value }) => setMessage(value)} maxLength="64" style={inputStyle} autofocus />
+    <Modal
+      header="SIGN TEXT"
+      subHeader={`sign text with account ${getAbbreviatedText(
+        getAddress(accounts[index].publicKey)
+      )}`}
+    >
+      <Input
+        value={message}
+        placeholder="ENTER TEXT TO SIGN"
+        onChange={({ value }) => setMessage(value)}
+        maxLength="64"
+        style={inputStyle}
+        autofocus
+      />
       <ButtonsWrapper>
-        <Button onClick={signText} text="SIGN" width={150} isDisabled={!message} />
+        <Button
+          onClick={signText}
+          text="SIGN"
+          width={150}
+          isDisabled={!message}
+        />
         <Button onClick={close} isPrimary={false} text="Cancel" />
       </ButtonsWrapper>
       <CopiedText>{isCopied ? 'Address copied' : ' '}</CopiedText>

--- a/app/components/transactions/LatestTransactions.tsx
+++ b/app/components/transactions/LatestTransactions.tsx
@@ -2,12 +2,26 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { Button } from '../../basicComponents';
-import { chevronLeftBlack, chevronLeftWhite, chevronRightBlack, chevronRightWhite } from '../../assets/images';
-import { getAbbreviatedText, getFormattedTimestamp, getAddress, formatSmidge } from '../../infra/utils';
+import {
+  chevronLeftBlack,
+  chevronLeftWhite,
+  chevronRightBlack,
+  chevronRightWhite,
+} from '../../assets/images';
+import {
+  getAbbreviatedText,
+  getFormattedTimestamp,
+  getAddress,
+  formatSmidge,
+} from '../../infra/utils';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
 import { TxState } from '../../../shared/types';
-import { getLatestTransactions, RewardView, TxView } from '../../redux/wallet/selectors';
+import {
+  getLatestTransactions,
+  RewardView,
+  TxView,
+} from '../../redux/wallet/selectors';
 import { isReward } from '../../../shared/types/guards';
 
 const Wrapper = styled.div`
@@ -16,7 +30,8 @@ const Wrapper = styled.div`
   width: 250px;
   height: 100%;
   padding: 20px 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const Header = styled.div`
@@ -52,11 +67,13 @@ const Section = styled.div`
 const Text = styled.div`
   font-size: 13px;
   line-height: 17px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.darkGray)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.darkGray};
 `;
 
 const NickName = styled(Text)`
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const Amount = styled.div`
@@ -68,14 +85,30 @@ type Props = {
 };
 
 const LatestTransactions = ({ navigateToAllTransactions }: Props) => {
-  const publicKey = useSelector((state: RootState) => state.wallet.accounts[state.wallet.currentAccountIndex]?.publicKey);
+  const publicKey = useSelector(
+    (state: RootState) =>
+      state.wallet.accounts[state.wallet.currentAccountIndex]?.publicKey
+  );
   const latestTransactions = useSelector(getLatestTransactions(publicKey));
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
 
-  const getColor = ({ status, isSent }: { status: number; isSent: boolean }) => {
-    if (status === TxState.TRANSACTION_STATE_MEMPOOL || status === TxState.TRANSACTION_STATE_MESH) {
+  const getColor = ({
+    status,
+    isSent,
+  }: {
+    status: number;
+    isSent: boolean;
+  }) => {
+    if (
+      status === TxState.TRANSACTION_STATE_MEMPOOL ||
+      status === TxState.TRANSACTION_STATE_MESH
+    ) {
       return smColors.orange;
-    } else if (status === TxState.TRANSACTION_STATE_REJECTED || status === TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS || status === TxState.TRANSACTION_STATE_CONFLICTING) {
+    } else if (
+      status === TxState.TRANSACTION_STATE_REJECTED ||
+      status === TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS ||
+      status === TxState.TRANSACTION_STATE_CONFLICTING
+    ) {
       return smColors.red;
     }
     return isSent ? smColors.blue : smColors.darkerGreen;
@@ -97,7 +130,9 @@ const LatestTransactions = ({ navigateToAllTransactions }: Props) => {
           </Section>
           <Section>
             <Text>{getFormattedTimestamp(timestamp)}</Text>
-            <Amount color={color}>{`${isSent ? '-' : '+'}${formatSmidge(amount)}`}</Amount>
+            <Amount color={color}>{`${isSent ? '-' : '+'}${formatSmidge(
+              amount
+            )}`}</Amount>
           </Section>
         </MainWrapper>
       </TxWrapper>
@@ -116,14 +151,18 @@ const LatestTransactions = ({ navigateToAllTransactions }: Props) => {
           </Section>
           <Section>
             <Text>{getFormattedTimestamp(timestamp)}</Text>
-            <Amount color={smColors.darkerGreen}>{`+${formatSmidge(amount)}`}</Amount>
+            <Amount color={smColors.darkerGreen}>{`+${formatSmidge(
+              amount
+            )}`}</Amount>
           </Section>
         </MainWrapper>
       </TxWrapper>
     );
   };
 
-  const renderedLatestTransactions = latestTransactions.map((tx) => (isReward(tx) ? renderReward(tx) : renderTransaction(tx)));
+  const renderedLatestTransactions = latestTransactions.map((tx) =>
+    isReward(tx) ? renderReward(tx) : renderTransaction(tx)
+  );
 
   return (
     <Wrapper>
@@ -133,7 +172,12 @@ const LatestTransactions = ({ navigateToAllTransactions }: Props) => {
         --
       </Header>
       <div>{renderedLatestTransactions}</div>
-      <Button onClick={navigateToAllTransactions} text="ALL TRANSACTIONS" width={175} style={{ marginTop: 'auto ' }} />
+      <Button
+        onClick={navigateToAllTransactions}
+        text="ALL TRANSACTIONS"
+        width={175}
+        style={{ marginTop: 'auto ' }}
+      />
     </Wrapper>
   );
 };

--- a/app/components/transactions/RewardRow.tsx
+++ b/app/components/transactions/RewardRow.tsx
@@ -12,7 +12,8 @@ import Address from '../common/Address';
 const Wrapper = styled.div<{ isDetailed: boolean }>`
   display: flex;
   flex-direction: column;
-  ${({ isDetailed }) => isDetailed && `background-color: ${smColors.lighterGray};`}
+  ${({ isDetailed }) =>
+    isDetailed && `background-color: ${smColors.lighterGray};`}
   cursor: pointer;
 `;
 
@@ -21,9 +22,11 @@ const Header = styled.div`
   flex-direction: row;
   padding: 10px 10px 15px 10px;
   cursor: pointer;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.black : 'transparent')};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.black : 'transparent'};
   &:hover {
-    background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dark75Alpha : smColors.disabledGray)};
+    background-color: ${({ theme }) =>
+      theme.isDarkMode ? smColors.dark75Alpha : smColors.disabledGray};
   }
 `;
 
@@ -51,11 +54,13 @@ const HeaderSection = styled.div`
 const Text = styled.span`
   font-size: 13px;
   line-height: 17px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.darkGray50Alpha)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.darkGray50Alpha};
 `;
 
 const BlackText = styled(Text)`
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const BoldText = styled(Text)`
@@ -70,7 +75,8 @@ const BoldText = styled(Text)`
 `;
 
 const DarkGrayText = styled(Text)`
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.darkGray)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.darkGray};
   cursor: inherit;
   text-align: right;
 `;
@@ -89,7 +95,8 @@ const DetailsSection = styled.div`
   flex-direction: column;
   justify-content: space-between;
   padding: 6px 12px 12px 20px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.black : 'transparent')};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.black : 'transparent'};
 `;
 
 const TextRow = styled.div<{ isLast?: boolean }>`
@@ -99,9 +106,17 @@ const TextRow = styled.div<{ isLast?: boolean }>`
   overflow: hidden;
   white-space: nowrap;
   padding: 5px 0;
-  border-bottom: ${({ isLast, theme }) => (isLast ? `0px` : `1px solid ${theme.isDarkMode ? smColors.dMBlack1 : smColors.darkGray10Alpha};`)};
+  border-bottom: ${({ isLast, theme }) =>
+    isLast
+      ? `0px`
+      : `1px solid ${
+          theme.isDarkMode ? smColors.dMBlack1 : smColors.darkGray10Alpha
+        };`};
   :first-child {
-    border-top: ${({ theme }) => `1px solid ${theme.isDarkMode ? smColors.dMBlack1 : smColors.darkGray10Alpha};`};
+    border-top: ${({ theme }) =>
+      `1px solid ${
+        theme.isDarkMode ? smColors.dMBlack1 : smColors.darkGray10Alpha
+      };`};
   }
   :last-child {
     border-bottom: none;
@@ -159,7 +174,9 @@ const RewardRow = ({ tx, publicKey }: Props) => {
             <DarkGrayText>SMESHING REWARD</DarkGrayText>
           </HeaderSection>
           <HeaderSection>
-            <Amount color={smColors.darkerGreen}>+{formatSmidge(amount)}</Amount>
+            <Amount color={smColors.darkerGreen}>
+              +{formatSmidge(amount)}
+            </Amount>
             <DarkGrayText>{getFormattedTimestamp(timestamp)}</DarkGrayText>
           </HeaderSection>
         </HeaderInner>

--- a/app/components/transactions/TransactionsMeta.tsx
+++ b/app/components/transactions/TransactionsMeta.tsx
@@ -6,13 +6,15 @@ import { smColors } from '../../vars';
 const Text = styled.span`
   font-size: 16px;
   line-height: 22px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const BoldText = styled.span`
   font-family: SourceCodeProBold;
   margin-bottom: 10px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const TextRow = styled.div`
@@ -48,13 +50,15 @@ const ProgressBar = styled.div`
 const SmallText = styled.span`
   font-size: 13px;
   line-height: 17px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.darkGray)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.darkGray};
 `;
 
 const Bar = styled.div`
   width: 100%;
   height: 5px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.mediumGray)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.mediumGray};
   position: relative;
 `;
 
@@ -75,7 +79,15 @@ type Props = {
   totalReceived: number;
 };
 
-const TransactionsMeta = ({ mined, sent, received, totalMined, totalSent, totalReceived, filterName }: Props) => {
+const TransactionsMeta = ({
+  mined,
+  sent,
+  received,
+  totalMined,
+  totalSent,
+  totalReceived,
+  filterName,
+}: Props) => {
   const totalFilteredCoins = mined + sent + received;
   const coinsMeta = [
     { title: 'SMESHED', coins: mined },
@@ -93,10 +105,14 @@ const TransactionsMeta = ({ mined, sent, received, totalMined, totalSent, totalR
       <Group>
         <BoldText>activity</BoldText>
         <BoldText>--</BoldText>
-        <Text style={{ marginBottom: 27 }}>{`${filterName.replace(/^\w/, (c) => c.toUpperCase())} coins: ${formatSmidge(totalFilteredCoins)}`}</Text>
+        <Text style={{ marginBottom: 27 }}>{`${filterName.replace(/^\w/, (c) =>
+          c.toUpperCase()
+        )} coins: ${formatSmidge(totalFilteredCoins)}`}</Text>
         {coinsMeta.map((coinMeta) => (
           <ProgressBar key={coinMeta.title}>
-            <SmallText>{`${coinMeta.title} ${formatSmidge(coinMeta.coins)}`}</SmallText>
+            <SmallText>{`${coinMeta.title} ${formatSmidge(
+              coinMeta.coins
+            )}`}</SmallText>
             <Bar>
               <Progress coins={coinMeta.coins} total={totalFilteredCoins} />
             </Bar>

--- a/app/components/transactions/TxRow.tsx
+++ b/app/components/transactions/TxRow.tsx
@@ -1,10 +1,19 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
-import { chevronLeftBlack, chevronLeftWhite, chevronRightBlack, chevronRightWhite } from '../../assets/images';
+import {
+  chevronLeftBlack,
+  chevronLeftWhite,
+  chevronRightBlack,
+  chevronRightWhite,
+} from '../../assets/images';
 import { Modal } from '../common';
 import { Button, Link, Input } from '../../basicComponents';
-import { getFormattedTimestamp, getAddress, formatSmidge } from '../../infra/utils';
+import {
+  getFormattedTimestamp,
+  getAddress,
+  formatSmidge,
+} from '../../infra/utils';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
 import { eventsService } from '../../infra/eventsService';
@@ -16,7 +25,8 @@ import { ExternalLinks, TX_STATE_LABELS } from '../../../shared/constants';
 const Wrapper = styled.div<{ isDetailed: boolean }>`
   display: flex;
   flex-direction: column;
-  ${({ isDetailed }) => isDetailed && `background-color: ${smColors.lighterGray};`}
+  ${({ isDetailed }) =>
+    isDetailed && `background-color: ${smColors.lighterGray};`}
   cursor: pointer;
 `;
 
@@ -25,9 +35,11 @@ const Header = styled.div`
   flex-direction: row;
   padding: 10px 10px 15px 10px;
   cursor: pointer;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.black : 'transparent')};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.black : 'transparent'};
   &:hover {
-    background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dark75Alpha : smColors.disabledGray)};
+    background-color: ${({ theme }) =>
+      theme.isDarkMode ? smColors.dark75Alpha : smColors.disabledGray};
   }
 `;
 
@@ -55,11 +67,13 @@ const HeaderSection = styled.div`
 const Text = styled.span`
   font-size: 13px;
   line-height: 17px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.darkGray50Alpha)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.darkGray50Alpha};
 `;
 
 const BlackText = styled(Text)`
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const BoldText = styled(Text)`
@@ -74,7 +88,8 @@ const BoldText = styled(Text)`
 `;
 
 const DarkGrayText = styled(Text)`
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.darkGray)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.darkGray};
   cursor: inherit;
   text-align: right;
 `;
@@ -93,7 +108,8 @@ const DetailsSection = styled.div`
   flex-direction: column;
   justify-content: space-between;
   padding: 6px 12px 12px 20px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.black : 'transparent')};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.black : 'transparent'};
 `;
 
 const TextRow = styled.div<{ isLast?: boolean }>`
@@ -103,9 +119,17 @@ const TextRow = styled.div<{ isLast?: boolean }>`
   overflow: hidden;
   white-space: nowrap;
   padding: 5px 0;
-  border-bottom: ${({ isLast, theme }) => (isLast ? `0px` : `1px solid ${theme.isDarkMode ? smColors.dMBlack1 : smColors.darkGray10Alpha};`)};
+  border-bottom: ${({ isLast, theme }) =>
+    isLast
+      ? `0px`
+      : `1px solid ${
+          theme.isDarkMode ? smColors.dMBlack1 : smColors.darkGray10Alpha
+        };`};
   :first-child {
-    border-top: ${({ theme }) => `1px solid ${theme.isDarkMode ? smColors.dMBlack1 : smColors.darkGray10Alpha};`};
+    border-top: ${({ theme }) =>
+      `1px solid ${
+        theme.isDarkMode ? smColors.dMBlack1 : smColors.darkGray10Alpha
+      };`};
   }
   :last-child {
     border-bottom: none;
@@ -158,14 +182,23 @@ const TxRow = ({ tx, publicKey, addAddressToContacts }: Props) => {
   const [note, setNote] = useState(tx.note || '');
   const [showNoteModal, setShowNoteModal] = useState(false);
 
-  const currentAccountIndex = useSelector((state: RootState) => state.wallet.currentAccountIndex);
+  const currentAccountIndex = useSelector(
+    (state: RootState) => state.wallet.currentAccountIndex
+  );
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
 
   const getColor = (isSent: boolean) => {
     const { status } = tx;
-    if (status === TxState.TRANSACTION_STATE_MEMPOOL || status === TxState.TRANSACTION_STATE_MESH) {
+    if (
+      status === TxState.TRANSACTION_STATE_MEMPOOL ||
+      status === TxState.TRANSACTION_STATE_MESH
+    ) {
       return smColors.orange;
-    } else if (status === TxState.TRANSACTION_STATE_REJECTED || status === TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS || status === TxState.TRANSACTION_STATE_CONFLICTING) {
+    } else if (
+      status === TxState.TRANSACTION_STATE_REJECTED ||
+      status === TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS ||
+      status === TxState.TRANSACTION_STATE_CONFLICTING
+    ) {
       return smColors.red;
     } else if (status === TxState.TRANSACTION_STATE_UNSPECIFIED) {
       return smColors.mediumGray;
@@ -190,11 +223,19 @@ const TxRow = ({ tx, publicKey, addAddressToContacts }: Props) => {
 
   const txFrom = isSent ? getAddress(publicKey) : tx.sender;
   const txFromSuffix = (isSent && '(Me)') || undefined;
-  const txFromAddContact = tx.senderNickname || isSent ? undefined : () => addAddressToContacts({ address: tx.sender });
+  const txFromAddContact =
+    tx.senderNickname || isSent
+      ? undefined
+      : () => addAddressToContacts({ address: tx.sender });
 
-  const txTo = isSent ? tx.receiverNickname || tx.receiver : getAddress(publicKey);
+  const txTo = isSent
+    ? tx.receiverNickname || tx.receiver
+    : getAddress(publicKey);
   const txToSuffix = (!isSent && '(Me)') || undefined;
-  const txToAddContract = tx.receiverNickname || !isSent ? undefined : () => addAddressToContacts({ address: tx.receiver });
+  const txToAddContract =
+    tx.receiverNickname || !isSent
+      ? undefined
+      : () => addAddressToContacts({ address: tx.receiver });
 
   const renderDetails = () => (
     <DetailsSection>
@@ -217,13 +258,23 @@ const TxRow = ({ tx, publicKey, addAddressToContacts }: Props) => {
       <TextRow>
         <BlackText>FROM</BlackText>
         <BoldText>
-          <Address address={txFrom} suffix={txFromSuffix} overlapText={tx.senderNickname} addToContacts={txFromAddContact} />
+          <Address
+            address={txFrom}
+            suffix={txFromSuffix}
+            overlapText={tx.senderNickname}
+            addToContacts={txFromAddContact}
+          />
         </BoldText>
       </TextRow>
       <TextRow>
         <BlackText>TO</BlackText>
         <BoldText>
-          <Address address={txTo} suffix={txToSuffix} overlapText={tx.receiverNickname} addToContacts={txToAddContract} />
+          <Address
+            address={txTo}
+            suffix={txToSuffix}
+            overlapText={tx.receiverNickname}
+            addToContacts={txToAddContract}
+          />
         </BoldText>
       </TextRow>
       <TextRow>
@@ -232,7 +283,9 @@ const TxRow = ({ tx, publicKey, addAddressToContacts }: Props) => {
       </TextRow>
       <TextRow>
         <BlackText>FEE</BlackText>
-        <BoldText>{formatSmidge(tx.gasOffered?.provided || tx.receipt?.fee || 0)}</BoldText>
+        <BoldText>
+          {formatSmidge(tx.gasOffered?.provided || tx.receipt?.fee || 0)}
+        </BoldText>
       </TextRow>
       <TextRow>
         <BlackText>NOTE</BlackText>
@@ -245,8 +298,15 @@ const TxRow = ({ tx, publicKey, addAddressToContacts }: Props) => {
   );
 
   const renderNickname = () => {
-    const nickname = (isSent && tx.receiverNickname) || (!isSent && tx.senderNickname);
-    return nickname && <DarkGrayText key="nickname">{nickname && nickname.toUpperCase()}</DarkGrayText>;
+    const nickname =
+      (isSent && tx.receiverNickname) || (!isSent && tx.senderNickname);
+    return (
+      nickname && (
+        <DarkGrayText key="nickname">
+          {nickname && nickname.toUpperCase()}
+        </DarkGrayText>
+      )
+    );
   };
 
   return (
@@ -259,7 +319,9 @@ const TxRow = ({ tx, publicKey, addAddressToContacts }: Props) => {
             <Text key={tx.id}>{formatTxId(tx.id)}</Text>
           </HeaderSection>
           <HeaderSection>
-            <Amount color={color}>{`${isSent ? '-' : '+'}${formatSmidge(tx.amount)}`}</Amount>
+            <Amount color={color}>{`${isSent ? '-' : '+'}${formatSmidge(
+              tx.amount
+            )}`}</Amount>
             <DarkGrayText>{getFormattedTimestamp(tx.timestamp)}</DarkGrayText>
           </HeaderSection>
         </HeaderInner>
@@ -281,10 +343,21 @@ const TxRow = ({ tx, publicKey, addAddressToContacts }: Props) => {
             />
           </InputSection>
           <ButtonsWrapper>
-            <Link onClick={() => window.open(ExternalLinks.SendCoinGuide)} text="TRANSACTION GUIDE" />
+            <Link
+              onClick={() => window.open(ExternalLinks.SendCoinGuide)}
+              text="TRANSACTION GUIDE"
+            />
             <RightButton>
-              <Link style={{ color: smColors.orange, marginRight: '10px' }} onClick={() => setShowNoteModal(false)} text="CANCEL" />
-              <Button text="NEXT" isDisabled={note === tx.note} onClick={save} />
+              <Link
+                style={{ color: smColors.orange, marginRight: '10px' }}
+                onClick={() => setShowNoteModal(false)}
+                text="CANCEL"
+              />
+              <Button
+                text="NEXT"
+                isDisabled={note === tx.note}
+                onClick={save}
+              />
             </RightButton>
           </ButtonsWrapper>
         </Modal>

--- a/app/components/vault/DailySpending.tsx
+++ b/app/components/vault/DailySpending.tsx
@@ -15,7 +15,8 @@ const DetailsRow = styled.div`
 const DetailsText = styled.div`
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const AccItem = styled.div<{ isInDropDown: boolean }>`
@@ -25,7 +26,9 @@ const AccItem = styled.div<{ isInDropDown: boolean }>`
   padding: 5px;
   width: 100%;
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -58,10 +61,27 @@ const limits = [
   },
 ];
 
-const DailySpending = ({ masterAccountIndex, selectAccountIndex, accountsOption, isDarkMode }: Props) => {
-  const ddStyle = { border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`, marginLeft: 'auto', flex: '0 0 240px' };
+const DailySpending = ({
+  masterAccountIndex,
+  selectAccountIndex,
+  accountsOption,
+  isDarkMode,
+}: Props) => {
+  const ddStyle = {
+    border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`,
+    marginLeft: 'auto',
+    flex: '0 0 240px',
+  };
 
-  const renderAccElement = ({ label, text, isInDropDown }: { label: string; text: string; isInDropDown: boolean }) => (
+  const renderAccElement = ({
+    label,
+    text,
+    isInDropDown,
+  }: {
+    label: string;
+    text: string;
+    isInDropDown: boolean;
+  }) => (
     <AccItem key={label} isInDropDown={isInDropDown}>
       {label} {text}
     </AccItem>
@@ -76,7 +96,9 @@ const DailySpending = ({ masterAccountIndex, selectAccountIndex, accountsOption,
         <DropDown
           data={accountsOption}
           onClick={selectAccountIndex}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={masterAccountIndex}
           rowHeight={40}
           style={ddStyle}
@@ -90,7 +112,9 @@ const DailySpending = ({ masterAccountIndex, selectAccountIndex, accountsOption,
         <DropDown
           data={limits}
           onClick={selectAccountIndex}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={masterAccountIndex}
           rowHeight={40}
           style={ddStyle}

--- a/app/components/vault/NewVault.tsx
+++ b/app/components/vault/NewVault.tsx
@@ -14,7 +14,8 @@ const DetailsRow = styled.div`
 const DetailsText = styled.div`
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const inputStyle = { flex: '0 0 240px' };
@@ -36,7 +37,15 @@ const NewVault = ({ vaultName, onChangeVaultName, isDarkMode }: Props) => {
           text="Vault will be created in My Wallet. To create a vault which uses a Ledger device for signing transactions, create a vault in a Ledger wallet."
         />
         <Dots />
-        <Input type="text" value={vaultName} onChange={onChangeVaultName} placeholder="MY VAULT NAME" maxLength={50} style={inputStyle} autofocus />
+        <Input
+          type="text"
+          value={vaultName}
+          onChange={onChangeVaultName}
+          placeholder="MY VAULT NAME"
+          maxLength={50}
+          style={inputStyle}
+          autofocus
+        />
       </DetailsRow>
     </>
   );

--- a/app/components/vault/ReviewNewVault.tsx
+++ b/app/components/vault/ReviewNewVault.tsx
@@ -9,14 +9,20 @@ const DetailsRow = styled.div<{ isLast?: boolean }>`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  border-bottom: ${({ isLast, theme }) => (isLast ? `0px` : `1px solid ${theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey};`)};
+  border-bottom: ${({ isLast, theme }) =>
+    isLast
+      ? `0px`
+      : `1px solid ${
+          theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey
+        };`};
 `;
 
 const DetailsText = styled.div`
   font-size: 16px;
   line-height: 20px;
   margin: 10px 0;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey};
 `;
 
 const DetailsTextWrap = styled.div`
@@ -28,7 +34,8 @@ const DetailsTextWrap = styled.div`
 const GrayText = styled.div`
   font-size: 14px;
   text-transform: uppercase;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.vaultDarkGrey : smColors.vaultLightGrey};
 `;
 
 type Props = {

--- a/app/components/vault/VaultFinish.tsx
+++ b/app/components/vault/VaultFinish.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 import { smColors } from '../../vars';
-import { vault, circle, wallet, fireworksWhite, fireworks } from '../../assets/images';
+import {
+  vault,
+  circle,
+  wallet,
+  fireworksWhite,
+  fireworks,
+} from '../../assets/images';
 
 const DetailsRow = styled.div`
   position: relative;
@@ -37,7 +43,10 @@ type Props = {
 const VaultFinish = ({ isDarkMode }: Props) => (
   <>
     <Fireworks src={isDarkMode ? fireworksWhite : fireworks} />
-    <GreenText>Your new vault transaction has been submitted to the mesh and is being created.</GreenText>
+    <GreenText>
+      Your new vault transaction has been submitted to the mesh and is being
+      created.
+    </GreenText>
     <DetailsRow>
       <Icon src={circle} />
       Track creation progress in your transactions log.
@@ -48,7 +57,8 @@ const VaultFinish = ({ isDarkMode }: Props) => (
     </DetailsRow>
     <DetailsRow>
       <Icon src={vault} />
-      To work with your new vault, select it from your wallet’s accounts list drop-down (left side).
+      To work with your new vault, select it from your wallet’s accounts list
+      drop-down (left side).
     </DetailsRow>
   </>
 );

--- a/app/components/vault/VaultMasterAccount.tsx
+++ b/app/components/vault/VaultMasterAccount.tsx
@@ -15,7 +15,8 @@ const DetailsRow = styled.div`
 const DetailsText = styled.div`
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const AccItem = styled.div<{ isInDropDown: boolean }>`
@@ -25,7 +26,9 @@ const AccItem = styled.div<{ isInDropDown: boolean }>`
   padding: 5px;
   width: 100%;
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -39,10 +42,27 @@ type Props = {
   accountsOption: Account[];
 };
 
-const VaultMasterAccount = ({ masterAccountIndex, selectedAccountIndex, isDarkMode, accountsOption }: Props) => {
-  const ddStyle = { border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`, marginLeft: 'auto', flex: '0 0 240px' };
+const VaultMasterAccount = ({
+  masterAccountIndex,
+  selectedAccountIndex,
+  isDarkMode,
+  accountsOption,
+}: Props) => {
+  const ddStyle = {
+    border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`,
+    marginLeft: 'auto',
+    flex: '0 0 240px',
+  };
 
-  const renderAccElement = ({ label, text, isInDropDown }: { label: string; text: string; isInDropDown: boolean }) => (
+  const renderAccElement = ({
+    label,
+    text,
+    isInDropDown,
+  }: {
+    label: string;
+    text: string;
+    isInDropDown: boolean;
+  }) => (
     <AccItem key={label} isInDropDown={isInDropDown}>
       {label} {text}
     </AccItem>
@@ -52,12 +72,18 @@ const VaultMasterAccount = ({ masterAccountIndex, selectedAccountIndex, isDarkMo
     <>
       <DetailsRow>
         <DetailsText>Account</DetailsText>
-        <Tooltip width={250} isDarkMode={isDarkMode} text="Use an account managed by this wallet to set yourself as the vault’s owner." />
+        <Tooltip
+          width={250}
+          isDarkMode={isDarkMode}
+          text="Use an account managed by this wallet to set yourself as the vault’s owner."
+        />
         <Dots />
         <DropDown
           data={accountsOption}
           onClick={selectedAccountIndex}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={masterAccountIndex}
           rowHeight={40}
           style={ddStyle}

--- a/app/components/vault/VaultMasterAccounts.tsx
+++ b/app/components/vault/VaultMasterAccounts.tsx
@@ -15,7 +15,8 @@ const DetailsRow = styled.div`
 const DetailsText = styled.div`
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const AccItem = styled.div<{ isInDropDown: boolean }>`
@@ -25,7 +26,9 @@ const AccItem = styled.div<{ isInDropDown: boolean }>`
   padding: 5px;
   width: 100%;
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -39,10 +42,27 @@ type Props = {
   accountsOption: Account[];
 };
 
-const VaultMasterAccounts = ({ masterAccountIndex, selectAccountIndex, isDarkMode, accountsOption }: Props) => {
-  const ddStyle = { border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`, marginLeft: 'auto', flex: '0 0 240px' };
+const VaultMasterAccounts = ({
+  masterAccountIndex,
+  selectAccountIndex,
+  isDarkMode,
+  accountsOption,
+}: Props) => {
+  const ddStyle = {
+    border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`,
+    marginLeft: 'auto',
+    flex: '0 0 240px',
+  };
 
-  const renderAccElement = ({ label, text, isInDropDown }: { label: string; text: string; isInDropDown: boolean }) => (
+  const renderAccElement = ({
+    label,
+    text,
+    isInDropDown,
+  }: {
+    label: string;
+    text: string;
+    isInDropDown: boolean;
+  }) => (
     <AccItem key={label} isInDropDown={isInDropDown}>
       {label} {text}
     </AccItem>
@@ -52,12 +72,18 @@ const VaultMasterAccounts = ({ masterAccountIndex, selectAccountIndex, isDarkMod
     <>
       <DetailsRow>
         <DetailsText>Address 1</DetailsText>
-        <Tooltip width={250} isDarkMode={isDarkMode} text="Use an account managed by this wallet to set yourself as the vault’s owner." />
+        <Tooltip
+          width={250}
+          isDarkMode={isDarkMode}
+          text="Use an account managed by this wallet to set yourself as the vault’s owner."
+        />
         <Dots />
         <DropDown
           data={accountsOption}
           onClick={selectAccountIndex}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={masterAccountIndex}
           rowHeight={40}
           style={ddStyle}
@@ -66,12 +92,18 @@ const VaultMasterAccounts = ({ masterAccountIndex, selectAccountIndex, isDarkMod
       </DetailsRow>
       <DetailsRow>
         <DetailsText>Address 2</DetailsText>
-        <Tooltip width={250} isDarkMode={isDarkMode} text="Use an account managed by this wallet to set yourself as the vault’s owner." />
+        <Tooltip
+          width={250}
+          isDarkMode={isDarkMode}
+          text="Use an account managed by this wallet to set yourself as the vault’s owner."
+        />
         <Dots />
         <DropDown
           data={accountsOption}
           onClick={selectAccountIndex}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={masterAccountIndex}
           rowHeight={40}
           style={ddStyle}
@@ -80,12 +112,18 @@ const VaultMasterAccounts = ({ masterAccountIndex, selectAccountIndex, isDarkMod
       </DetailsRow>
       <DetailsRow>
         <DetailsText>Address 3</DetailsText>
-        <Tooltip width={250} isDarkMode={isDarkMode} text="Use an account managed by this wallet to set yourself as the vault’s owner." />
+        <Tooltip
+          width={250}
+          isDarkMode={isDarkMode}
+          text="Use an account managed by this wallet to set yourself as the vault’s owner."
+        />
         <Dots />
         <DropDown
           data={accountsOption}
           onClick={selectAccountIndex}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={masterAccountIndex}
           rowHeight={40}
           style={ddStyle}

--- a/app/components/vault/VaultTx.tsx
+++ b/app/components/vault/VaultTx.tsx
@@ -14,7 +14,8 @@ const DetailsRow = styled.div`
 const DetailsText = styled.div`
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const AccItem = styled.div<{ isInDropDown: boolean }>`
@@ -24,7 +25,9 @@ const AccItem = styled.div<{ isInDropDown: boolean }>`
   padding: 5px;
   width: 100%;
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -73,12 +76,37 @@ const unitPrice = [
   },
 ];
 
-const VaultTx = ({ selectAccountIndex, selectFundAmount, selectGasUnits, selectGasPrice, isDarkMode }: Props) => {
-  const ddStyle = { border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`, marginLeft: 'auto', flex: '0 0 340px' };
-  const ddStyleGasUnit = { border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`, marginLeft: 'auto', flex: '0 0 140px' };
-  const ddStyleGasPrice = { border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`, marginLeft: 'auto', flex: '0 0 200px' };
+const VaultTx = ({
+  selectAccountIndex,
+  selectFundAmount,
+  selectGasUnits,
+  selectGasPrice,
+  isDarkMode,
+}: Props) => {
+  const ddStyle = {
+    border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`,
+    marginLeft: 'auto',
+    flex: '0 0 340px',
+  };
+  const ddStyleGasUnit = {
+    border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`,
+    marginLeft: 'auto',
+    flex: '0 0 140px',
+  };
+  const ddStyleGasPrice = {
+    border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`,
+    marginLeft: 'auto',
+    flex: '0 0 200px',
+  };
 
-  const renderAccElement = ({ label, isInDropDown }: { label: string; text: string; isInDropDown: boolean }) => (
+  const renderAccElement = ({
+    label,
+    isInDropDown,
+  }: {
+    label: string;
+    text: string;
+    isInDropDown: boolean;
+  }) => (
     <AccItem key={label} isInDropDown={isInDropDown}>
       {label}
     </AccItem>
@@ -93,7 +121,9 @@ const VaultTx = ({ selectAccountIndex, selectFundAmount, selectGasUnits, selectG
         <DropDown
           data={accounts}
           onClick={selectAccountIndex}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={0}
           rowHeight={40}
           style={ddStyle}
@@ -107,7 +137,9 @@ const VaultTx = ({ selectAccountIndex, selectFundAmount, selectGasUnits, selectG
         <DropDown
           data={accounts}
           onClick={selectFundAmount}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={0}
           rowHeight={40}
           style={ddStyle}
@@ -121,7 +153,9 @@ const VaultTx = ({ selectAccountIndex, selectFundAmount, selectGasUnits, selectG
         <DropDown
           data={gasUnit}
           onClick={selectGasUnits}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={0}
           rowHeight={40}
           style={ddStyleGasUnit}
@@ -135,7 +169,9 @@ const VaultTx = ({ selectAccountIndex, selectFundAmount, selectGasUnits, selectG
         <DropDown
           data={unitPrice}
           onClick={selectGasPrice}
-          DdElement={({ label, text, isMain }) => renderAccElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderAccElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={0}
           rowHeight={40}
           style={ddStyleGasPrice}

--- a/app/components/vault/VaultType.tsx
+++ b/app/components/vault/VaultType.tsx
@@ -30,17 +30,32 @@ type Props = {
 const VaultType = ({ type, handleChangeType, isDarkMode }: Props) => (
   <>
     <Label>
-      <RadioButton checked={type === 'single'} name="single" value={'single'} onChange={handleChangeType} />
+      <RadioButton
+        checked={type === 'single'}
+        name="single"
+        value={'single'}
+        onChange={handleChangeType}
+      />
       <InputTitle>Simple Vault</InputTitle>
       <Tooltip width={250} text="Simple Vault" isDarkMode={isDarkMode} />
     </Label>
-    <InputSubTitle>A vault controlled by a single master account.</InputSubTitle>
+    <InputSubTitle>
+      A vault controlled by a single master account.
+    </InputSubTitle>
     <Label>
-      <RadioButton checked={type === 'multi-sig'} name="multi-sig" value={'multi-sig'} onChange={handleChangeType} />
+      <RadioButton
+        checked={type === 'multi-sig'}
+        name="multi-sig"
+        value={'multi-sig'}
+        onChange={handleChangeType}
+      />
       <InputTitle>Multi-sig Vault</InputTitle>
       <Tooltip width={250} text="Multi-sig Vault" isDarkMode={isDarkMode} />
     </Label>
-    <InputSubTitle>A 2/3 multi-sig vault which is controlled by 3 master accounts and requires 2 signatures on each operation.</InputSubTitle>
+    <InputSubTitle>
+      A 2/3 multi-sig vault which is controlled by 3 master accounts and
+      requires 2 signatures on each operation.
+    </InputSubTitle>
   </>
 );
 

--- a/app/components/wallet/AccountsOverview.tsx
+++ b/app/components/wallet/AccountsOverview.tsx
@@ -20,16 +20,19 @@ const AccountWrapper = styled.div<{ isInDropDown: boolean }>`
   align-items: flex-start;
   margin: 5px;
   cursor: inherit;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
   &:hover {
     opacity: 1;
-    color: ${({ theme }) => (theme.isDarkMode ? smColors.lightGray : smColors.darkGray50Alpha)};
+    color: ${({ theme }) =>
+      theme.isDarkMode ? smColors.lightGray : smColors.darkGray50Alpha};
   }
   ${({ isInDropDown }) =>
     isInDropDown &&
     `opacity: 0.5; color: ${smColors.realBlack}; &:hover {
     opacity: 1;
-    color: ${(theme: any) => (theme.isDarkMode ? smColors.darkGray50Alpha : smColors.darkGray50Alpha)};
+    color: ${(theme: any) =>
+      theme.isDarkMode ? smColors.darkGray50Alpha : smColors.darkGray50Alpha};
   }`}
 `;
 
@@ -79,10 +82,14 @@ const NotSyncedYetText = styled.div`
 `;
 
 const AccountsOverview = () => {
-  const isSynced = useSelector((state: RootState) => !!state.node.status?.isSynced);
+  const isSynced = useSelector(
+    (state: RootState) => !!state.node.status?.isSynced
+  );
   const meta = useSelector((state: RootState) => state.wallet.meta);
   const accounts = useSelector((state: RootState) => state.wallet.accounts);
-  const currentAccountIndex = useSelector((state: RootState) => state.wallet.currentAccountIndex);
+  const currentAccountIndex = useSelector(
+    (state: RootState) => state.wallet.currentAccountIndex
+  );
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
   const dispatch = useDispatch();
 
@@ -90,7 +97,15 @@ const AccountsOverview = () => {
     dispatch(setCurrentAccount(index));
   };
 
-  const renderAccountRow = ({ displayName, publicKey, isInDropDown = false }: { displayName: string; publicKey: string; isInDropDown?: boolean }) => (
+  const renderAccountRow = ({
+    displayName,
+    publicKey,
+    isInDropDown = false,
+  }: {
+    displayName: string;
+    publicKey: string;
+    isInDropDown?: boolean;
+  }) => (
     <AccountWrapper isInDropDown={isInDropDown}>
       <AccountName>{displayName}</AccountName>
       <Address address={publicKey} />
@@ -100,16 +115,32 @@ const AccountsOverview = () => {
   if (!accounts || !accounts.length) {
     return null;
   }
-  const { displayName, publicKey, currentState } = accounts[currentAccountIndex];
-  const { value, unit }: any = formatSmidge(currentState ? currentState.balance : 0, true);
+  const { displayName, publicKey, currentState } = accounts[
+    currentAccountIndex
+  ];
+  const { value, unit }: any = formatSmidge(
+    currentState ? currentState.balance : 0,
+    true
+  );
 
   return (
-    <WrapperWith2SideBars width={290} height={'calc(100% - 65px)'} header={meta.displayName} isDarkMode={isDarkMode}>
+    <WrapperWith2SideBars
+      width={290}
+      height={'calc(100% - 65px)'}
+      header={meta.displayName}
+      isDarkMode={isDarkMode}
+    >
       <AccountDetails>
         {accounts.length > 1 ? (
           <DropDown
             data={accounts}
-            DdElement={({ displayName, publicKey, isMain }) => renderAccountRow({ displayName, publicKey, isInDropDown: !isMain })}
+            DdElement={({ displayName, publicKey, isMain }) =>
+              renderAccountRow({
+                displayName,
+                publicKey,
+                isInDropDown: !isMain,
+              })
+            }
             onClick={handleSetCurrentAccount}
             selectedItemIndex={currentAccountIndex}
             rowHeight={55}

--- a/app/components/wallet/TxConfirmation.tsx
+++ b/app/components/wallet/TxConfirmation.tsx
@@ -13,7 +13,8 @@ const Wrapper = styled.div`
   height: 100%;
   margin-right: 10px;
   padding: 10px 15px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const Header = styled.div`
@@ -93,7 +94,8 @@ const ComplexButtonText = styled.div`
   font-size: 13px;
   line-height: 17px;
   text-decoration: underline;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.mediumGray)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.mediumGray};
 `;
 
 type Props = {
@@ -108,13 +110,27 @@ type Props = {
   cancelTx: () => void;
 };
 
-const TxConfirmation = ({ fromAddress, address, amount, fee, note, canSend, doneAction, editTx, cancelTx }: Props) => {
+const TxConfirmation = ({
+  fromAddress,
+  address,
+  amount,
+  fee,
+  note,
+  canSend,
+  doneAction,
+  editTx,
+  cancelTx,
+}: Props) => {
   const navigateToGuide = () => window.open(ExternalLinks.SendCoinGuide);
   return (
     <Wrapper>
       <Header>
         <HeaderText>Send SMH</HeaderText>
-        <Link onClick={cancelTx} text="CANCEL TRANSACTION" style={{ color: smColors.orange }} />
+        <Link
+          onClick={cancelTx}
+          text="CANCEL TRANSACTION"
+          style={{ color: smColors.orange }}
+        />
       </Header>
       <SubHeader1>--</SubHeader1>
       <SubHeader2>SUMMARY</SubHeader2>
@@ -146,11 +162,21 @@ const TxConfirmation = ({ fromAddress, address, amount, fee, note, canSend, done
       </>
       <Footer>
         <ComplexButton>
-          <SecondaryButton onClick={editTx} img={chevronLeftWhite} imgWidth={10} imgHeight={15} />
+          <SecondaryButton
+            onClick={editTx}
+            img={chevronLeftWhite}
+            imgWidth={10}
+            imgHeight={15}
+          />
           <ComplexButtonText>EDIT TRANSACTION</ComplexButtonText>
         </ComplexButton>
         <Link onClick={navigateToGuide} text="SEND SMH GUIDE" />
-        <Button onClick={doneAction} text="SEND" style={{ marginLeft: 'auto' }} isDisabled={!canSend} />
+        <Button
+          onClick={doneAction}
+          text="SEND"
+          style={{ marginLeft: 'auto' }}
+          isDisabled={!canSend}
+        />
       </Footer>
     </Wrapper>
   );

--- a/app/components/wallet/TxParams.tsx
+++ b/app/components/wallet/TxParams.tsx
@@ -1,6 +1,13 @@
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
-import { Link, Input, DropDown, Button, ErrorPopup, AutocompleteDropdown } from '../../basicComponents';
+import {
+  Link,
+  Input,
+  DropDown,
+  Button,
+  ErrorPopup,
+  AutocompleteDropdown,
+} from '../../basicComponents';
 import { CoinUnits, getAbbreviatedText, getAddress } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { Contact } from '../../types';
@@ -14,7 +21,8 @@ const Wrapper = styled.div`
   height: 100%;
   margin-right: 10px;
   padding: 10px 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const Header = styled.div`
@@ -45,7 +53,8 @@ const DetailsRow = styled.div`
 const DetailsText = styled.div`
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const Dots = styled.div`
@@ -55,7 +64,8 @@ const Dots = styled.div`
   margin-right: 12px;
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const Fee = styled.div<{ isInDropDown: boolean }>`
@@ -64,7 +74,9 @@ const Fee = styled.div<{ isInDropDown: boolean }>`
   color: ${smColors.black};
   padding: 5px;
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -140,9 +152,21 @@ const TxParams = ({
   isDarkMode,
 }: Props) => {
   const [selectedFeeIndex, setSelectedFeeIndex] = useState(0);
-  const ddStyle = { border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`, marginLeft: 'auto', flex: '0 0 240px' };
+  const ddStyle = {
+    border: `1px solid ${isDarkMode ? smColors.white : smColors.black}`,
+    marginLeft: 'auto',
+    flex: '0 0 240px',
+  };
 
-  const renderFeeElement = ({ label, text, isInDropDown }: { label: string; text: string; isInDropDown: boolean }) => (
+  const renderFeeElement = ({
+    label,
+    text,
+    isInDropDown,
+  }: {
+    label: string;
+    text: string;
+    isInDropDown: boolean;
+  }) => (
     <Fee key={label} isInDropDown={isInDropDown}>
       {label} {text}
     </Fee>
@@ -155,13 +179,20 @@ const TxParams = ({
 
   const navigateToGuide = () => window.open(ExternalLinks.SendCoinGuide);
 
-  const handleAmountChange = useCallback((value) => updateTxAmount(parseFloat(value)), [updateTxAmount]);
+  const handleAmountChange = useCallback(
+    (value) => updateTxAmount(parseFloat(value)),
+    [updateTxAmount]
+  );
 
   return (
     <Wrapper>
       <Header>
         <HeaderText>Send SMH</HeaderText>
-        <Link onClick={cancelTx} text="CANCEL TRANSACTION" style={{ color: smColors.orange }} />
+        <Link
+          onClick={cancelTx}
+          text="CANCEL TRANSACTION"
+          style={{ color: smColors.orange }}
+        />
       </Header>
       <SubHeader>--</SubHeader>
       <DetailsRow>
@@ -179,12 +210,20 @@ const TxParams = ({
           onEnter={(value: string) => updateTxAddress({ value })}
           autofocus
         />
-        {hasAddressError && <ErrorPopup onClick={resetAddressError} text="This address is invalid." style={errorPopupStyle} />}
+        {hasAddressError && (
+          <ErrorPopup
+            onClick={resetAddressError}
+            text="This address is invalid."
+            style={errorPopupStyle}
+          />
+        )}
       </DetailsRow>
       <DetailsRow>
         <DetailsText>From</DetailsText>
         <Dots>....................................</Dots>
-        <DetailsText>{getAbbreviatedText(getAddress(fromAddress), true, 10)}</DetailsText>
+        <DetailsText>
+          {getAbbreviatedText(getAddress(fromAddress), true, 10)}
+        </DetailsText>
       </DetailsRow>
       <DetailsRow>
         <DetailsText>Amount</DetailsText>
@@ -193,10 +232,18 @@ const TxParams = ({
           value={amount}
           onChange={handleAmountChange}
           style={inputStyle}
-          selectedUnits={amount.toString().length > 10 ? CoinUnits.SMH : CoinUnits.Smidge}
+          selectedUnits={
+            amount.toString().length > 10 ? CoinUnits.SMH : CoinUnits.Smidge
+          }
           valueUnits={CoinUnits.Smidge}
         />
-        {hasAmountError && <ErrorPopup onClick={resetAmountError} text="You don't have enough Smidge in your wallet." style={errorPopupStyle1} />}
+        {hasAmountError && (
+          <ErrorPopup
+            onClick={resetAmountError}
+            text="You don't have enough Smidge in your wallet."
+            style={errorPopupStyle1}
+          />
+        )}
       </DetailsRow>
       <DetailsRow>
         <DetailsText>Fee</DetailsText>
@@ -204,7 +251,9 @@ const TxParams = ({
         <DropDown
           data={fees}
           onClick={selectFee}
-          DdElement={({ label, text, isMain }) => renderFeeElement({ label, text, isInDropDown: !isMain })}
+          DdElement={({ label, text, isMain }) =>
+            renderFeeElement({ label, text, isInDropDown: !isMain })
+          }
           selectedItemIndex={selectedFeeIndex}
           rowHeight={40}
           style={ddStyle}
@@ -214,10 +263,20 @@ const TxParams = ({
       <DetailsRow>
         <DetailsText>Note</DetailsText>
         <Dots>....................................</Dots>
-        <Input value={note} onChange={updateTxNote} maxLength="50" style={inputStyle} placeholder="Only visible to you." />
+        <Input
+          value={note}
+          onChange={updateTxNote}
+          maxLength="50"
+          style={inputStyle}
+          placeholder="Only visible to you."
+        />
       </DetailsRow>
       <Footer>
-        <Link onClick={navigateToGuide} text="SEND SMH GUIDE" style={{ marginRight: 25 }} />
+        <Link
+          onClick={navigateToGuide}
+          text="SEND SMH GUIDE"
+          style={{ marginRight: 25 }}
+        />
         <Button onClick={nextAction} text="NEXT" />
       </Footer>
     </Wrapper>

--- a/app/components/wallet/TxSent.tsx
+++ b/app/components/wallet/TxSent.tsx
@@ -16,7 +16,8 @@ const Wrapper = styled.div`
   padding: 10px 15px;
   background: url(${fireworksImg}) center center no-repeat;
   background-size: contain;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const Header = styled.div`
@@ -97,7 +98,14 @@ type Props = {
   navigateToTxList: () => void;
 };
 
-const TxSent = ({ fromAddress, address, amount, txId, doneAction, navigateToTxList }: Props) => {
+const TxSent = ({
+  fromAddress,
+  address,
+  amount,
+  txId,
+  doneAction,
+  navigateToTxList,
+}: Props) => {
   const navigateToGuide = () => window.open(ExternalLinks.SendCoinGuide);
 
   const { unit }: any = formatSmidge(amount, true);
@@ -114,7 +122,9 @@ const TxSent = ({ fromAddress, address, amount, txId, doneAction, navigateToTxLi
         </DetailsRow>
         <DetailsRow>
           <DetailsTextRight>From</DetailsTextRight>
-          <DetailsTextLeftBold>{`0x${getAddress(fromAddress)}`}</DetailsTextLeftBold>
+          <DetailsTextLeftBold>{`0x${getAddress(
+            fromAddress
+          )}`}</DetailsTextLeftBold>
         </DetailsRow>
         <DetailsRow>
           <DetailsTextRight>To</DetailsTextRight>
@@ -132,7 +142,13 @@ const TxSent = ({ fromAddress, address, amount, txId, doneAction, navigateToTxLi
       <Footer>
         <Link onClick={navigateToGuide} text="SEND SMH GUIDE" />
         <ButtonsBlock>
-          <Button onClick={navigateToTxList} text="VIEW TRANSACTION" isPrimary={false} width={170} style={{ marginRight: 20 }} />
+          <Button
+            onClick={navigateToTxList}
+            text="VIEW TRANSACTION"
+            isPrimary={false}
+            width={170}
+            style={{ marginRight: 20 }}
+          />
           <Button onClick={doneAction} text="DONE" />
         </ButtonsBlock>
       </Footer>

--- a/app/components/wallet/TxSummary.tsx
+++ b/app/components/wallet/TxSummary.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
-import { getAbbreviatedText, getAddress, formatSmidge } from '../../infra/utils';
+import {
+  getAbbreviatedText,
+  getAddress,
+  formatSmidge,
+} from '../../infra/utils';
 import { smColors } from '../../vars';
 
 const Wrapper = styled.div`
@@ -9,7 +13,8 @@ const Wrapper = styled.div`
   width: 175px;
   height: 100%;
   padding: 10px 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const Header = styled.div`

--- a/app/globalStyle.ts
+++ b/app/globalStyle.ts
@@ -21,7 +21,8 @@ const GlobalStyle = createGlobalStyle<{ theme: { isDarkMode: boolean } }>`
         height: 100%;
         margin: 0;
         padding: 0;
-        background-color: ${({ theme }) => (theme.isDarkMode ? smColors.black : smColors.background)};
+        background-color: ${({ theme }) =>
+          theme.isDarkMode ? smColors.black : smColors.background};
     }
     
     html, body, div, span, applet, object, iframe,

--- a/app/infra/eventsService/eventsService.ts
+++ b/app/infra/eventsService/eventsService.ts
@@ -2,7 +2,11 @@ import { ipcRenderer } from 'electron';
 import { ProgressInfo, UpdateInfo } from 'electron-updater';
 
 import { ipcConsts } from '../../vars';
-import { setNodeError, setNodeStatus, setVersionAndBuild } from '../../redux/node/actions';
+import {
+  setNodeError,
+  setNodeStatus,
+  setVersionAndBuild,
+} from '../../redux/node/actions';
 import { setTransactions, updateAccountData } from '../../redux/wallet/actions';
 import {
   SET_ACCOUNT_REWARDS,
@@ -33,7 +37,11 @@ import { showClosingAppModal } from '../../redux/ui/actions';
 import { LOCAL_NODE_API_URL } from '../../../shared/constants';
 import TransactionManager from '../../../desktop/TransactionManager';
 import updaterSlice from '../../redux/updater/slice';
-import { CurrentLayer, GlobalStateHash, NetworkDefinitions } from '../../types/events';
+import {
+  CurrentLayer,
+  GlobalStateHash,
+  NetworkDefinitions,
+} from '../../types/events';
 
 class EventsService {
   static createWallet = ({
@@ -57,45 +65,101 @@ class EventsService {
       netId,
     });
 
-  static readWalletFiles = () => ipcRenderer.invoke(ipcConsts.READ_WALLET_FILES);
+  static readWalletFiles = () =>
+    ipcRenderer.invoke(ipcConsts.READ_WALLET_FILES);
 
-  static getOsThemeColor = () => ipcRenderer.invoke(ipcConsts.GET_OS_THEME_COLOR);
+  static getOsThemeColor = () =>
+    ipcRenderer.invoke(ipcConsts.GET_OS_THEME_COLOR);
 
   static openBrowserView = () => ipcRenderer.send(ipcConsts.OPEN_BROWSER_VIEW);
 
-  static updateBrowserViewTheme = ({ isDarkMode }: { isDarkMode: boolean }) => ipcRenderer.send(ipcConsts.SEND_THEME_COLOR, { isDarkMode });
+  static updateBrowserViewTheme = ({ isDarkMode }: { isDarkMode: boolean }) =>
+    ipcRenderer.send(ipcConsts.SEND_THEME_COLOR, { isDarkMode });
 
-  static destroyBrowserView = () => ipcRenderer.send(ipcConsts.DESTROY_BROWSER_VIEW);
+  static destroyBrowserView = () =>
+    ipcRenderer.send(ipcConsts.DESTROY_BROWSER_VIEW);
 
-  static listNetworks = (): Promise<{ netId: number; netName: string; explorer: string }[]> => ipcRenderer.invoke(ipcConsts.LIST_NETWORKS);
+  static listNetworks = (): Promise<
+    { netId: number; netName: string; explorer: string }[]
+  > => ipcRenderer.invoke(ipcConsts.LIST_NETWORKS);
 
-  static listPublicServices = (): Promise<PublicService[]> => ipcRenderer.invoke(ipcConsts.LIST_PUBLIC_SERVICES);
+  static listPublicServices = (): Promise<PublicService[]> =>
+    ipcRenderer.invoke(ipcConsts.LIST_PUBLIC_SERVICES);
 
-  static unlockWallet = ({ path, password }: { path: string; password: string }) => ipcRenderer.invoke(ipcConsts.W_M_UNLOCK_WALLET, { path, password });
+  static unlockWallet = ({
+    path,
+    password,
+  }: {
+    path: string;
+    password: string;
+  }) => ipcRenderer.invoke(ipcConsts.W_M_UNLOCK_WALLET, { path, password });
 
-  static updateWalletMeta = <T extends keyof WalletMeta>(fileName: string, key: T, value: WalletMeta[T]) =>
-    ipcRenderer.send(ipcConsts.W_M_UPDATE_WALLET_META, { fileName, key, value });
+  static updateWalletMeta = <T extends keyof WalletMeta>(
+    fileName: string,
+    key: T,
+    value: WalletMeta[T]
+  ) =>
+    ipcRenderer.send(ipcConsts.W_M_UPDATE_WALLET_META, {
+      fileName,
+      key,
+      value,
+    });
 
-  static updateWalletSecrets = (fileName: string, password: string, data: WalletSecrets) => ipcRenderer.send(ipcConsts.W_M_UPDATE_WALLET_SECRETS, { fileName, password, data });
+  static updateWalletSecrets = (
+    fileName: string,
+    password: string,
+    data: WalletSecrets
+  ) =>
+    ipcRenderer.send(ipcConsts.W_M_UPDATE_WALLET_SECRETS, {
+      fileName,
+      password,
+      data,
+    });
 
-  static createNewAccount = ({ fileName, password }: { fileName: string; password: string }) => ipcRenderer.invoke(ipcConsts.W_M_CREATE_NEW_ACCOUNT, { fileName, password });
+  static createNewAccount = ({
+    fileName,
+    password,
+  }: {
+    fileName: string;
+    password: string;
+  }) =>
+    ipcRenderer.invoke(ipcConsts.W_M_CREATE_NEW_ACCOUNT, {
+      fileName,
+      password,
+    });
 
-  static backupWallet = (filePath: string) => ipcRenderer.invoke(ipcConsts.W_M_BACKUP_WALLET, filePath);
+  static backupWallet = (filePath: string) =>
+    ipcRenderer.invoke(ipcConsts.W_M_BACKUP_WALLET, filePath);
 
-  static addWalletPath = (filePath: string) => ipcRenderer.invoke(ipcConsts.W_M_ADD_WALLET_PATH, filePath);
+  static addWalletPath = (filePath: string) =>
+    ipcRenderer.invoke(ipcConsts.W_M_ADD_WALLET_PATH, filePath);
 
-  static showFileInFolder = ({ filePath, isLogFile }: { filePath?: string; isLogFile?: boolean }) => ipcRenderer.send(ipcConsts.W_M_SHOW_FILE_IN_FOLDER, { filePath, isLogFile });
+  static showFileInFolder = ({
+    filePath,
+    isLogFile,
+  }: {
+    filePath?: string;
+    isLogFile?: boolean;
+  }) =>
+    ipcRenderer.send(ipcConsts.W_M_SHOW_FILE_IN_FOLDER, {
+      filePath,
+      isLogFile,
+    });
 
-  static deleteWalletFile = (filepath: string) => ipcRenderer.send(ipcConsts.W_M_SHOW_DELETE_FILE, filepath);
+  static deleteWalletFile = (filepath: string) =>
+    ipcRenderer.send(ipcConsts.W_M_SHOW_DELETE_FILE, filepath);
 
   static wipeOut = () => ipcRenderer.send(ipcConsts.W_M_WIPE_OUT);
 
   /** ************************************   SMESHER   ****************************************** */
-  static selectPostFolder = () => ipcRenderer.invoke(ipcConsts.SMESHER_SELECT_POST_FOLDER);
+  static selectPostFolder = () =>
+    ipcRenderer.invoke(ipcConsts.SMESHER_SELECT_POST_FOLDER);
 
-  static checkFreeSpace = ({ dataDir }: { dataDir: string }) => ipcRenderer.invoke(ipcConsts.SMESHER_CHECK_FREE_SPACE, { dataDir });
+  static checkFreeSpace = ({ dataDir }: { dataDir: string }) =>
+    ipcRenderer.invoke(ipcConsts.SMESHER_CHECK_FREE_SPACE, { dataDir });
 
-  static getEstimatedRewards = () => ipcRenderer.invoke(ipcConsts.SMESHER_GET_ESTIMATED_REWARDS);
+  static getEstimatedRewards = () =>
+    ipcRenderer.invoke(ipcConsts.SMESHER_GET_ESTIMATED_REWARDS);
 
   static startSmeshing = async (postSetupOpts: PostSetupOpts) => {
     await ipcRenderer.invoke(ipcConsts.SWITCH_API_PROVIDER, LOCAL_NODE_API_URL);
@@ -103,18 +167,35 @@ class EventsService {
     ipcRenderer.invoke(ipcConsts.SMESHER_START_SMESHING, { postSetupOpts });
   };
 
-  static stopSmeshing = ({ deleteFiles }: { deleteFiles: boolean }) => ipcRenderer.invoke(ipcConsts.SMESHER_STOP_SMESHING, { deleteFiles });
+  static stopSmeshing = ({ deleteFiles }: { deleteFiles: boolean }) =>
+    ipcRenderer.invoke(ipcConsts.SMESHER_STOP_SMESHING, { deleteFiles });
 
   /** **********************************   TRANSACTIONS   ************************************** */
 
-  static sendTx = ({ fullTx, accountIndex }: { fullTx: TxSendRequest; accountIndex: number }): Promise<ReturnType<TransactionManager['sendTx']>> =>
+  static sendTx = ({
+    fullTx,
+    accountIndex,
+  }: {
+    fullTx: TxSendRequest;
+    accountIndex: number;
+  }): Promise<ReturnType<TransactionManager['sendTx']>> =>
     ipcRenderer.invoke(ipcConsts.W_M_SEND_TX, { fullTx, accountIndex });
 
-  static updateTransactionNote = (accountIndex: number, txId: HexString, note: string) => ipcRenderer.invoke(ipcConsts.W_M_UPDATE_TX_NOTE, { accountIndex, txId, note });
+  static updateTransactionNote = (
+    accountIndex: number,
+    txId: HexString,
+    note: string
+  ) =>
+    ipcRenderer.invoke(ipcConsts.W_M_UPDATE_TX_NOTE, {
+      accountIndex,
+      txId,
+      note,
+    });
 
   /** ************************************   AUTOSTART   ************************************** */
 
-  static isAutoStartEnabled = () => ipcRenderer.invoke(ipcConsts.IS_AUTO_START_ENABLED_REQUEST);
+  static isAutoStartEnabled = () =>
+    ipcRenderer.invoke(ipcConsts.IS_AUTO_START_ENABLED_REQUEST);
 
   static toggleAutoStart = () => ipcRenderer.send(ipcConsts.TOGGLE_AUTO_START);
 
@@ -122,31 +203,47 @@ class EventsService {
 
   static reloadApp = () => ipcRenderer.send(ipcConsts.RELOAD_APP);
 
-  static print = ({ content }: { content: string }) => ipcRenderer.send(ipcConsts.PRINT, { content });
+  static print = ({ content }: { content: string }) =>
+    ipcRenderer.send(ipcConsts.PRINT, { content });
 
-  static signMessage = ({ message, accountIndex }: { message: string; accountIndex: number }) => ipcRenderer.invoke(ipcConsts.W_M_SIGN_MESSAGE, { message, accountIndex });
+  static signMessage = ({
+    message,
+    accountIndex,
+  }: {
+    message: string;
+    accountIndex: number;
+  }) =>
+    ipcRenderer.invoke(ipcConsts.W_M_SIGN_MESSAGE, { message, accountIndex });
 
-  static switchNetwork = (netId: number) => ipcRenderer.invoke(ipcConsts.SWITCH_NETWORK, netId);
+  static switchNetwork = (netId: number) =>
+    ipcRenderer.invoke(ipcConsts.SWITCH_NETWORK, netId);
 
-  static switchApiProvider = (apiUrl: SocketAddress | null) => ipcRenderer.invoke(ipcConsts.SWITCH_API_PROVIDER, apiUrl);
+  static switchApiProvider = (apiUrl: SocketAddress | null) =>
+    ipcRenderer.invoke(ipcConsts.SWITCH_API_PROVIDER, apiUrl);
 
   /** **************************************  WALLET MANAGER  **************************************** */
 
-  static getNetworkDefinitions = (): Promise<NetworkDefinitions> => ipcRenderer.invoke(ipcConsts.W_M_GET_NETWORK_DEFINITIONS);
+  static getNetworkDefinitions = (): Promise<NetworkDefinitions> =>
+    ipcRenderer.invoke(ipcConsts.W_M_GET_NETWORK_DEFINITIONS);
 
-  static getCurrentLayer = (): Promise<CurrentLayer> => ipcRenderer.invoke(ipcConsts.W_M_GET_CURRENT_LAYER);
+  static getCurrentLayer = (): Promise<CurrentLayer> =>
+    ipcRenderer.invoke(ipcConsts.W_M_GET_CURRENT_LAYER);
 
-  static getGlobalStateHash = (): Promise<GlobalStateHash> => ipcRenderer.invoke(ipcConsts.W_M_GET_GLOBAL_STATE_HASH);
+  static getGlobalStateHash = (): Promise<GlobalStateHash> =>
+    ipcRenderer.invoke(ipcConsts.W_M_GET_GLOBAL_STATE_HASH);
 
   /** **************************************  NODE MANAGER  **************************************** */
 
   static restartNode = () => ipcRenderer.invoke(ipcConsts.N_M_RESTART_NODE);
 
-  static requestVersionAndBuild = () => ipcRenderer.send(ipcConsts.N_M_GET_VERSION_AND_BUILD);
+  static requestVersionAndBuild = () =>
+    ipcRenderer.send(ipcConsts.N_M_GET_VERSION_AND_BUILD);
 
-  static setPort = ({ port }: { port: string }) => ipcRenderer.send(ipcConsts.SET_NODE_PORT, { port });
+  static setPort = ({ port }: { port: string }) =>
+    ipcRenderer.send(ipcConsts.SET_NODE_PORT, { port });
 
-  static changeDataDir = () => ipcRenderer.invoke(ipcConsts.PROMPT_CHANGE_DATADIR);
+  static changeDataDir = () =>
+    ipcRenderer.invoke(ipcConsts.PROMPT_CHANGE_DATADIR);
 
   /** **************************************  AUTO UPDATER  **************************************** */
   static downloadUpdate = () => ipcRenderer.send(ipcConsts.AU_REQUEST_DOWNLOAD);
@@ -161,53 +258,81 @@ ipcRenderer.on(ipcConsts.N_M_SET_NODE_ERROR, (_event, error: NodeError) => {
   store.dispatch(setNodeError(error));
 });
 
-ipcRenderer.on(ipcConsts.N_M_GET_VERSION_AND_BUILD, (_event, payload: NodeVersionAndBuild) => {
-  store.dispatch(setVersionAndBuild(payload));
-});
+ipcRenderer.on(
+  ipcConsts.N_M_GET_VERSION_AND_BUILD,
+  (_event, payload: NodeVersionAndBuild) => {
+    store.dispatch(setVersionAndBuild(payload));
+  }
+);
 
 ipcRenderer.on(ipcConsts.T_M_UPDATE_ACCOUNT, (_event, request) => {
-  store.dispatch(updateAccountData({ account: request.account, accountId: request.accountId }));
+  store.dispatch(
+    updateAccountData({
+      account: request.account,
+      accountId: request.accountId,
+    })
+  );
 });
 
 ipcRenderer.on(ipcConsts.T_M_UPDATE_TXS, (_event, request) => {
-  store.dispatch(setTransactions({ txs: request.txs, publicKey: request.publicKey }));
+  store.dispatch(
+    setTransactions({ txs: request.txs, publicKey: request.publicKey })
+  );
 });
 
 ipcRenderer.on(ipcConsts.T_M_UPDATE_REWARDS, (_event, request) => {
   const { rewards, publicKey } = request;
-  store.dispatch({ type: SET_ACCOUNT_REWARDS, payload: { rewards, publicKey } });
-});
-
-ipcRenderer.on(ipcConsts.SMESHER_SET_SETTINGS_AND_STARTUP_STATUS, (_event, request: IPCSmesherStartupData) => {
   store.dispatch({
-    type: SET_SMESHER_SETTINGS_AND_STARTUP_STATUS,
-    payload: request,
+    type: SET_ACCOUNT_REWARDS,
+    payload: { rewards, publicKey },
   });
 });
+
+ipcRenderer.on(
+  ipcConsts.SMESHER_SET_SETTINGS_AND_STARTUP_STATUS,
+  (_event, request: IPCSmesherStartupData) => {
+    store.dispatch({
+      type: SET_SMESHER_SETTINGS_AND_STARTUP_STATUS,
+      payload: request,
+    });
+  }
+);
 
 ipcRenderer.on(ipcConsts.SMESHER_SEND_SMESHING_CONFIG, (_event, request) => {
   const { smeshingConfig } = request;
   store.dispatch({ type: SET_SMESHER_CONFIG, payload: { smeshingConfig } });
 });
 
-ipcRenderer.on(ipcConsts.SMESHER_SET_SETUP_COMPUTE_PROVIDERS, (_event, request) => {
-  const { providers } = request;
-  store.dispatch({
-    type: SET_SETUP_COMPUTE_PROVIDERS,
-    payload: providers,
-  });
-});
-
-ipcRenderer.on(ipcConsts.SMESHER_POST_DATA_CREATION_PROGRESS, (_event, request) => {
-  const {
-    error,
-    status: { postSetupState, numLabelsWritten, errorMessage },
-  } = request;
-  if (postSetupState === PostSetupState.STATE_COMPLETE) {
-    localStorage.setItem('smesherSmeshingTimestamp', `${new Date().getTime()}`);
+ipcRenderer.on(
+  ipcConsts.SMESHER_SET_SETUP_COMPUTE_PROVIDERS,
+  (_event, request) => {
+    const { providers } = request;
+    store.dispatch({
+      type: SET_SETUP_COMPUTE_PROVIDERS,
+      payload: providers,
+    });
   }
-  store.dispatch({ type: SET_POST_DATA_CREATION_STATUS, payload: { error, postSetupState, numLabelsWritten, errorMessage } });
-});
+);
+
+ipcRenderer.on(
+  ipcConsts.SMESHER_POST_DATA_CREATION_PROGRESS,
+  (_event, request) => {
+    const {
+      error,
+      status: { postSetupState, numLabelsWritten, errorMessage },
+    } = request;
+    if (postSetupState === PostSetupState.STATE_COMPLETE) {
+      localStorage.setItem(
+        'smesherSmeshingTimestamp',
+        `${new Date().getTime()}`
+      );
+    }
+    store.dispatch({
+      type: SET_POST_DATA_CREATION_STATUS,
+      payload: { error, postSetupState, numLabelsWritten, errorMessage },
+    });
+  }
+);
 
 ipcRenderer.on(ipcConsts.AU_AVAILABLE, (_, info: UpdateInfo) => {
   store.dispatch(updaterSlice.actions.updateAvailable(info));

--- a/app/infra/lastSelectedWalletPath.ts
+++ b/app/infra/lastSelectedWalletPath.ts
@@ -1,10 +1,14 @@
 export const LAST_SELECTED_WALLET_PATH_KEY = 'lastSelectedWalletPath';
 
-export const setLastSelectedWalletPath = (walletPath: string) => window.localStorage.setItem(LAST_SELECTED_WALLET_PATH_KEY, walletPath);
+export const setLastSelectedWalletPath = (walletPath: string) =>
+  window.localStorage.setItem(LAST_SELECTED_WALLET_PATH_KEY, walletPath);
 
-export const getLastSelectedWalletPath = () => window.localStorage.getItem(LAST_SELECTED_WALLET_PATH_KEY);
+export const getLastSelectedWalletPath = () =>
+  window.localStorage.getItem(LAST_SELECTED_WALLET_PATH_KEY);
 
-export const getIndexOfLastSelectedWalletPath = (walletFiles: { path: string }[]) => {
+export const getIndexOfLastSelectedWalletPath = (
+  walletFiles: { path: string }[]
+) => {
   if (!(walletFiles instanceof Array)) return 0;
 
   const last = getLastSelectedWalletPath();

--- a/app/infra/utils.ts
+++ b/app/infra/utils.ts
@@ -9,27 +9,44 @@ export const has0x = (addr: string) => addr.indexOf('0x') === 0;
 export const ensure0x = (addr: string) => (!has0x(addr) ? `0x${addr}` : addr);
 export const trim0x = (addr: string) => (has0x(addr) ? addr.substr(2) : addr);
 
-export const getAbbreviatedText = (address: string, addPrefix = true, tailSize = 4) => {
+export const getAbbreviatedText = (
+  address: string,
+  addPrefix = true,
+  tailSize = 4
+) => {
   const hexOnly = trim0x(address);
-  const abbr = `${hexOnly.substr(0, tailSize)}...${hexOnly.substr(-tailSize)}`.toUpperCase();
+  const abbr = `${hexOnly.substr(0, tailSize)}...${hexOnly.substr(
+    -tailSize
+  )}`.toUpperCase();
   return addPrefix ? ensure0x(abbr) : abbr;
 };
 
 export const getFormattedTimestamp = (timestamp: number | null): string => {
   if (timestamp) {
-    const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' };
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    };
     const dateObj = new Date(timestamp);
     return dateObj.toLocaleDateString('en-US', options).replace(',', '');
   }
   return 'Pending';
 };
 
-export const getAddress = (key: string) => (key.length <= 44 ? key : key.substring(24));
+export const getAddress = (key: string) =>
+  key.length <= 44 ? key : key.substring(24);
 
 // Address can start with `0x` or without
 // By default it checks the account address, length = 40
 // To validate tx / smesher address, set length to 64
-export const validateAddress = (address: string, length = 40): address is HexString => {
+export const validateAddress = (
+  address: string,
+  length = 40
+): address is HexString => {
   const r = new RegExp(`^(0x)?[a-f0-9]{${length}}$`, 'i').test(address);
   return r;
 };
@@ -47,7 +64,8 @@ export const formatBytes = (bytes: number) => {
   return `${parseFloat((bytes / 1073741824).toFixed(2))} GB`;
 };
 
-export const formatWithCommas = (x: number) => x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+export const formatWithCommas = (x: number) =>
+  x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
 // -------------------
 // Units
@@ -72,16 +90,23 @@ export const getValueAndUnit = (amount: number) => {
   // Show `23.053 SMH` for big amount
   if (amount >= 10 ** 9) return packValueAndUnit(toSMH(amount), CoinUnits.SMH);
   // Or `6739412 Smidge` (without dot) for small amount
-  else if (!Number.isNaN(amount)) return packValueAndUnit(amount, CoinUnits.Smidge);
+  else if (!Number.isNaN(amount))
+    return packValueAndUnit(amount, CoinUnits.Smidge);
   // Show `0 SMH` for zero amount and NaN
   else return packValueAndUnit(0, CoinUnits.SMH);
 };
 
 // Returns formatted display string for a smidge amount.
 // All coin displayed in the app should display amount formatted
-export const formatSmidge = (amount: number, separateResult?: boolean): string | { value: string; unit: string } => {
+export const formatSmidge = (
+  amount: number,
+  separateResult?: boolean
+): string | { value: string; unit: string } => {
   const res = getValueAndUnit(amount);
-  return separateResult ? { value: res.value, unit: res.unit } : `${res.value} ${res.unit}`;
+  return separateResult
+    ? { value: res.value, unit: res.unit }
+    : `${res.value} ${res.unit}`;
 };
 
-export const constrain = (min: number, max: number, value: number) => Math.min(Math.max(value, min), max);
+export const constrain = (min: number, max: number, value: number) =>
+  Math.min(Math.max(value, min), max);

--- a/app/redux/createIpcAction.ts
+++ b/app/redux/createIpcAction.ts
@@ -1,11 +1,21 @@
-import { ActionReducerMapBuilder, AsyncThunk, AsyncThunkPayloadCreator, createAsyncThunk } from '@reduxjs/toolkit';
+import {
+  ActionReducerMapBuilder,
+  AsyncThunk,
+  AsyncThunkPayloadCreator,
+  createAsyncThunk,
+} from '@reduxjs/toolkit';
 
 type EmptyObject = Record<string, never>;
 type ActionFn<T> = AsyncThunk<T, void, EmptyObject>;
-type BuildFn<T> = (builder: ActionReducerMapBuilder<T>) => ActionReducerMapBuilder<T>;
+type BuildFn<T> = (
+  builder: ActionReducerMapBuilder<T>
+) => ActionReducerMapBuilder<T>;
 
 const DEFAULT_IPC_REDUCERS = {
-  onFulfilled: <S, T extends Partial<S>>(state: S, action: { type: string; payload: T }) => ({ ...state, ...action.payload }),
+  onFulfilled: <S, T extends Partial<S>>(
+    state: S,
+    action: { type: string; payload: T }
+  ) => ({ ...state, ...action.payload }),
   onPending: <S>(state: S): S => state,
   onRejected: <S, T extends Record<string, any>>(state: S, action: T): S => {
     // eslint-disable-next-line no-console
@@ -20,7 +30,11 @@ const createIpcAction = <T>(
   { onFulfilled, onRejected, onPending } = DEFAULT_IPC_REDUCERS
 ): [ActionFn<T>, BuildFn<T>] => {
   const action = createAsyncThunk(typePrefix, payloadCreator);
-  const build: BuildFn<T> = (builder) => builder.addCase(action.fulfilled, onFulfilled).addCase(action.rejected, onRejected).addCase(action.pending, onPending);
+  const build: BuildFn<T> = (builder) =>
+    builder
+      .addCase(action.fulfilled, onFulfilled)
+      .addCase(action.rejected, onRejected)
+      .addCase(action.pending, onPending);
   return [action, build];
 };
 

--- a/app/redux/errorHandlerMiddleware.ts
+++ b/app/redux/errorHandlerMiddleware.ts
@@ -1,6 +1,8 @@
 import { AnyAction, Middleware } from 'redux';
 
-const createErrorHandlerMiddleware = (onError: (error: Error) => AnyAction): Middleware => () => (next) => (action) => {
+const createErrorHandlerMiddleware = (
+  onError: (error: Error) => AnyAction
+): Middleware => () => (next) => (action) => {
   try {
     const result = next(action);
     if (result?.then && result?.catch) {

--- a/app/redux/ipcSync.ts
+++ b/app/redux/ipcSync.ts
@@ -2,14 +2,20 @@ import { ipcRenderer } from 'electron';
 import { AnyAction, Store } from 'redux';
 
 export const IPC_SYNC_TYPE = 'IPC_SYNC_STORE';
-const getAction = (channel, payload) => ({ type: IPC_SYNC_TYPE, payload, meta: { channel } });
+const getAction = (channel, payload) => ({
+  type: IPC_SYNC_TYPE,
+  payload,
+  meta: { channel },
+});
 
 const IpcSyncRenderer = (store: Store) => {
-  const dispatchAction = (_, payload, channel) => store.dispatch(getAction(channel, payload));
+  const dispatchAction = (_, payload, channel) =>
+    store.dispatch(getAction(channel, payload));
   ipcRenderer.on(IPC_SYNC_TYPE, dispatchAction);
   return () => ipcRenderer.off(IPC_SYNC_TYPE, dispatchAction);
 };
 
-export const isMySyncChannel = (channel: string, action: AnyAction) => action?.meta?.channel === channel;
+export const isMySyncChannel = (channel: string, action: AnyAction) =>
+  action?.meta?.channel === channel;
 
 export default IpcSyncRenderer;

--- a/app/redux/network/actions.ts
+++ b/app/redux/network/actions.ts
@@ -1,11 +1,22 @@
 import { eventsService } from '../../infra/eventsService';
 import createIpcAction from '../createIpcAction';
 
-export const [getNetworkDefinitions, attachNetworkDefinitions] = createIpcAction('network/getNetworkDefinitions', eventsService.getNetworkDefinitions);
-export const [getCurrentLayer, attachCurrentLayer] = createIpcAction('network/getCurrentLayer', eventsService.getCurrentLayer);
-export const [getGlobalStateHash, attachGlobalStateHash] = createIpcAction('network/getGlobalStateHash', () =>
-  eventsService
-    .getGlobalStateHash()
-    .then(({ rootHash }) => ({ rootHash: rootHash || '' }))
-    .catch(() => ({ rootHash: '' }))
+export const [
+  getNetworkDefinitions,
+  attachNetworkDefinitions,
+] = createIpcAction(
+  'network/getNetworkDefinitions',
+  eventsService.getNetworkDefinitions
+);
+export const [getCurrentLayer, attachCurrentLayer] = createIpcAction(
+  'network/getCurrentLayer',
+  eventsService.getCurrentLayer
+);
+export const [getGlobalStateHash, attachGlobalStateHash] = createIpcAction(
+  'network/getGlobalStateHash',
+  () =>
+    eventsService
+      .getGlobalStateHash()
+      .then(({ rootHash }) => ({ rootHash: rootHash || '' }))
+      .catch(() => ({ rootHash: '' }))
 );

--- a/app/redux/network/selectors.ts
+++ b/app/redux/network/selectors.ts
@@ -2,6 +2,7 @@ import { RootState } from '../../types';
 
 export const getNetworkInfo = (state: RootState) => state.network;
 
-export const getNetworkName = (state: RootState) => getNetworkInfo(state).netName;
+export const getNetworkName = (state: RootState) =>
+  getNetworkInfo(state).netName;
 
 export const getNetworkId = (state: RootState) => getNetworkInfo(state).netId;

--- a/app/redux/network/slice.ts
+++ b/app/redux/network/slice.ts
@@ -1,7 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
 import * as R from 'ramda';
 import { NetworkState } from '../../types';
-import { attachCurrentLayer, attachGlobalStateHash, attachNetworkDefinitions } from './actions';
+import {
+  attachCurrentLayer,
+  attachGlobalStateHash,
+  attachNetworkDefinitions,
+} from './actions';
 
 const initialState: NetworkState = {
   netId: '',
@@ -17,7 +21,11 @@ const slice = createSlice({
   name: 'network',
   initialState,
   reducers: {},
-  extraReducers: R.compose(attachNetworkDefinitions, attachCurrentLayer, attachGlobalStateHash),
+  extraReducers: R.compose(
+    attachNetworkDefinitions,
+    attachCurrentLayer,
+    attachGlobalStateHash
+  ),
 });
 
 export default slice;

--- a/app/redux/node/actions.ts
+++ b/app/redux/node/actions.ts
@@ -1,11 +1,24 @@
-import { NodeError, NodeStatus, NodeVersionAndBuild } from '../../../shared/types';
+import {
+  NodeError,
+  NodeStatus,
+  NodeVersionAndBuild,
+} from '../../../shared/types';
 
 export const SET_NODE_VERSION_AND_BUILD = 'SET_NODE_VERSION_AND_BUILD';
 export const SET_NODE_STATUS = 'SET_NODE_STATUS';
 export const SET_NODE_ERROR = 'SET_NODE_ERROR';
 
-export const setNodeStatus = (status: NodeStatus) => ({ type: SET_NODE_STATUS, payload: status });
+export const setNodeStatus = (status: NodeStatus) => ({
+  type: SET_NODE_STATUS,
+  payload: status,
+});
 
-export const setNodeError = (error: NodeError) => ({ type: SET_NODE_ERROR, payload: error });
+export const setNodeError = (error: NodeError) => ({
+  type: SET_NODE_ERROR,
+  payload: error,
+});
 
-export const setVersionAndBuild = (payload: NodeVersionAndBuild) => ({ type: SET_NODE_VERSION_AND_BUILD, payload });
+export const setVersionAndBuild = (payload: NodeVersionAndBuild) => ({
+  type: SET_NODE_VERSION_AND_BUILD,
+  payload,
+});

--- a/app/redux/node/reducer.ts
+++ b/app/redux/node/reducer.ts
@@ -1,7 +1,11 @@
 import type { NodeState, CustomAction } from '../../types';
 import { LOGOUT } from '../auth/actions';
 import { IPC_SYNC_TYPE, isMySyncChannel } from '../ipcSync';
-import { SET_NODE_ERROR, SET_NODE_STATUS, SET_NODE_VERSION_AND_BUILD } from './actions';
+import {
+  SET_NODE_ERROR,
+  SET_NODE_STATUS,
+  SET_NODE_VERSION_AND_BUILD,
+} from './actions';
 
 const initialState = {
   status: null,
@@ -37,7 +41,11 @@ const reducer = (state: NodeState = initialState, action: CustomAction) => {
     case IPC_SYNC_TYPE: {
       if (!isMySyncChannel('config', action)) return state;
       const { payload } = action;
-      return { ...state, dataPath: payload.node.dataPath, port: payload.node.port };
+      return {
+        ...state,
+        dataPath: payload.node.dataPath,
+        port: payload.node.port,
+      };
     }
     default:
       return state;

--- a/app/redux/smesher/actions.ts
+++ b/app/redux/smesher/actions.ts
@@ -3,9 +3,14 @@ import { AppThDispatch, GetState } from '../../types';
 import { SmeshingOpts } from '../../../shared/types';
 import { addErrorPrefix } from '../../infra/utils';
 import { setUiError } from '../ui/actions';
-import { getSmeshingOpts, isSmeshingPaused, isValidSmeshingOpts } from './selectors';
+import {
+  getSmeshingOpts,
+  isSmeshingPaused,
+  isValidSmeshingOpts,
+} from './selectors';
 
-export const SET_SMESHER_SETTINGS_AND_STARTUP_STATUS = 'SET_SMESHER_SETTINGS_AND_STARTUP_STATUS';
+export const SET_SMESHER_SETTINGS_AND_STARTUP_STATUS =
+  'SET_SMESHER_SETTINGS_AND_STARTUP_STATUS';
 export const SET_SETUP_COMPUTE_PROVIDERS = 'SET_SETUP_COMPUTE_PROVIDERS';
 export const SET_SMESHER_CONFIG = 'SET_SMESHER_CONFIG';
 export const STARTED_SMESHING = 'STARTED_SMESHING';
@@ -15,16 +20,34 @@ export const RESUMED_SMESHING = 'RESUMED_SMESHING';
 export const SET_POST_DATA_CREATION_STATUS = 'SET_POST_DATA_CREATION_STATUS';
 export const SET_ACCOUNT_REWARDS = 'SET_ACCOUNT_REWARDS';
 
-export const startSmeshing = ({ coinbase, dataDir, numUnits, provider, throttle }: SmeshingOpts) => async (dispatch: AppThDispatch) => {
+export const startSmeshing = ({
+  coinbase,
+  dataDir,
+  numUnits,
+  provider,
+  throttle,
+}: SmeshingOpts) => async (dispatch: AppThDispatch) => {
   try {
     // TODO: Replace hardcoded `numFiles: 1` with something reasonable?
-    await eventsService.startSmeshing({ coinbase, dataDir, numUnits, numFiles: 1, computeProviderId: provider, throttle });
+    await eventsService.startSmeshing({
+      coinbase,
+      dataDir,
+      numUnits,
+      numFiles: 1,
+      computeProviderId: provider,
+      throttle,
+    });
     localStorage.setItem('smesherInitTimestamp', `${new Date().getTime()}`);
     localStorage.removeItem('smesherSmeshingTimestamp');
-    dispatch({ type: STARTED_SMESHING, payload: { coinbase, dataDir, numUnits, provider, throttle } });
+    dispatch({
+      type: STARTED_SMESHING,
+      payload: { coinbase, dataDir, numUnits, provider, throttle },
+    });
     return true;
   } catch (error) {
-    dispatch(setUiError(addErrorPrefix('Error initiating smeshing\n', error as Error)));
+    dispatch(
+      setUiError(addErrorPrefix('Error initiating smeshing\n', error as Error))
+    );
     return false;
   }
 };
@@ -47,9 +70,14 @@ export const pauseSmeshing = () => async (dispatch: AppThDispatch) => {
   dispatch({ type: PAUSED_SMESHING });
 };
 
-export const resumeSmeshing = () => async (dispatch: AppThDispatch, getState: GetState) => {
+export const resumeSmeshing = () => async (
+  dispatch: AppThDispatch,
+  getState: GetState
+) => {
   const state = getState();
   const isPaused = isSmeshingPaused(state);
   const smeshingOpts = getSmeshingOpts(state);
-  return isPaused && isValidSmeshingOpts(smeshingOpts) ? dispatch(startSmeshing(smeshingOpts)) : false;
+  return isPaused && isValidSmeshingOpts(smeshingOpts)
+    ? dispatch(startSmeshing(smeshingOpts))
+    : false;
 };

--- a/app/redux/smesher/reducer.ts
+++ b/app/redux/smesher/reducer.ts
@@ -1,6 +1,10 @@
 import { CustomAction, SmesherState } from '../../types/redux';
 import { LOGOUT } from '../auth/actions';
-import { PostSetupComputeProvider, PostSetupState, SmesherConfig } from '../../../shared/types';
+import {
+  PostSetupComputeProvider,
+  PostSetupState,
+  SmesherConfig,
+} from '../../../shared/types';
 import { BITS } from '../../types';
 import {
   SET_SMESHER_SETTINGS_AND_STARTUP_STATUS,
@@ -34,10 +38,19 @@ const reducer = (state: SmesherState = initialState, action: CustomAction) => {
   switch (action.type) {
     case SET_SMESHER_SETTINGS_AND_STARTUP_STATUS: {
       const {
-        payload: { config, smesherId, postSetupState, numLabelsWritten, errorMessage, numUnits },
+        payload: {
+          config,
+          smesherId,
+          postSetupState,
+          numLabelsWritten,
+          errorMessage,
+          numUnits,
+        },
       } = action;
 
-      const commitmentSize = config ? (config.labelsPerUnit * config.bitsPerLabel * numUnits) / BITS : 0;
+      const commitmentSize = config
+        ? (config.labelsPerUnit * config.bitsPerLabel * numUnits) / BITS
+        : 0;
 
       return {
         ...state,
@@ -46,7 +59,8 @@ const reducer = (state: SmesherState = initialState, action: CustomAction) => {
         numUnits,
         numLabelsWritten,
         postSetupState,
-        postProgressError: postSetupState === PostSetupState.STATE_ERROR ? errorMessage : '',
+        postProgressError:
+          postSetupState === PostSetupState.STATE_ERROR ? errorMessage : '',
         commitmentSize,
       };
     }
@@ -63,8 +77,19 @@ const reducer = (state: SmesherState = initialState, action: CustomAction) => {
       const {
         payload: { coinbase, dataDir, numUnits, provider, throttle },
       } = action;
-      const commitmentSize = state.config ? (state.config.labelsPerUnit * state.config.bitsPerLabel * numUnits) / BITS : 0;
-      return { ...state, coinbase, dataDir, numUnits, throttle, provider, commitmentSize };
+      const commitmentSize = state.config
+        ? (state.config.labelsPerUnit * state.config.bitsPerLabel * numUnits) /
+          BITS
+        : 0;
+      return {
+        ...state,
+        coinbase,
+        dataDir,
+        numUnits,
+        throttle,
+        provider,
+        commitmentSize,
+      };
     }
     case DELETED_POS_DATA: {
       return {

--- a/app/redux/smesher/selectors.ts
+++ b/app/redux/smesher/selectors.ts
@@ -1,10 +1,13 @@
 import { PostSetupState, SmeshingOpts } from '../../../shared/types';
 import { RootState } from '../../types';
 
-export const getPostSetupState = (state: RootState) => state.smesher.postSetupState;
+export const getPostSetupState = (state: RootState) =>
+  state.smesher.postSetupState;
 
-export const isSmeshing = (state: RootState) => getPostSetupState(state) === PostSetupState.STATE_COMPLETE;
-export const isCreatingPostData = (state: RootState) => getPostSetupState(state) === PostSetupState.STATE_IN_PROGRESS;
+export const isSmeshing = (state: RootState) =>
+  getPostSetupState(state) === PostSetupState.STATE_COMPLETE;
+export const isCreatingPostData = (state: RootState) =>
+  getPostSetupState(state) === PostSetupState.STATE_IN_PROGRESS;
 
 export const getSmeshingOpts = (state: RootState) => {
   const {
@@ -13,15 +16,19 @@ export const getSmeshingOpts = (state: RootState) => {
   return { coinbase, dataDir, numUnits, throttle, provider };
 };
 
-export const isValidSmeshingOpts = (opts: ReturnType<typeof getSmeshingOpts>): opts is SmeshingOpts => {
+export const isValidSmeshingOpts = (
+  opts: ReturnType<typeof getSmeshingOpts>
+): opts is SmeshingOpts => {
   const { coinbase, dataDir, numUnits, provider } = opts;
   return !!(coinbase && dataDir && numUnits && provider !== null);
 };
 
 export const isSmeshingPaused = (state: RootState) => {
-  const isNotStarted = getPostSetupState(state) === PostSetupState.STATE_NOT_STARTED;
+  const isNotStarted =
+    getPostSetupState(state) === PostSetupState.STATE_NOT_STARTED;
   const opts = getSmeshingOpts(state);
   return isNotStarted && isValidSmeshingOpts(opts);
 };
 
-export const getPostProgressError = (state: RootState) => state.smesher.postProgressError;
+export const getPostProgressError = (state: RootState) =>
+  state.smesher.postProgressError;

--- a/app/redux/store.ts
+++ b/app/redux/store.ts
@@ -24,7 +24,10 @@ const errorHandlerMiddleware = createErrorHandlerMiddleware((err: Error) => {
   return setUiError(error);
 });
 
-const store: Store<RootState, CustomAction> & { dispatch: AppThDispatch; getState: GetState } = createStore(
+const store: Store<RootState, CustomAction> & {
+  dispatch: AppThDispatch;
+  getState: GetState;
+} = createStore(
   rootReducer,
   composeEnhancers(applyMiddleware(errorHandlerMiddleware, thunk))
 );

--- a/app/redux/ui/reducer.ts
+++ b/app/redux/ui/reducer.ts
@@ -1,5 +1,11 @@
 import { UiState, CustomAction } from '../../types';
-import { SET_OS_THEME, THEME_SWITCHER, HIDE_LEFT_PANEL, SET_UI_ERROR, SHOW_CLOSING_APP_MODAL } from './actions';
+import {
+  SET_OS_THEME,
+  THEME_SWITCHER,
+  HIDE_LEFT_PANEL,
+  SET_UI_ERROR,
+  SHOW_CLOSING_APP_MODAL,
+} from './actions';
 
 const initialState = {
   isDarkMode: false,

--- a/app/redux/updater/selectors.ts
+++ b/app/redux/updater/selectors.ts
@@ -1,9 +1,12 @@
 import { RootState } from '../../types';
 
-export const getUpdateInfo = (state: RootState) => state.updater.availableUpdate;
+export const getUpdateInfo = (state: RootState) =>
+  state.updater.availableUpdate;
 export const isUpdateAvailable = (state: RootState) => !!getUpdateInfo(state);
-export const isUpdateDownloading = (state: RootState) => state.updater.isDownloading;
-export const isUpdateDownloaded = (state: RootState) => !!state.updater.downloadedUpdate;
+export const isUpdateDownloading = (state: RootState) =>
+  state.updater.isDownloading;
+export const isUpdateDownloaded = (state: RootState) =>
+  !!state.updater.downloadedUpdate;
 
 export const getProgressInfo = (state: RootState) => state.updater.progress;
 export const getError = (state: RootState) => state.updater.error;

--- a/app/redux/updater/slice.ts
+++ b/app/redux/updater/slice.ts
@@ -21,11 +21,27 @@ const slice = createSlice({
   name: 'updater',
   initialState,
   reducers: {
-    updateAvailable: (state, action: PayloadAction<UpdateInfo>) => ({ ...state, availableUpdate: action.payload }),
-    updateProgress: (state, action: PayloadAction<ProgressInfo>) => ({ ...state, progress: action.payload }),
-    updateDownloaded: (state, action: PayloadAction<UpdateInfo>) => ({ ...state, downloadedUpdate: action.payload, isDownloading: false }),
-    setError: (state, action: PayloadAction<Error>) => ({ ...state, error: action.payload }),
-    setDownloading: (state, action: PayloadAction<boolean>) => ({ ...state, isDownloading: action.payload }),
+    updateAvailable: (state, action: PayloadAction<UpdateInfo>) => ({
+      ...state,
+      availableUpdate: action.payload,
+    }),
+    updateProgress: (state, action: PayloadAction<ProgressInfo>) => ({
+      ...state,
+      progress: action.payload,
+    }),
+    updateDownloaded: (state, action: PayloadAction<UpdateInfo>) => ({
+      ...state,
+      downloadedUpdate: action.payload,
+      isDownloading: false,
+    }),
+    setError: (state, action: PayloadAction<Error>) => ({
+      ...state,
+      error: action.payload,
+    }),
+    setDownloading: (state, action: PayloadAction<boolean>) => ({
+      ...state,
+      isDownloading: action.payload,
+    }),
   },
 });
 

--- a/app/redux/wallet/actions.ts
+++ b/app/redux/wallet/actions.ts
@@ -1,5 +1,19 @@
-import { Account, Contact, HexString, SocketAddress, Tx, TxSendRequest, WalletMeta, WalletType } from '../../../shared/types';
-import { isLocalNodeApi, isRemoteNodeApi, isWalletOnlyType, stringifySocketAddress } from '../../../shared/utils';
+import {
+  Account,
+  Contact,
+  HexString,
+  SocketAddress,
+  Tx,
+  TxSendRequest,
+  WalletMeta,
+  WalletType,
+} from '../../../shared/types';
+import {
+  isLocalNodeApi,
+  isRemoteNodeApi,
+  isWalletOnlyType,
+  stringifySocketAddress,
+} from '../../../shared/utils';
 import { eventsService } from '../../infra/eventsService';
 import { addErrorPrefix, getAddress } from '../../infra/utils';
 import { AppThDispatch, GetState } from '../../types';
@@ -23,23 +37,56 @@ export const SET_BACKUP_TIME = 'SET_BACKUP_TIME';
 
 export const SET_CURRENT_WALLET_PATH = 'SET_CURRENT_WALLET_PATH';
 
-export const setCurrentWalletPath = (path: string | null) => ({ type: SET_CURRENT_WALLET_PATH, payload: path });
+export const setCurrentWalletPath = (path: string | null) => ({
+  type: SET_CURRENT_WALLET_PATH,
+  payload: path,
+});
 
-export const setWalletMeta = (wallet: WalletMeta) => ({ type: SET_WALLET_META, payload: wallet });
+export const setWalletMeta = (wallet: WalletMeta) => ({
+  type: SET_WALLET_META,
+  payload: wallet,
+});
 
-export const setAccounts = (accounts: Account[]) => ({ type: SET_ACCOUNTS, payload: accounts });
+export const setAccounts = (accounts: Account[]) => ({
+  type: SET_ACCOUNTS,
+  payload: accounts,
+});
 
-export const setCurrentAccount = (index: number) => ({ type: SET_CURRENT_ACCOUNT_INDEX, payload: index });
+export const setCurrentAccount = (index: number) => ({
+  type: SET_CURRENT_ACCOUNT_INDEX,
+  payload: index,
+});
 
-export const setMnemonic = (mnemonic: string) => ({ type: SET_MNEMONIC, payload: mnemonic });
+export const setMnemonic = (mnemonic: string) => ({
+  type: SET_MNEMONIC,
+  payload: mnemonic,
+});
 
-export const updateAccountData = ({ account, accountId }: { account: any; accountId: string }) => ({ type: UPDATE_ACCOUNT_DATA, payload: { account, accountId } });
+export const updateAccountData = ({
+  account,
+  accountId,
+}: {
+  account: any;
+  accountId: string;
+}) => ({ type: UPDATE_ACCOUNT_DATA, payload: { account, accountId } });
 
-export const setTransactions = ({ txs, publicKey }: { txs: Record<HexString, Tx>; publicKey: string }) => ({ type: SET_TRANSACTIONS, payload: { txs, publicKey } });
+export const setTransactions = ({
+  txs,
+  publicKey,
+}: {
+  txs: Record<HexString, Tx>;
+  publicKey: string;
+}) => ({ type: SET_TRANSACTIONS, payload: { txs, publicKey } });
 
-export const setContacts = (contacts: Contact[]) => ({ type: SET_CONTACTS, payload: contacts });
+export const setContacts = (contacts: Contact[]) => ({
+  type: SET_CONTACTS,
+  payload: contacts,
+});
 
-export const setCurrentMode = (mode: number) => ({ type: SET_CURRENT_MODE, payload: mode });
+export const setCurrentMode = (mode: number) => ({
+  type: SET_CURRENT_MODE,
+  payload: mode,
+});
 
 export const readWalletFiles = () => async (dispatch: AppThDispatch) => {
   const { error, files } = await eventsService.readWalletFiles();
@@ -84,8 +131,18 @@ export const createNewWallet = ({
       dispatch(setUiError(addErrorPrefix('Can not create new wallet\n', err)));
     });
 
-export const unlockWallet = (path: string, password: string) => async (dispatch: AppThDispatch) => {
-  const { error, accounts, mnemonic, meta, contacts, isNetworkExist, hasNetworks } = await eventsService.unlockWallet({ path, password });
+export const unlockWallet = (path: string, password: string) => async (
+  dispatch: AppThDispatch
+) => {
+  const {
+    error,
+    accounts,
+    mnemonic,
+    meta,
+    contacts,
+    isNetworkExist,
+    hasNetworks,
+  } = await eventsService.unlockWallet({ path, password });
   if (error) {
     // Incorrecrt password
     if (error.message && error.message.indexOf('Unexpected token') === 0) {
@@ -105,14 +162,24 @@ export const unlockWallet = (path: string, password: string) => async (dispatch:
   dispatch(setCurrentAccount(0));
   const isWalletOnly = isWalletOnlyType(meta.type);
   const requestApiSelection = isWalletOnly && !meta.remoteApi;
-  return { success: true, forceNetworkSelection: hasNetworks && (!isNetworkExist || requestApiSelection), isWalletOnly };
+  return {
+    success: true,
+    forceNetworkSelection:
+      hasNetworks && (!isNetworkExist || requestApiSelection),
+    isWalletOnly,
+  };
 };
-export const unlockCurrentWallet = (password: string) => async (dispatch: AppThDispatch, getState: GetState) => {
+export const unlockCurrentWallet = (password: string) => async (
+  dispatch: AppThDispatch,
+  getState: GetState
+) => {
   const {
     wallet: { currentWalletPath },
   } = getState();
   if (!currentWalletPath) {
-    dispatch(setUiError(new Error(`Can not find wallet in ${currentWalletPath}`)));
+    dispatch(
+      setUiError(new Error(`Can not find wallet in ${currentWalletPath}`))
+    );
     return { success: false };
   }
   return dispatch(unlockWallet(currentWalletPath, password));
@@ -127,34 +194,57 @@ export const closeWallet = () => (dispatch: AppThDispatch) => {
   dispatch(setCurrentAccount(0));
 };
 
-export const switchApiProvider = (api: SocketAddress | null) => async (dispatch: AppThDispatch) => {
+export const switchApiProvider = (api: SocketAddress | null) => async (
+  dispatch: AppThDispatch
+) => {
   await eventsService.switchApiProvider(api);
   dispatch({
     type: SET_REMOTE_API,
     payload: {
       api: api && isRemoteNodeApi(api) ? stringifySocketAddress(api) : '',
-      type: api && isLocalNodeApi(api) ? WalletType.LocalNode : WalletType.RemoteApi,
+      type:
+        api && isLocalNodeApi(api)
+          ? WalletType.LocalNode
+          : WalletType.RemoteApi,
     },
   });
   return true;
 };
 
-export const updateWalletName = ({ displayName }: { displayName: string }) => async (dispatch: AppThDispatch, getState: GetState) => {
+export const updateWalletName = ({
+  displayName,
+}: {
+  displayName: string;
+}) => async (dispatch: AppThDispatch, getState: GetState) => {
   const { wallet } = getState();
   const { meta, currentWalletPath } = wallet;
   const updatedMeta = { ...meta, displayName };
 
-  await eventsService.updateWalletMeta(currentWalletPath || '', 'displayName', displayName);
+  await eventsService.updateWalletMeta(
+    currentWalletPath || '',
+    'displayName',
+    displayName
+  );
   dispatch(setWalletMeta(updatedMeta));
 };
 
-export const createNewAccount = ({ password }: { password: string }) => async (dispatch: AppThDispatch, getState: GetState) => {
+export const createNewAccount = ({ password }: { password: string }) => async (
+  dispatch: AppThDispatch,
+  getState: GetState
+) => {
   const { accounts, currentWalletPath } = getState().wallet;
   if (!currentWalletPath) {
-    dispatch(setUiError(new Error('Can not create new account: No currently opened wallet')));
+    dispatch(
+      setUiError(
+        new Error('Can not create new account: No currently opened wallet')
+      )
+    );
     return;
   }
-  const { error, newAccount } = await eventsService.createNewAccount({ fileName: currentWalletPath, password });
+  const { error, newAccount } = await eventsService.createNewAccount({
+    fileName: currentWalletPath,
+    password,
+  });
   if (error) {
     console.log(error); // eslint-disable-line no-console
     dispatch(setUiError(addErrorPrefix('Can not create new account\n', error)));
@@ -163,52 +253,104 @@ export const createNewAccount = ({ password }: { password: string }) => async (d
   }
 };
 
-export const updateAccountName = ({ accountIndex, name, password }: { accountIndex: number; name: string; password: string }) => async (
-  dispatch: AppThDispatch,
-  getState: GetState
-) => {
+export const updateAccountName = ({
+  accountIndex,
+  name,
+  password,
+}: {
+  accountIndex: number;
+  name: string;
+  password: string;
+}) => async (dispatch: AppThDispatch, getState: GetState) => {
   const { currentWalletPath, accounts, mnemonic, contacts } = getState().wallet;
   const updatedAccount = { ...accounts[accountIndex], displayName: name };
-  const updatedAccounts = [...accounts.slice(0, accountIndex), updatedAccount, ...accounts.slice(accountIndex + 1)];
-  await eventsService.updateWalletSecrets(currentWalletPath || '', password, { mnemonic, accounts: updatedAccounts, contacts });
+  const updatedAccounts = [
+    ...accounts.slice(0, accountIndex),
+    updatedAccount,
+    ...accounts.slice(accountIndex + 1),
+  ];
+  await eventsService.updateWalletSecrets(currentWalletPath || '', password, {
+    mnemonic,
+    accounts: updatedAccounts,
+    contacts,
+  });
   dispatch(setAccounts(updatedAccounts));
 };
 
-export const addToContacts = ({ contact, password }: { contact: Contact; password: string }) => async (dispatch: AppThDispatch, getState: GetState) => {
+export const addToContacts = ({
+  contact,
+  password,
+}: {
+  contact: Contact;
+  password: string;
+}) => async (dispatch: AppThDispatch, getState: GetState) => {
   const { currentWalletPath, accounts, mnemonic, contacts } = getState().wallet;
   const updatedContacts = [contact, ...contacts];
-  await eventsService.updateWalletSecrets(currentWalletPath || '', password, { accounts, mnemonic, contacts: updatedContacts });
+  await eventsService.updateWalletSecrets(currentWalletPath || '', password, {
+    accounts,
+    mnemonic,
+    contacts: updatedContacts,
+  });
   dispatch(setContacts(updatedContacts));
 };
 
-export const removeFromContacts = ({ contact, password }: { contact: Contact; password: string }) => async (dispatch: AppThDispatch, getState: GetState) => {
+export const removeFromContacts = ({
+  contact,
+  password,
+}: {
+  contact: Contact;
+  password: string;
+}) => async (dispatch: AppThDispatch, getState: GetState) => {
   const { currentWalletPath, accounts, mnemonic, contacts } = getState().wallet;
-  const updatedContacts = contacts.filter((item) => contact.address !== item.address);
-  await eventsService.updateWalletSecrets(currentWalletPath || '', password, { accounts, mnemonic, contacts: updatedContacts });
+  const updatedContacts = contacts.filter(
+    (item) => contact.address !== item.address
+  );
+  await eventsService.updateWalletSecrets(currentWalletPath || '', password, {
+    accounts,
+    mnemonic,
+    contacts: updatedContacts,
+  });
   dispatch(setContacts(updatedContacts));
 };
 
-export const restoreFile = ({ filePath }: { filePath: string }) => async (dispatch: AppThDispatch) => {
+export const restoreFile = ({ filePath }: { filePath: string }) => async (
+  dispatch: AppThDispatch
+) => {
   try {
     await eventsService.addWalletPath(filePath);
     return true;
   } catch (error) {
     console.log(error); // eslint-disable-line no-console
-    dispatch(setUiError(addErrorPrefix('Can not restore wallet file\n', error as Error)));
+    dispatch(
+      setUiError(
+        addErrorPrefix('Can not restore wallet file\n', error as Error)
+      )
+    );
     return false;
   }
 };
 
-export const backupWallet = () => async (dispatch: AppThDispatch, getState: GetState) => {
+export const backupWallet = () => async (
+  dispatch: AppThDispatch,
+  getState: GetState
+) => {
   const { currentWalletPath } = getState().wallet;
   if (!currentWalletPath) {
-    dispatch(setUiError(new Error('Can not create wallet backup: Wallet does not opened')));
+    dispatch(
+      setUiError(
+        new Error('Can not create wallet backup: Wallet does not opened')
+      )
+    );
     return null;
   }
-  const { error, filePath } = await eventsService.backupWallet(currentWalletPath);
+  const { error, filePath } = await eventsService.backupWallet(
+    currentWalletPath
+  );
   if (error) {
     console.log(error); // eslint-disable-line no-console
-    dispatch(setUiError(addErrorPrefix('Can not create wallet backup\n', error)));
+    dispatch(
+      setUiError(addErrorPrefix('Can not create wallet backup\n', error))
+    );
     return null;
   } else {
     dispatch({ type: SET_BACKUP_TIME, payload: { backupTime: new Date() } });
@@ -216,10 +358,17 @@ export const backupWallet = () => async (dispatch: AppThDispatch, getState: GetS
   }
 };
 
-export const sendTransaction = ({ receiver, amount, fee, note }: { receiver: string; amount: number; fee: number; note: string }) => async (
-  dispatch: AppThDispatch,
-  getState: GetState
-) => {
+export const sendTransaction = ({
+  receiver,
+  amount,
+  fee,
+  note,
+}: {
+  receiver: string;
+  amount: number;
+  fee: number;
+  note: string;
+}) => async (dispatch: AppThDispatch, getState: GetState) => {
   const { accounts, currentAccountIndex } = getState().wallet;
   const fullTx: TxSendRequest = {
     sender: getAddress(accounts[currentAccountIndex].publicKey),
@@ -228,11 +377,18 @@ export const sendTransaction = ({ receiver, amount, fee, note }: { receiver: str
     fee,
     note,
   };
-  const { error, tx, state } = await eventsService.sendTx({ fullTx, accountIndex: currentAccountIndex });
+  const { error, tx, state } = await eventsService.sendTx({
+    fullTx,
+    accountIndex: currentAccountIndex,
+  });
   if (tx) {
     return { id: tx.id, state };
   } else {
-    const errorToLog = error ? addErrorPrefix('Send transaction error\n', error) : new Error('Send transaction error: unexpectedly got no Tx and no Error');
+    const errorToLog = error
+      ? addErrorPrefix('Send transaction error\n', error)
+      : new Error(
+          'Send transaction error: unexpectedly got no Tx and no Error'
+        );
     console.log(errorToLog); // eslint-disable-line no-console
     dispatch(setUiError(errorToLog));
     return {}; // TODO: Need a refactoring here

--- a/app/redux/wallet/reducer.ts
+++ b/app/redux/wallet/reducer.ts
@@ -62,7 +62,14 @@ const reducer = (state: WalletState = initialState, action: CustomAction) => {
       return { ...state, mnemonic: action.payload };
     }
     case SET_REMOTE_API: {
-      return { ...state, meta: { ...state.meta, remoteApi: action.payload.api, type: action.payload.type } };
+      return {
+        ...state,
+        meta: {
+          ...state.meta,
+          remoteApi: action.payload.api,
+          type: action.payload.type,
+        },
+      };
     }
     case SET_CURRENT_ACCOUNT_INDEX: {
       const index = action.payload;
@@ -76,15 +83,28 @@ const reducer = (state: WalletState = initialState, action: CustomAction) => {
     }
     case UPDATE_ACCOUNT_DATA: {
       const { account, accountId } = action.payload;
-      const accountIndexToUpdate = state.accounts.findIndex((account) => account.publicKey === accountId);
+      const accountIndexToUpdate = state.accounts.findIndex(
+        (account) => account.publicKey === accountId
+      );
       return {
         ...state,
-        accounts: R.over(R.lensIndex(accountIndexToUpdate), (acc) => ({ ...acc, currentState: account.currentState, projectedState: account.projectedState }), state.accounts),
+        accounts: R.over(
+          R.lensIndex(accountIndexToUpdate),
+          (acc) => ({
+            ...acc,
+            currentState: account.currentState,
+            projectedState: account.projectedState,
+          }),
+          state.accounts
+        ),
       };
     }
     case SET_TRANSACTIONS: {
       const { publicKey, txs } = action.payload;
-      return { ...state, transactions: { ...state.transactions, [publicKey]: txs } };
+      return {
+        ...state,
+        transactions: { ...state.transactions, [publicKey]: txs },
+      };
     }
     case SET_ACCOUNT_REWARDS: {
       const { rewards, publicKey } = action.payload;

--- a/app/routeUtils.ts
+++ b/app/routeUtils.ts
@@ -3,8 +3,14 @@
 import { useHistory } from 'react-router';
 import { AuthPath } from './routerPaths';
 
-export const goToSwitchNetwork = (history: ReturnType<typeof useHistory>, isWalletOnly: boolean) =>
+export const goToSwitchNetwork = (
+  history: ReturnType<typeof useHistory>,
+  isWalletOnly: boolean
+) =>
   setImmediate(() => {
     if (history.location.pathname === AuthPath.SwitchNetwork) return;
-    history.push(AuthPath.SwitchNetwork, { redirect: history.location.pathname, isWalletOnly });
+    history.push(AuthPath.SwitchNetwork, {
+      redirect: history.location.pathname,
+      isWalletOnly,
+    });
   });

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,4 +1,10 @@
-import { AuthPath, BackupPath, MainPath, RouterPath, WalletPath } from './routerPaths';
+import {
+  AuthPath,
+  BackupPath,
+  MainPath,
+  RouterPath,
+  WalletPath,
+} from './routerPaths';
 import {
   Auth,
   Welcome,
@@ -46,7 +52,8 @@ type Routes = Record<string, Route[]>;
 //
 // Utils
 //
-const formatRoutes = (list: [RouterPath, any][]): Route[] => list.map(([path, component]) => ({ path, component }));
+const formatRoutes = (list: [RouterPath, any][]): Route[] =>
+  list.map(([path, component]) => ({ path, component }));
 
 //
 // Map paths to components

--- a/app/screens/auth/Auth.tsx
+++ b/app/screens/auth/Auth.tsx
@@ -43,16 +43,24 @@ const RelativeContainer = styled.div`
 
 const renderHorizontalPane = (path, isDarkMode) => {
   const DO_NOT_SHOW_ON = [AuthPath.Welcome, AuthPath.Leaving];
-  return DO_NOT_SHOW_ON.includes(path) ? null : <SmallHorizontalPanel isDarkMode={isDarkMode} />;
+  return DO_NOT_SHOW_ON.includes(path) ? null : (
+    <SmallHorizontalPanel isDarkMode={isDarkMode} />
+  );
 };
 
 const Auth = ({ history, location }: AuthRouterParams) => {
-  const walletFiles = useSelector((state: RootState) => state.wallet.walletFiles);
+  const walletFiles = useSelector(
+    (state: RootState) => state.wallet.walletFiles
+  );
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (location.pathname === AuthPath.ConnectToAPI || location.pathname === AuthPath.SwitchNetwork) return;
+    if (
+      location.pathname === AuthPath.ConnectToAPI ||
+      location.pathname === AuthPath.SwitchNetwork
+    )
+      return;
     const initialSetup = async () => {
       const files = await dispatch(readWalletFiles());
       if (files.length && location.pathname === AuthPath.Auth) {
@@ -71,7 +79,12 @@ const Auth = ({ history, location }: AuthRouterParams) => {
             {renderHorizontalPane(location.pathname, isDarkMode)}
             <Switch>
               {routes.auth.map((route) => (
-                <Route exact key={route.path} path={route.path} component={route.component} />
+                <Route
+                  exact
+                  key={route.path}
+                  path={route.path}
+                  component={route.component}
+                />
               ))}
               <Redirect to="/auth/welcome" />
             </Switch>
@@ -81,7 +94,9 @@ const Auth = ({ history, location }: AuthRouterParams) => {
         )}
       </InnerWrapper>
       <Version />
-      <RightDecoration src={isDarkMode ? rightDecorationWhite : rightDecoration} />
+      <RightDecoration
+        src={isDarkMode ? rightDecorationWhite : rightDecoration}
+      />
     </Wrapper>
   );
 };

--- a/app/screens/auth/ConnectToApi.tsx
+++ b/app/screens/auth/ConnectToApi.tsx
@@ -48,7 +48,9 @@ const AccItem = styled.div<{ isInDropDown: boolean }>`
   text-transform: uppercase;
   color: ${smColors.black};
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -65,11 +67,17 @@ type PublicServicesView = {
 const ConnectToApi = ({ history, location }: AuthRouterParams) => {
   const dispatch: AppThDispatch = useDispatch();
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
-  const ddStyle = { border: `1px solid ${isDarkMode ? smColors.black : smColors.white}`, marginLeft: 'auto' };
+  const ddStyle = {
+    border: `1px solid ${isDarkMode ? smColors.black : smColors.white}`,
+    marginLeft: 'auto',
+  };
 
   const [selectedItemIndex, setSelectedItemIndex] = useState(0);
 
-  const [publicServices, setPublicServices] = useState({ loading: true, services: [] as PublicServicesView[] });
+  const [publicServices, setPublicServices] = useState({
+    loading: true,
+    services: [] as PublicServicesView[],
+  });
 
   const updatePublicServices = () => {
     eventsService
@@ -103,7 +111,15 @@ const ConnectToApi = ({ history, location }: AuthRouterParams) => {
 
   const selectItem = ({ index }) => setSelectedItemIndex(index);
 
-  const renderAccElement = ({ label, text, isMain }: { label: string; text: string; isMain: boolean }) => (
+  const renderAccElement = ({
+    label,
+    text,
+    isMain,
+  }: {
+    label: string;
+    text: string;
+    isMain: boolean;
+  }) => (
     <AccItem key={label} isInDropDown={!isMain}>
       {text ? (
         <>
@@ -126,7 +142,10 @@ const ConnectToApi = ({ history, location }: AuthRouterParams) => {
       : [{ label: 'NO REMOTE API AVAILABLE', isDisabled: true }];
 
   const handleNext = () => {
-    const value = publicServices.services.length > selectedItemIndex ? publicServices.services[selectedItemIndex].value : undefined;
+    const value =
+      publicServices.services.length > selectedItemIndex
+        ? publicServices.services[selectedItemIndex].value
+        : undefined;
 
     value &&
       dispatch(switchApiProvider(value)).catch((err) => {
@@ -134,12 +153,17 @@ const ConnectToApi = ({ history, location }: AuthRouterParams) => {
         dispatch(setUiError(err));
       });
 
-    history.push(location?.state?.redirect || AuthPath.Unlock, { apiUrl: value, ...location.state });
+    history.push(location?.state?.redirect || AuthPath.Unlock, {
+      apiUrl: value,
+      ...location.state,
+    });
   };
 
   return (
     <Wrapper>
-      {!!location.state?.creatingWallet && <Steps step={Step.SELECT_NETWORK} isDarkMode={isDarkMode} />}
+      {!!location.state?.creatingWallet && (
+        <Steps step={Step.SELECT_NETWORK} isDarkMode={isDarkMode} />
+      )}
       <CorneredContainer
         width={650}
         height={400}
@@ -160,13 +184,28 @@ const ConnectToApi = ({ history, location }: AuthRouterParams) => {
             isDisabled={!hasPublicServices}
           />
         </RowColumn>
-        <RowColumn>{!publicServices.loading && <Link onClick={updatePublicServices} text="REFRESH" />}</RowColumn>
+        <RowColumn>
+          {!publicServices.loading && (
+            <Link onClick={updatePublicServices} text="REFRESH" />
+          )}
+        </RowColumn>
 
         <BackButton action={history.goBack} />
         <BottomPart>
           <Link onClick={navigateToExplanation} text="WALLET SETUP GUIDE" />
-          {!hasPublicServices && !publicServices.loading && <Button onClick={handleNext} text="SKIP" isPrimary={false} style={{ marginLeft: 'auto', marginRight: '1em' }} />}
-          <Button onClick={handleNext} text="NEXT" isDisabled={!hasPublicServices} />
+          {!hasPublicServices && !publicServices.loading && (
+            <Button
+              onClick={handleNext}
+              text="SKIP"
+              isPrimary={false}
+              style={{ marginLeft: 'auto', marginRight: '1em' }}
+            />
+          )}
+          <Button
+            onClick={handleNext}
+            text="NEXT"
+            isDisabled={!hasPublicServices}
+          />
         </BottomPart>
       </CorneredContainer>
     </Wrapper>

--- a/app/screens/auth/CreateWallet.tsx
+++ b/app/screens/auth/CreateWallet.tsx
@@ -9,7 +9,10 @@ import { eventsService } from '../../infra/eventsService';
 import { chevronRightBlack, chevronRightWhite } from '../../assets/images';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
-import { getCurrentWalletFile, isWalletOnly } from '../../redux/wallet/selectors';
+import {
+  getCurrentWalletFile,
+  isWalletOnly,
+} from '../../redux/wallet/selectors';
 import { WalletType } from '../../../shared/types';
 import { MainPath } from '../../routerPaths';
 import { setLastSelectedWalletPath } from '../../infra/lastSelectedWalletPath';
@@ -24,7 +27,8 @@ const Wrapper = styled.div`
 `;
 
 const SubHeader = styled.div`
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const UpperPart = styled.div`
@@ -98,24 +102,35 @@ const CreateWallet = ({ history, location }: AuthRouterParams) => {
 
   const renderSubHeader = (subMode: number) => {
     return subMode === 1 ? (
-      <SubHeader>Protect your wallet with a password. You will need it to access latter</SubHeader>
+      <SubHeader>
+        Protect your wallet with a password. You will need it to access latter
+      </SubHeader>
     ) : (
       <SubHeader>
         Your wallet was created and saved in a password-protected file
         <br />
         <br />
-        <Link onClick={() => eventsService.showFileInFolder({})} text="Browse file location" />
+        <Link
+          onClick={() => eventsService.showFileInFolder({})}
+          text="Browse file location"
+        />
       </SubHeader>
     );
   };
 
   const validate = () => {
     const pasMinLength = 1; // TODO: Changed to 8 before testnet.
-    const hasPasswordError = !password || (!!password && password.length < pasMinLength);
-    const hasVerifyPasswordError = !verifiedPassword || password !== verifiedPassword;
+    const hasPasswordError =
+      !password || (!!password && password.length < pasMinLength);
+    const hasVerifyPasswordError =
+      !verifiedPassword || password !== verifiedPassword;
     // eslint-disable-next-line no-template-curly-in-string
-    const passwordError = hasPasswordError ? 'Password has to be ${pasMinLength} characters or more.' : '';
-    const verifyPasswordError = hasVerifyPasswordError ? "These passwords don't match, please try again." : '';
+    const passwordError = hasPasswordError
+      ? `Password has to be ${pasMinLength} characters or more.`
+      : '';
+    const verifyPasswordError = hasVerifyPasswordError
+      ? "These passwords don't match, please try again."
+      : '';
     setPasswordError(passwordError);
     setVerifiedPassword(verifyPasswordError);
     return !passwordError && !verifyPasswordError;
@@ -128,7 +143,9 @@ const CreateWallet = ({ history, location }: AuthRouterParams) => {
         createNewWallet({
           existingMnemonic: location?.state?.mnemonic,
           password,
-          type: location?.state?.isWalletOnly ? WalletType.RemoteApi : WalletType.LocalNode,
+          type: location?.state?.isWalletOnly
+            ? WalletType.RemoteApi
+            : WalletType.LocalNode,
           netId: location?.state?.netId || -1,
           apiUrl: location?.state?.apiUrl || null,
         })
@@ -158,7 +175,11 @@ const CreateWallet = ({ history, location }: AuthRouterParams) => {
     if (subMode === 1 && validate()) {
       createWallet();
     } else if (subMode === 2) {
-      if (location?.state?.netId && typeof location?.state?.apiUrl === 'string' && isLocalNodeApi(location.state.apiUrl)) {
+      if (
+        location?.state?.netId &&
+        typeof location?.state?.apiUrl === 'string' &&
+        isLocalNodeApi(location.state.apiUrl)
+      ) {
         history.push(MainPath.SmeshingSetup);
         return;
       }
@@ -175,27 +196,51 @@ const CreateWallet = ({ history, location }: AuthRouterParams) => {
         <Loader
           size={Loader.sizes.BIG}
           isDarkMode={isDarkMode}
-          note={isWalletOnlyMode ? 'Please wait, connecting to Spacemesh api...' : 'Please wait, starting up Spacemesh node...'}
+          note={
+            isWalletOnlyMode
+              ? 'Please wait, connecting to Spacemesh api...'
+              : 'Please wait, starting up Spacemesh node...'
+          }
         />
       </LoaderWrapper>
     );
   }
-  const header = subMode === 1 ? 'PROTECT YOUR WALLET' : 'WALLET PASSWORD PROTECTED';
+  const header =
+    subMode === 1 ? 'PROTECT YOUR WALLET' : 'WALLET PASSWORD PROTECTED';
   return (
     <Wrapper>
       <Steps step={Step.PROTECT_WALLET} isDarkMode={isDarkMode} />
-      <CorneredContainer width={650} height={400} header={header} subHeader={renderSubHeader(subMode)} isDarkMode={isDarkMode}>
+      <CorneredContainer
+        width={650}
+        height={400}
+        header={header}
+        subHeader={renderSubHeader(subMode)}
+        isDarkMode={isDarkMode}
+      >
         {subMode === 1 && (
           <>
             <UpperPart>
               <Inputs>
                 <InputSection>
                   <Chevron src={chevronRight} />
-                  <Input value={password} type="password" placeholder="ENTER PASSWORD" onEnterPress={handleEnterPress} onChange={handlePasswordTyping} autofocus />
+                  <Input
+                    value={password}
+                    type="password"
+                    placeholder="ENTER PASSWORD"
+                    onEnterPress={handleEnterPress}
+                    onChange={handlePasswordTyping}
+                    autofocus
+                  />
                 </InputSection>
                 <InputSection>
                   <Chevron src={chevronRight} />
-                  <Input value={verifiedPassword} type="password" placeholder="VERIFY PASSWORD" onEnterPress={handleEnterPress} onChange={handlePasswordVerifyTyping} />
+                  <Input
+                    value={verifiedPassword}
+                    type="password"
+                    placeholder="VERIFY PASSWORD"
+                    onEnterPress={handleEnterPress}
+                    onChange={handlePasswordVerifyTyping}
+                  />
                 </InputSection>
               </Inputs>
               <ErrorSection>

--- a/app/screens/auth/FileRestore.tsx
+++ b/app/screens/auth/FileRestore.tsx
@@ -34,7 +34,13 @@ const FileRestore = ({ history }: AuthRouterParams) => {
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
   const dispatch: AppThDispatch = useDispatch();
 
-  const addFile = ({ fileName, filePath }: { fileName: string; filePath: string }) => {
+  const addFile = ({
+    fileName,
+    filePath,
+  }: {
+    fileName: string;
+    filePath: string;
+  }) => {
     if (fileName.split('.').pop() !== 'json') {
       setHasError(true);
     } else {
@@ -52,17 +58,33 @@ const FileRestore = ({ history }: AuthRouterParams) => {
     }
   };
 
-  const navigateToBackupGuide = () => window.open(ExternalLinks.RestoreFileGuide);
+  const navigateToBackupGuide = () =>
+    window.open(ExternalLinks.RestoreFileGuide);
 
   return (
-    <WrapperWith2SideBars width={800} height={480} isDarkMode={isDarkMode} header="OPEN WALLET" subHeader="Open a wallet from a wallet file">
+    <WrapperWith2SideBars
+      width={800}
+      height={480}
+      isDarkMode={isDarkMode}
+      header="OPEN WALLET"
+      subHeader="Open a wallet from a wallet file"
+    >
       <BackButton action={history.goBack} />
       <DdArea>
-        <DragAndDrop onFilesAdded={addFile} fileName={fileName} hasError={hasError} isDarkMode={isDarkMode} />
+        <DragAndDrop
+          onFilesAdded={addFile}
+          fileName={fileName}
+          hasError={hasError}
+          isDarkMode={isDarkMode}
+        />
       </DdArea>
       <BottomSection>
         <Link onClick={navigateToBackupGuide} text="BACKUP GUIDE" />
-        <Button onClick={openWalletFile} text="OPEN" isDisabled={hasError || !fileName} />
+        <Button
+          onClick={openWalletFile}
+          text="OPEN"
+          isDisabled={hasError || !fileName}
+        />
       </BottomSection>
     </WrapperWith2SideBars>
   );

--- a/app/screens/auth/Leaving.tsx
+++ b/app/screens/auth/Leaving.tsx
@@ -48,7 +48,8 @@ const Indicator = styled.div`
   left: -30px;
   width: 16px;
   height: 16px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.black)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.black};
 `;
 const Row = styled.div`
   display: flex;
@@ -66,7 +67,9 @@ const BottomPart = styled.div`
 
 const Leaving = ({ history }: AuthRouterParams) => {
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
-  const hasWalletFiles = useSelector((state: RootState) => state.wallet.walletFiles.length > 0);
+  const hasWalletFiles = useSelector(
+    (state: RootState) => state.wallet.walletFiles.length > 0
+  );
 
   const navigateToSetupGuide = () => window.open(ExternalLinks.SetupGuide);
 
@@ -74,7 +77,13 @@ const Leaving = ({ history }: AuthRouterParams) => {
 
   return (
     <Wrapper>
-      <CorneredContainer width={760} height={400} header={header} subHeader="Are you sure you want to quit the setup?" isDarkMode={isDarkMode}>
+      <CorneredContainer
+        width={760}
+        height={400}
+        header={header}
+        subHeader="Are you sure you want to quit the setup?"
+        isDarkMode={isDarkMode}
+      >
         <SideBar src={bigInnerSideBar} />
         <Indicator />
         <BackButton action={history.goBack} />
@@ -83,11 +92,23 @@ const Leaving = ({ history }: AuthRouterParams) => {
             <Link onClick={navigateToSetupGuide} text="SETUP GUIDE" />
             <Row>
               <Text>DON`T HAVE A DESKTOP?</Text>
-              <Link onClick={() => history.push(AuthPath.Recover)} text="SETUP WALLET ONLY" />
-              <Tooltip width={100} text="SETUP WALLET ONLY" isDarkMode={isDarkMode} />
+              <Link
+                onClick={() => history.push(AuthPath.Recover)}
+                text="SETUP WALLET ONLY"
+              />
+              <Tooltip
+                width={100}
+                text="SETUP WALLET ONLY"
+                isDarkMode={isDarkMode}
+              />
             </Row>
           </ComplexLink>
-          <Button text="LEAVE SETUP" onClick={() => history.push(hasWalletFiles ? AuthPath.Unlock : AuthPath.Welcome)} />
+          <Button
+            text="LEAVE SETUP"
+            onClick={() =>
+              history.push(hasWalletFiles ? AuthPath.Unlock : AuthPath.Welcome)
+            }
+          />
         </BottomPart>
       </CorneredContainer>
     </Wrapper>

--- a/app/screens/auth/RestoreWallet.tsx
+++ b/app/screens/auth/RestoreWallet.tsx
@@ -15,11 +15,32 @@ const RestoreWallet = ({ history }: AuthRouterParams) => {
   const navigateToWalletGuide = () => window.open(ExternalLinks.RestoreGuide);
 
   return (
-    <CorneredContainer width={650} height={400} header="OPEN AN EXISTING WALLET" subHeader="Open from a file or restore from 12 words" isDarkMode={isDarkMode}>
+    <CorneredContainer
+      width={650}
+      height={400}
+      header="OPEN AN EXISTING WALLET"
+      subHeader="Open from a file or restore from 12 words"
+      isDarkMode={isDarkMode}
+    >
       <BackButton action={history.goBack} />
-      <Button text="OPEN FROM FILE" isPrimary={false} onClick={() => history.push(AuthPath.RecoverFromFile)} width={250} style={btnStyle} />
-      <Button text="RESTORE FROM 12 WORDS" isPrimary={false} onClick={() => history.push(AuthPath.RecoverFromMnemonics)} width={250} />
-      <Link onClick={navigateToWalletGuide} text="WALLET GUIDE" style={{ marginTop: 'auto', marginRight: 'auto' }} />
+      <Button
+        text="OPEN FROM FILE"
+        isPrimary={false}
+        onClick={() => history.push(AuthPath.RecoverFromFile)}
+        width={250}
+        style={btnStyle}
+      />
+      <Button
+        text="RESTORE FROM 12 WORDS"
+        isPrimary={false}
+        onClick={() => history.push(AuthPath.RecoverFromMnemonics)}
+        width={250}
+      />
+      <Link
+        onClick={navigateToWalletGuide}
+        text="WALLET GUIDE"
+        style={{ marginTop: 'auto', marginRight: 'auto' }}
+      />
     </CorneredContainer>
   );
 };

--- a/app/screens/auth/Steps.tsx
+++ b/app/screens/auth/Steps.tsx
@@ -7,10 +7,25 @@ export enum Step {
   PROTECT_WALLET = 'PROTECT_WALLET',
   SELECT_NETWORK = 'SELECT NETWORK',
 }
-const STEPS_ORDERED = [Step.NEW_WALLET_SETUP, Step.NEW_WALLET_TYPE, Step.SELECT_NETWORK, Step.PROTECT_WALLET];
+const STEPS_ORDERED = [
+  Step.NEW_WALLET_SETUP,
+  Step.NEW_WALLET_TYPE,
+  Step.SELECT_NETWORK,
+  Step.PROTECT_WALLET,
+];
 
-const Steps = ({ step = Step[0], isDarkMode }: { step: Step; isDarkMode: boolean }) => (
-  <StepsContainer steps={STEPS_ORDERED} currentStep={STEPS_ORDERED.indexOf(step)} isDarkMode={isDarkMode} />
+const Steps = ({
+  step = Step[0],
+  isDarkMode,
+}: {
+  step: Step;
+  isDarkMode: boolean;
+}) => (
+  <StepsContainer
+    steps={STEPS_ORDERED}
+    currentStep={STEPS_ORDERED.indexOf(step)}
+    isDarkMode={isDarkMode}
+  />
 );
 
 export default Steps;

--- a/app/screens/auth/SwitchNetwork.tsx
+++ b/app/screens/auth/SwitchNetwork.tsx
@@ -46,7 +46,9 @@ const AccItem = styled.div<{ isInDropDown: boolean }>`
   text-transform: uppercase;
   color: ${smColors.black};
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -56,10 +58,16 @@ const AccItem = styled.div<{ isInDropDown: boolean }>`
 const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
   const dispatch: AppThDispatch = useDispatch();
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
-  const ddStyle = { border: `1px solid ${isDarkMode ? smColors.black : smColors.white}`, marginLeft: 'auto' };
+  const ddStyle = {
+    border: `1px solid ${isDarkMode ? smColors.black : smColors.white}`,
+    marginLeft: 'auto',
+  };
 
   const [selectedItemIndex, setSelectedItemIndex] = useState(0);
-  const [networks, setNetworks] = useState({ loading: false, networks: [] as { netId: number; netName: string; explorer?: string }[] });
+  const [networks, setNetworks] = useState({
+    loading: false,
+    networks: [] as { netId: number; netName: string; explorer?: string }[],
+  });
   const [showLoader, setLoader] = useState(false);
 
   const updateNetworks = () => {
@@ -91,7 +99,17 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
     window.open(explorer.concat(isDarkMode ? '?dark' : ''), '_blank');
   };
 
-  const renderAccElement = ({ label, explorer, netId, isMain }: { label: string; explorer: string; netId: number; isMain: boolean }) => (
+  const renderAccElement = ({
+    label,
+    explorer,
+    netId,
+    isMain,
+  }: {
+    label: string;
+    explorer: string;
+    netId: number;
+    isMain: boolean;
+  }) => (
     <AccItem key={label} isInDropDown={!isMain}>
       {netId > 0 ? (
         <>
@@ -114,24 +132,43 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
     networks.loading
       ? [{ label: 'LOADING... PLEASE WAIT', netId: -1, isDisabled: true }]
       : hasAvailableNetworks
-      ? networks.networks.map(({ netId, netName, explorer }) => ({ label: netName, netId, explorer }))
+      ? networks.networks.map(({ netId, netName, explorer }) => ({
+          label: netName,
+          netId,
+          explorer,
+        }))
       : [{ label: 'NO NETWORKS AVAILABLE', netId: -1, isDisabled: true }];
 
   const goNext = (netId: number) => {
     const { creatingWallet, isWalletOnly } = location.state;
     if (creatingWallet) {
-      if (netId === -1) return history.push(AuthPath.CreateWallet, { netId, isWalletOnly });
-      if (isWalletOnly) return history.push(AuthPath.ConnectToAPI, { redirect: AuthPath.CreateWallet, netId, isWalletOnly, creatingWallet });
+      if (netId === -1)
+        return history.push(AuthPath.CreateWallet, { netId, isWalletOnly });
+      if (isWalletOnly)
+        return history.push(AuthPath.ConnectToAPI, {
+          redirect: AuthPath.CreateWallet,
+          netId,
+          isWalletOnly,
+          creatingWallet,
+        });
       return history.push(AuthPath.CreateWallet, { netId, isWalletOnly });
     }
     if (netId > -1 && isWalletOnly) {
-      return history.push(AuthPath.ConnectToAPI, { redirect: location?.state?.redirect, netId, isWalletOnly, creatingWallet });
+      return history.push(AuthPath.ConnectToAPI, {
+        redirect: location?.state?.redirect,
+        netId,
+        isWalletOnly,
+        creatingWallet,
+      });
     }
     return history.push(location?.state?.redirect || AuthPath.Unlock);
   };
 
   const handleNext = async () => {
-    const netId = networks.networks.length > selectedItemIndex ? networks.networks[selectedItemIndex].netId : -1;
+    const netId =
+      networks.networks.length > selectedItemIndex
+        ? networks.networks[selectedItemIndex].netId
+        : -1;
     setLoader(true);
     if (netId > -1) {
       try {
@@ -148,10 +185,16 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
   };
 
   return showLoader ? (
-    <Loader size={Loader.sizes.BIG} isDarkMode={isDarkMode} note="Please wait, connecting to Spacemesh network..." />
+    <Loader
+      size={Loader.sizes.BIG}
+      isDarkMode={isDarkMode}
+      note="Please wait, connecting to Spacemesh network..."
+    />
   ) : (
     <Wrapper>
-      {!!location.state.creatingWallet && <Steps step={Step.SELECT_NETWORK} isDarkMode={isDarkMode} />}
+      {!!location.state.creatingWallet && (
+        <Steps step={Step.SELECT_NETWORK} isDarkMode={isDarkMode} />
+      )}
       <CorneredContainer
         width={650}
         height={400}
@@ -172,12 +215,27 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
             isDisabled={!hasAvailableNetworks}
           />
         </RowColumn>
-        <RowColumn>{!networks.loading && <Link onClick={updateNetworks} text="REFRESH" />}</RowColumn>
+        <RowColumn>
+          {!networks.loading && (
+            <Link onClick={updateNetworks} text="REFRESH" />
+          )}
+        </RowColumn>
 
         <BottomPart>
           <Link onClick={navigateToExplanation} text="WALLET SETUP GUIDE" />
-          {!hasAvailableNetworks && !networks.loading && <Button onClick={handleNext} text="SKIP" isPrimary={false} style={{ marginLeft: 'auto', marginRight: '1em' }} />}
-          <Button onClick={handleNext} text="NEXT" isDisabled={!hasAvailableNetworks} />
+          {!hasAvailableNetworks && !networks.loading && (
+            <Button
+              onClick={handleNext}
+              text="SKIP"
+              isPrimary={false}
+              style={{ marginLeft: 'auto', marginRight: '1em' }}
+            />
+          )}
+          <Button
+            onClick={handleNext}
+            text="NEXT"
+            isDisabled={!hasAvailableNetworks}
+          />
         </BottomPart>
       </CorneredContainer>
     </Wrapper>

--- a/app/screens/auth/UnlockWallet.tsx
+++ b/app/screens/auth/UnlockWallet.tsx
@@ -4,13 +4,27 @@ import { useSelector, useDispatch } from 'react-redux';
 import { readWalletFiles, unlockWallet } from '../../redux/wallet/actions';
 import { CorneredContainer } from '../../components/common';
 import { LoggedOutBanner } from '../../components/banners';
-import { Link, Button, Input, ErrorPopup, Loader, DropDown } from '../../basicComponents';
+import {
+  Link,
+  Button,
+  Input,
+  ErrorPopup,
+  Loader,
+  DropDown,
+} from '../../basicComponents';
 import { smColors } from '../../vars';
-import { smallInnerSideBar, chevronRightBlack, chevronRightWhite } from '../../assets/images';
+import {
+  smallInnerSideBar,
+  chevronRightBlack,
+  chevronRightWhite,
+} from '../../assets/images';
 import { AppThDispatch, RootState } from '../../types';
 import { isWalletOnly, listWalletFiles } from '../../redux/wallet/selectors';
 import { WalletMeta } from '../../../shared/types';
-import { setLastSelectedWalletPath, getIndexOfLastSelectedWalletPath } from '../../infra/lastSelectedWalletPath';
+import {
+  setLastSelectedWalletPath,
+  getIndexOfLastSelectedWalletPath,
+} from '../../infra/lastSelectedWalletPath';
 import { AuthPath, MainPath } from '../../routerPaths';
 import { formatISOAsUS } from '../../../shared/datetime';
 import { ExternalLinks } from '../../../shared/constants';
@@ -99,7 +113,9 @@ const AccItem = styled.div<{ isInDropDown: boolean }>`
   text-transform: uppercase;
   color: ${smColors.black};
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -118,7 +134,9 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
   const dispatch: AppThDispatch = useDispatch();
   const chevronIcon = isDarkMode ? chevronRightWhite : chevronRightBlack;
 
-  const [selectedWalletIndex, updateSelectedWalletIndex] = useState(getIndexOfLastSelectedWalletPath(walletFiles));
+  const [selectedWalletIndex, updateSelectedWalletIndex] = useState(
+    getIndexOfLastSelectedWalletPath(walletFiles)
+  );
 
   useEffect(() => {
     // Ensure that we had loaded wallet files
@@ -126,7 +144,13 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
   }, [dispatch]);
 
   const getDropDownData = () =>
-    walletFiles.length === 0 ? [{ label: 'NO WALLET FILES FOUND', isDisabled: true }] : walletFiles.map(({ path, meta }) => ({ label: meta.displayName, path, meta }));
+    walletFiles.length === 0
+      ? [{ label: 'NO WALLET FILES FOUND', isDisabled: true }]
+      : walletFiles.map(({ path, meta }) => ({
+          label: meta.displayName,
+          path,
+          meta,
+        }));
 
   const selectItem = ({ index }) => {
     setLastSelectedWalletPath(walletFiles[index].path);
@@ -134,8 +158,19 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
   };
 
   // TODO: Get rid from code duplication
-  const ddStyle = { border: `1px solid ${isDarkMode ? smColors.black : smColors.white}`, marginLeft: 'auto' };
-  const renderAccElement = ({ label, meta, isMain }: { label: string; meta?: WalletMeta; isMain: boolean }) => (
+  const ddStyle = {
+    border: `1px solid ${isDarkMode ? smColors.black : smColors.white}`,
+    marginLeft: 'auto',
+  };
+  const renderAccElement = ({
+    label,
+    meta,
+    isMain,
+  }: {
+    label: string;
+    meta?: WalletMeta;
+    isMain: boolean;
+  }) => (
     <AccItem key={label} isInDropDown={!isMain}>
       {label}
       {meta && (
@@ -159,12 +194,20 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
       if (walletFiles.length === 0) {
         throw new Error('No wallets found to unlock');
       }
-      const status = await dispatch(unlockWallet(walletFiles[selectedWalletIndex].path, password));
+      const status = await dispatch(
+        unlockWallet(walletFiles[selectedWalletIndex].path, password)
+      );
       setShowLoader(false);
       if (status.success) {
-        const nextPage = (location.state?.redirect !== AuthPath.Unlock && location.state?.redirect) || MainPath.Wallet;
+        const nextPage =
+          (location.state?.redirect !== AuthPath.Unlock &&
+            location.state?.redirect) ||
+          MainPath.Wallet;
         if (status.forceNetworkSelection) {
-          history.push(AuthPath.SwitchNetwork, { redirect: nextPage, isWalletOnly: status.isWalletOnly });
+          history.push(AuthPath.SwitchNetwork, {
+            redirect: nextPage,
+            isWalletOnly: status.isWalletOnly,
+          });
           return;
         }
         history.push(nextPage);
@@ -179,12 +222,23 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
     <Loader
       size={Loader.sizes.BIG}
       isDarkMode={isDarkMode}
-      note={isWalletOnlyMode ? 'Please wait, connecting to Spacemesh api...' : 'Please wait, starting up Spacemesh node...'}
+      note={
+        isWalletOnlyMode
+          ? 'Please wait, connecting to Spacemesh api...'
+          : 'Please wait, starting up Spacemesh node...'
+      }
     />
   ) : (
     <Wrapper>
       {location?.state?.isLoggedOut && <LoggedOutBanner key="banner" />}
-      <CorneredContainer width={520} height={showWalletFileSelection ? 415 : 310} header="UNLOCK" subHeader="Welcome back to Spacemesh." key="main" isDarkMode={isDarkMode}>
+      <CorneredContainer
+        width={520}
+        height={showWalletFileSelection ? 415 : 310}
+        header="UNLOCK"
+        subHeader="Welcome back to Spacemesh."
+        key="main"
+        isDarkMode={isDarkMode}
+      >
         {showWalletFileSelection ? (
           <>
             <Text>Select a wallet:</Text>
@@ -207,7 +261,15 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
         <SmallSideBar src={smallInnerSideBar} />
         <InputSection>
           <Chevron src={chevronIcon} />
-          <Input type="password" placeholder="ENTER PASSWORD" value={password} onEnterPress={decryptWallet} onChange={handlePasswordTyping} style={{ flex: 1 }} autofocus />
+          <Input
+            type="password"
+            placeholder="ENTER PASSWORD"
+            value={password}
+            onEnterPress={decryptWallet}
+            onChange={handlePasswordTyping}
+            style={{ flex: 1 }}
+            autofocus
+          />
           <ErrorSection>
             {isWrongPassword && (
               <ErrorPopup
@@ -223,11 +285,28 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
         <BottomPart>
           <LinksWrapper>
             <GrayText>FORGOT YOUR PASSWORD?</GrayText>
-            <Link onClick={() => history.push(AuthPath.Recover)} text="OPEN AN EXISTING WALLET" style={{ marginRight: 'auto' }} />
-            <Link onClick={() => history.push(AuthPath.ConnectionType)} text="CREATE" style={{ marginRight: 'auto' }} />
-            <Link onClick={navigateToSetupGuide} text="SETUP GUIDE" style={{ marginRight: 'auto' }} />
+            <Link
+              onClick={() => history.push(AuthPath.Recover)}
+              text="OPEN AN EXISTING WALLET"
+              style={{ marginRight: 'auto' }}
+            />
+            <Link
+              onClick={() => history.push(AuthPath.ConnectionType)}
+              text="CREATE"
+              style={{ marginRight: 'auto' }}
+            />
+            <Link
+              onClick={navigateToSetupGuide}
+              text="SETUP GUIDE"
+              style={{ marginRight: 'auto' }}
+            />
           </LinksWrapper>
-          <Button text="UNLOCK" isDisabled={!password.trim() || !!isWrongPassword} onClick={decryptWallet} style={{ marginTop: 'auto' }} />
+          <Button
+            text="UNLOCK"
+            isDisabled={!password.trim() || !!isWrongPassword}
+            onClick={decryptWallet}
+            style={{ marginTop: 'auto' }}
+          />
         </BottomPart>
       </CorneredContainer>
     </Wrapper>

--- a/app/screens/auth/WalletConnectionType.tsx
+++ b/app/screens/auth/WalletConnectionType.tsx
@@ -3,7 +3,12 @@ import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { CorneredContainer, BackButton } from '../../components/common';
 import { Button, Link, Tooltip } from '../../basicComponents';
-import { posSmesherWhite, walletSecondWhite, walletSecondBlack, posSmesherBlack } from '../../assets/images';
+import {
+  posSmesherWhite,
+  walletSecondWhite,
+  walletSecondBlack,
+  posSmesherBlack,
+} from '../../assets/images';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
 import { AuthPath } from '../../routerPaths';
@@ -90,37 +95,68 @@ const WalletConnectionType = ({ history }: AuthRouterParams) => {
   return (
     <Wrapper>
       <Steps step={Step.NEW_WALLET_SETUP} isDarkMode={isDarkMode} />
-      <CorneredContainer width={650} height={400} header="NEW WALLET" subHeader="Configure your new wallet" isDarkMode={isDarkMode}>
+      <CorneredContainer
+        width={650}
+        height={400}
+        header="NEW WALLET"
+        subHeader="Configure your new wallet"
+        isDarkMode={isDarkMode}
+      >
         <BackButton action={() => history.push(AuthPath.Leaving)} />
         <RowJust>
           <RowColumn>
             <Row>
               <Icon src={`${isDarkMode ? posSmesherWhite : posSmesherBlack}`} />
               <RowTitle>WALLET + NODE</RowTitle>
-              <Tooltip width={100} text="WALLET + NODE" isDarkMode={isDarkMode} />
+              <Tooltip
+                width={100}
+                text="WALLET + NODE"
+                isDarkMode={isDarkMode}
+              />
             </Row>
             <RowText>A wallet that uses a local full Spacemesh</RowText>
             <RowText>p2p node and optionally setup smeshing</RowText>
           </RowColumn>
-          <Button text="WALLET + NODE" width={150} isPrimary={false} onClick={handleNextStep(false)} />
+          <Button
+            text="WALLET + NODE"
+            width={150}
+            isPrimary={false}
+            onClick={handleNextStep(false)}
+          />
         </RowJust>
         <RowSecond>
           <RowColumn>
             <Row>
-              <IconWallet src={`${isDarkMode ? walletSecondWhite : walletSecondBlack}`} />
+              <IconWallet
+                src={`${isDarkMode ? walletSecondWhite : walletSecondBlack}`}
+              />
               <RowTitle>WALLET ONLY</RowTitle>
               <Tooltip width={100} text="Wallet only" isDarkMode={isDarkMode} />
             </Row>
             <RowText>Setup a wallet that uses a public</RowText>
             <RowText>Spacemesh web service</RowText>
           </RowColumn>
-          <Button text="WALLET ONLY" width={150} onClick={handleNextStep(true)} />
+          <Button
+            text="WALLET ONLY"
+            width={150}
+            onClick={handleNextStep(true)}
+          />
         </RowSecond>
         <BottomPart>
-          <Link onClick={navigateToExplanation} text="NOT SURE WHAT TO DO? READ THE GUIDE " />
+          <Link
+            onClick={navigateToExplanation}
+            text="NOT SURE WHAT TO DO? READ THE GUIDE "
+          />
           <Row>
-            <Link onClick={() => history.push(AuthPath.Recover)} text="RESTORE EXISTING WALLET" />
-            <Tooltip width={100} text="RESTORE EXISTING WALLET" isDarkMode={isDarkMode} />
+            <Link
+              onClick={() => history.push(AuthPath.Recover)}
+              text="RESTORE EXISTING WALLET"
+            />
+            <Tooltip
+              width={100}
+              text="RESTORE EXISTING WALLET"
+              isDarkMode={isDarkMode}
+            />
           </Row>
         </BottomPart>
       </CorneredContainer>

--- a/app/screens/auth/WalletType.tsx
+++ b/app/screens/auth/WalletType.tsx
@@ -66,7 +66,8 @@ const RowSecond = styled.div`
   &:after {
     content: '';
     position: absolute;
-    background-color: ${({ theme }) => (theme.isDarkMode ? smColors.darkerGray : smColors.black)};
+    background-color: ${({ theme }) =>
+      theme.isDarkMode ? smColors.darkerGray : smColors.black};
     width: 100%;
     top: -29px;
     left: 0;
@@ -106,41 +107,78 @@ const WalletType = ({ history, location }: AuthRouterParams) => {
 
   const navigateToCreateWallet = async () => {
     const { isWalletOnly } = location.state;
-    history.push(AuthPath.SwitchNetwork, { ...(isWalletOnly ? { isWalletOnly } : { redirect: AuthPath.CreateWallet }), creatingWallet: true });
+    history.push(AuthPath.SwitchNetwork, {
+      ...(isWalletOnly
+        ? { isWalletOnly }
+        : { redirect: AuthPath.CreateWallet }),
+      creatingWallet: true,
+    });
   };
 
   return (
     <Wrapper>
       <Steps step={Step.NEW_WALLET_TYPE} isDarkMode={isDarkMode} />
-      <CorneredContainer width={650} height={400} header="WALLET SETUP" subHeader="Select which features you`d like to setup" isDarkMode={isDarkMode}>
+      <CorneredContainer
+        width={650}
+        height={400}
+        header="WALLET SETUP"
+        subHeader="Select which features you`d like to setup"
+        isDarkMode={isDarkMode}
+      >
         <BackButton action={history.goBack} />
         <RowJust>
           <RowColumn>
             <Row>
               <Icon src={walletSecondWhite} />
               <RowTitle>STANDARD WALLET</RowTitle>
-              <Tooltip width={100} text="STANDARD WALLET" isDarkMode={isDarkMode} />
+              <Tooltip
+                width={100}
+                text="STANDARD WALLET"
+                isDarkMode={isDarkMode}
+              />
             </Row>
             <PurpleText>(STANDARD SECURITY)</PurpleText>
           </RowColumn>
-          <Button text="STANDARD WALLET" width={150} isPrimary={false} onClick={navigateToCreateWallet} />
+          <Button
+            text="STANDARD WALLET"
+            width={150}
+            isPrimary={false}
+            onClick={navigateToCreateWallet}
+          />
         </RowJust>
         <RowSecond>
           <RowColumn>
             <Row>
               <IconWallet src={walletSecondWhite} />
               <RowTitle>HARDWARE WALLET</RowTitle>
-              <Tooltip width={100} text="HARDWARE WALLET" isDarkMode={isDarkMode} />
+              <Tooltip
+                width={100}
+                text="HARDWARE WALLET"
+                isDarkMode={isDarkMode}
+              />
             </Row>
             <RowText>Using a Ledger device</RowText>
             <GreenText>(ENHANCED SECURITY)</GreenText>
           </RowColumn>
-          <Button text="HARDWARE WALLET" onClick={() => {}} width={150} isDisabled />
+          <Button
+            text="HARDWARE WALLET"
+            onClick={() => {}}
+            width={150}
+            isDisabled
+          />
         </RowSecond>
         <BottomPart>
           <Link onClick={navigateToExplanation} text="WALLET SETUP GUIDE" />
           <Row>
-            <Link onClick={() => history.push(AuthPath.Recover)} text="RESTORE  WALLET" /> <Tooltip width={100} text="RESTORE EXISTING WALLET" isDarkMode={isDarkMode} />
+            <Link
+              onClick={() => history.push(AuthPath.Recover)}
+              text="RESTORE  WALLET"
+            />{' '}
+            <Tooltip
+              width={100}
+              text="RESTORE EXISTING WALLET"
+              isDarkMode={isDarkMode}
+            />
           </Row>
         </BottomPart>
       </CorneredContainer>

--- a/app/screens/auth/Welcome.tsx
+++ b/app/screens/auth/Welcome.tsx
@@ -4,7 +4,12 @@ import styled from 'styled-components';
 import { CorneredContainer } from '../../components/common';
 import { SubHeader } from '../../components/common/CorneredContainer';
 import { Button, Link, Tooltip } from '../../basicComponents';
-import { bigInnerSideBar, posSmesher, networkPink, walletSecond } from '../../assets/images';
+import {
+  bigInnerSideBar,
+  posSmesher,
+  networkPink,
+  walletSecond,
+} from '../../assets/images';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
 import { AuthPath } from '../../routerPaths';
@@ -25,7 +30,8 @@ const Indicator = styled.div`
   left: -30px;
   width: 16px;
   height: 16px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.black)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.black};
 `;
 
 const Row = styled.div`
@@ -92,7 +98,12 @@ const Welcome = ({ history }: AuthRouterParams) => {
   const navigateToSetupGuide = () => window.open(ExternalLinks.SetupGuide);
 
   return (
-    <CorneredContainer width={760} height={400} header="WELCOME TO SPACEMESH" isDarkMode={isDarkMode}>
+    <CorneredContainer
+      width={760}
+      height={400}
+      header="WELCOME TO SPACEMESH"
+      isDarkMode={isDarkMode}
+    >
       <SubHeaderExt>
         <RowText>
           <span>
@@ -125,10 +136,16 @@ const Welcome = ({ history }: AuthRouterParams) => {
       <BottomPart>
         <Link onClick={navigateToSetupGuide} text="SETUP GUIDE" />
         <ComplexLink>
-          <Link onClick={() => history.push(AuthPath.Recover)} text="OPEN AN EXISTING WALLET" />
+          <Link
+            onClick={() => history.push(AuthPath.Recover)}
+            text="OPEN AN EXISTING WALLET"
+          />
           <Tooltip width={250} text="tooltip" isDarkMode={isDarkMode} />
           <ButtonMargin>
-            <Button text="SETUP" onClick={() => history.push(AuthPath.ConnectionType)} />
+            <Button
+              text="SETUP"
+              onClick={() => history.push(AuthPath.ConnectionType)}
+            />
           </ButtonMargin>
         </ComplexLink>
       </BottomPart>

--- a/app/screens/auth/WordsRestore.tsx
+++ b/app/screens/auth/WordsRestore.tsx
@@ -3,7 +3,13 @@ import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { BackButton } from '../../components/common';
-import { WrapperWith2SideBars, Input, Button, Link, ErrorPopup } from '../../basicComponents';
+import {
+  WrapperWith2SideBars,
+  Input,
+  Button,
+  Link,
+  ErrorPopup,
+} from '../../basicComponents';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
 import { AuthPath } from '../../routerPaths';
@@ -33,7 +39,8 @@ const InputCounter = styled.div`
   width: 25px;
   font-size: 18px;
   line-height: 22px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
   margin-right: 10px;
 `;
 
@@ -44,7 +51,10 @@ const BottomSection = styled.div`
   align-items: flex-end;
 `;
 
-const getInputStyle = (hasError: boolean) => ({ border: `1px dashed ${hasError ? smColors.orange : smColors.darkGray}`, borderRadius: 2 });
+const getInputStyle = (hasError: boolean) => ({
+  border: `1px dashed ${hasError ? smColors.orange : smColors.darkGray}`,
+  borderRadius: 2,
+});
 
 const WordsRestore = ({ history }: AuthRouterParams) => {
   const [words, setWords] = useState(Array(12).fill(''));
@@ -52,7 +62,13 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
 
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
 
-  const handleInputChange = ({ value, index }: { value: string; index: number }) => {
+  const handleInputChange = ({
+    value,
+    index,
+  }: {
+    value: string;
+    index: number;
+  }) => {
     const newWords = [...words];
     newWords[index] = value;
     setWords(newWords);
@@ -60,7 +76,10 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
   };
 
   const isDoneEnabled = () => {
-    return words.every((word: string) => !!word && word.trim().length > 0) || hasError;
+    return (
+      words.every((word: string) => !!word && word.trim().length > 0) ||
+      hasError
+    );
   };
 
   const validateMnemonic = ({ mnemonic }: { mnemonic: string }) => {
@@ -96,7 +115,8 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
     };
   }, [handleKeyUp]);
 
-  const navigateTo12WordRestoreGuide = () => window.open(ExternalLinks.RestoreMnemoGuide);
+  const navigateTo12WordRestoreGuide = () =>
+    window.open(ExternalLinks.RestoreMnemoGuide);
 
   const renderInputs = ({ start }: { start: number }) => {
     const res: Array<any> = [];
@@ -104,7 +124,12 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
       res.push(
         <InputWrapper key={`input${index}`}>
           <InputCounter>{index + 1}</InputCounter>
-          <Input value={words[index]} onChange={({ value }) => handleInputChange({ value, index })} style={getInputStyle(hasError)} autofocus={index === 0} />
+          <Input
+            value={words[index]}
+            onChange={({ value }) => handleInputChange({ value, index })}
+            style={getInputStyle(hasError)}
+            autofocus={index === 0}
+          />
         </InputWrapper>
       );
     }
@@ -113,7 +138,13 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
 
   const isDoneDisabled = !isDoneEnabled();
   return (
-    <WrapperWith2SideBars width={800} height={480} isDarkMode={isDarkMode} header="WALLET 12 WORDS RESTORE" subHeader="Please enter the 12 words in the right order.">
+    <WrapperWith2SideBars
+      width={800}
+      height={480}
+      isDarkMode={isDarkMode}
+      header="WALLET 12 WORDS RESTORE"
+      subHeader="Please enter the 12 words in the right order."
+    >
       <BackButton action={history.goBack} />
       <Table>
         <TableColumn>{renderInputs({ start: 0 })}</TableColumn>
@@ -122,7 +153,11 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
       </Table>
       <BottomSection>
         <Link onClick={navigateTo12WordRestoreGuide} text="12 WORDS GUIDE" />
-        <Button onClick={restoreWith12Words} text="RESTORE" isDisabled={isDoneDisabled} />
+        <Button
+          onClick={restoreWith12Words}
+          text="RESTORE"
+          isDisabled={isDoneDisabled}
+        />
       </BottomSection>
       {hasError && (
         <ErrorPopup

--- a/app/screens/auth/routerParams.ts
+++ b/app/screens/auth/routerParams.ts
@@ -11,4 +11,8 @@ type AuthLocationState = Partial<{
   isWalletOnly: boolean;
 }>;
 
-export type AuthRouterParams = RouteComponentProps<Record<string, any>, StaticContext, AuthLocationState>;
+export type AuthRouterParams = RouteComponentProps<
+  Record<string, any>,
+  StaticContext,
+  AuthLocationState
+>;

--- a/app/screens/backup/Backup.tsx
+++ b/app/screens/backup/Backup.tsx
@@ -15,7 +15,12 @@ const Backup = ({ history }: RouteComponentProps) => (
     <BackButton action={history.goBack} width={7} height={10} />
     <Switch>
       {routes.backup.map((route) => (
-        <Route exact key={route.path} path={route.path} component={route.component} />
+        <Route
+          exact
+          key={route.path}
+          path={route.path}
+          component={route.component}
+        />
       ))}
       <Redirect to="/main/backup/backup-options" />
     </Switch>

--- a/app/screens/backup/BackupOptions.tsx
+++ b/app/screens/backup/BackupOptions.tsx
@@ -3,7 +3,12 @@ import styled from 'styled-components';
 import { RouteComponentProps } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { backupWallet } from '../../redux/wallet/actions';
-import { WrapperWith2SideBars, Button, Link, CorneredWrapper } from '../../basicComponents';
+import {
+  WrapperWith2SideBars,
+  Button,
+  Link,
+  CorneredWrapper,
+} from '../../basicComponents';
 import { smColors } from '../../vars';
 import { AppThDispatch, RootState } from '../../types';
 import { BackupPath } from '../../routerPaths';
@@ -19,7 +24,8 @@ const SmallText = styled.span`
   line-height: 20px;
   margin-bottom: 6px;
   flex: 1;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const GreenText = styled(SmallText)`
@@ -29,7 +35,8 @@ const GreenText = styled(SmallText)`
 const Text = styled.span`
   font-size: 16px;
   line-height: 22px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const BoldText = styled(Text)`
@@ -49,7 +56,8 @@ const MiddleSection = styled.div`
   width: 500px;
   height: 100%;
   padding: 25px 15px 15px 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const MiddleSectionRow = styled.div`
@@ -84,9 +92,17 @@ const BackupOptions = ({ history }: RouteComponentProps) => {
 
   return (
     <Wrapper>
-      <WrapperWith2SideBars width={300} header="WALLET" style={{ marginRight: 10 }} isDarkMode={isDarkMode}>
+      <WrapperWith2SideBars
+        width={300}
+        header="WALLET"
+        style={{ marginRight: 10 }}
+        isDarkMode={isDarkMode}
+      >
         <BoldText>How would you like to backup your wallet?</BoldText>
-        <Text>Your wallet is encrypted using your password. We recommend you backup your wallet for additional security.</Text>
+        <Text>
+          Your wallet is encrypted using your password. We recommend you backup
+          your wallet for additional security.
+        </Text>
       </WrapperWith2SideBars>
       <RightSection isDarkMode={isDarkMode}>
         <MiddleSection>
@@ -97,8 +113,19 @@ const BackupOptions = ({ history }: RouteComponentProps) => {
             </SmallText>
           </MiddleSectionRow>
           <MiddleSectionRow>
-            <Button onClick={handleBackupWallet} text="FILE BACKUP" isPrimary={false} isContainerFullWidth style={{ marginRight: 22 }} />
-            <Button onClick={navigateTo12WordsBackup} text="12 WORDS BACKUP" isPrimary={false} isContainerFullWidth />
+            <Button
+              onClick={handleBackupWallet}
+              text="FILE BACKUP"
+              isPrimary={false}
+              isContainerFullWidth
+              style={{ marginRight: 22 }}
+            />
+            <Button
+              onClick={navigateTo12WordsBackup}
+              text="12 WORDS BACKUP"
+              isPrimary={false}
+              isContainerFullWidth
+            />
           </MiddleSectionRow>
           <BottomRow>
             <Link onClick={openBackupGuide} text="BACKUP GUIDE" />

--- a/app/screens/backup/FileBackup.tsx
+++ b/app/screens/backup/FileBackup.tsx
@@ -14,7 +14,8 @@ const Text = styled.span`
   margin-bottom: 10px;
   font-size: 16px;
   line-height: 22px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const MiddleSectionRow = styled.div`
@@ -30,7 +31,14 @@ const BottomRow = styled(MiddleSectionRow)`
   justify-content: space-between;
 `;
 
-const FileBackup = ({ history, location }: RouteComponentProps<Record<string, any>, StaticContext, { filePath: string }>) => {
+const FileBackup = ({
+  history,
+  location,
+}: RouteComponentProps<
+  Record<string, any>,
+  StaticContext,
+  { filePath: string }
+>) => {
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
 
   const showBackupFile = () => {
@@ -44,10 +52,17 @@ const FileBackup = ({ history, location }: RouteComponentProps<Record<string, an
   const openBackupGuide = () => window.open(ExternalLinks.BackupGuide);
 
   return (
-    <WrapperWith2SideBars width={820} header="BACKUP EXISTING WALLET" subHeader="A wallet restore file has been saved." isDarkMode={isDarkMode}>
+    <WrapperWith2SideBars
+      width={820}
+      header="BACKUP EXISTING WALLET"
+      subHeader="A wallet restore file has been saved."
+      isDarkMode={isDarkMode}
+    >
       <Text>A restore file has been created in your documents folder.</Text>
       <Link onClick={showBackupFile} text="Browse file location" />
-      <Text>You can use this file to restore your spacemesh wallet on any computer.</Text>
+      <Text>
+        You can use this file to restore your spacemesh wallet on any computer.
+      </Text>
       <BottomRow>
         <Link onClick={openBackupGuide} text="BACKUP GUIDE" />
         <Button onClick={backToWalletRoot} text="GOT IT" width={95} />

--- a/app/screens/backup/TestMe.tsx
+++ b/app/screens/backup/TestMe.tsx
@@ -1,9 +1,19 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
-import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  DropResult,
+} from 'react-beautiful-dnd';
 import { RouteComponentProps } from 'react-router-dom';
-import { WrapperWith2SideBars, Button, Link, CorneredWrapper } from '../../basicComponents';
+import {
+  WrapperWith2SideBars,
+  Button,
+  Link,
+  CorneredWrapper,
+} from '../../basicComponents';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
 import { WalletPath } from '../../routerPaths';
@@ -13,7 +23,8 @@ const SubHeader = styled.div`
   margin-bottom: 25px;
   font-size: 15px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const Text = styled.span`
@@ -54,7 +65,8 @@ const WordsSection = styled.div`
 `;
 
 const WordContainer = styled.div<{ isDraggingOver?: boolean }>`
-  border: ${({ isDraggingOver }) => (isDraggingOver ? `none` : `1px dashed ${smColors.darkGray}`)};
+  border: ${({ isDraggingOver }) =>
+    isDraggingOver ? `none` : `1px dashed ${smColors.darkGray}`};
   height: 27px;
   width: 155px;
   border-radius: 5px;
@@ -62,7 +74,10 @@ const WordContainer = styled.div<{ isDraggingOver?: boolean }>`
   padding-left: 16px;
 `;
 
-const TestWordContainer = styled(WordContainer)<{ isDropped: boolean; isDragging?: boolean }>`
+const TestWordContainer = styled(WordContainer)<{
+  isDropped: boolean;
+  isDragging?: boolean;
+}>`
   background-color: ${smColors.black};
   ${({ isDropped }) =>
     !isDropped &&
@@ -82,7 +97,10 @@ const TestWordDroppable = styled.div`
   margin-bottom: 30px;
 `;
 
-const WordDroppable = styled.div<{ isDraggingOver: boolean; isDropped: boolean }>`
+const WordDroppable = styled.div<{
+  isDraggingOver: boolean;
+  isDropped: boolean;
+}>`
   height: 27px;
   width: 155px;
   border-radius: 5px;
@@ -109,7 +127,8 @@ const IndexWrapper = styled.div`
 
 const Index = styled(Text)`
   line-height: 26px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.darkGray)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.darkGray};
 `;
 
 const WordWrapper = styled.div`
@@ -131,7 +150,9 @@ const NotificationBox = styled.div`
   color: ${({ color }) => color};
 `;
 
-const getTestWords = (mnemonic: string): Array<{ id: string; content: string }> => {
+const getTestWords = (
+  mnemonic: string
+): Array<{ id: string; content: string }> => {
   const twelveWords = mnemonic.split(' ');
   const indices: Array<number> = [];
   while (indices.length < 4) {
@@ -160,8 +181,12 @@ const TestMe = ({ history, location }: Props) => {
   const {
     state: { mnemonic },
   } = location;
-  const [testWords, setTestWords] = useState<{ id: string; content: string }[]>(getTestWords(mnemonic));
-  const [twelveWords, setTwelveWords] = useState<{ id: string; content: string }[]>(mnemonic.split(' ').map((word: string) => ({ id: word, content: '' })));
+  const [testWords, setTestWords] = useState<{ id: string; content: string }[]>(
+    getTestWords(mnemonic)
+  );
+  const [twelveWords, setTwelveWords] = useState<
+    { id: string; content: string }[]
+  >(mnemonic.split(' ').map((word: string) => ({ id: word, content: '' })));
   const [dropsCounter, setDropsCounter] = useState(0);
   const [matchCounter, setMatchCounter] = useState(0);
 
@@ -171,7 +196,9 @@ const TestMe = ({ history, location }: Props) => {
 
   const resetTest = () => {
     setTestWords(getTestWords(mnemonic));
-    setTwelveWords(mnemonic.split(' ').map((word: string) => ({ id: word, content: '' })));
+    setTwelveWords(
+      mnemonic.split(' ').map((word: string) => ({ id: word, content: '' }))
+    );
     setDropsCounter(0);
     setMatchCounter(0);
   };
@@ -185,20 +212,36 @@ const TestMe = ({ history, location }: Props) => {
   const handleDragEnd = (result: DropResult) => {
     const { source, destination } = result;
     // dropped outside the destination zone
-    if (!destination || !destination.droppableId.startsWith('Droppable_Dest_')) {
+    if (
+      !destination ||
+      !destination.droppableId.startsWith('Droppable_Dest_')
+    ) {
       return;
     }
 
     const wordId = destination.droppableId.split('_').pop() || '';
-    const wordIndex: number = twelveWords.findIndex((word: { id: string; content: string }) => word.id === wordId);
+    const wordIndex: number = twelveWords.findIndex(
+      (word: { id: string; content: string }) => word.id === wordId
+    );
     const droppedWord = source.droppableId.split('_').pop() || '';
-    const isDraggedFromTestWords = source.droppableId.startsWith('Droppable_Src_');
+    const isDraggedFromTestWords = source.droppableId.startsWith(
+      'Droppable_Src_'
+    );
     const droppedWordIndex = isDraggedFromTestWords
-      ? testWords.findIndex((testWord: { id: string; content: string }) => testWord.id === droppedWord)
-      : twelveWords.findIndex((testWord: { id: string; content: string }) => testWord.id === droppedWord);
+      ? testWords.findIndex(
+          (testWord: { id: string; content: string }) =>
+            testWord.id === droppedWord
+        )
+      : twelveWords.findIndex(
+          (testWord: { id: string; content: string }) =>
+            testWord.id === droppedWord
+        );
     const droppedWordFromDropZone = twelveWords[droppedWordIndex].content;
-    const isDropMatch = isDraggedFromTestWords ? droppedWord === destination.droppableId.split('_').pop() : droppedWordFromDropZone === destination.droppableId.split('_').pop();
-    const wasDraggedPreviousMatch = droppedWordFromDropZone === source.droppableId.split('_').pop();
+    const isDropMatch = isDraggedFromTestWords
+      ? droppedWord === destination.droppableId.split('_').pop()
+      : droppedWordFromDropZone === destination.droppableId.split('_').pop();
+    const wasDraggedPreviousMatch =
+      droppedWordFromDropZone === source.droppableId.split('_').pop();
 
     if (twelveWords[wordIndex].content) {
       return;
@@ -208,11 +251,27 @@ const TestMe = ({ history, location }: Props) => {
     let tmpTestWords: Array<{ id: string; content: string }>;
 
     if (isDraggedFromTestWords) {
-      tmpTwelveWords = [...twelveWords.slice(0, wordIndex), { id: wordId, content: droppedWord }, ...twelveWords.slice(wordIndex + 1)];
-      tmpTestWords = [...testWords.slice(0, droppedWordIndex), { id: droppedWord, content: '' }, ...testWords.slice(droppedWordIndex + 1)];
+      tmpTwelveWords = [
+        ...twelveWords.slice(0, wordIndex),
+        { id: wordId, content: droppedWord },
+        ...twelveWords.slice(wordIndex + 1),
+      ];
+      tmpTestWords = [
+        ...testWords.slice(0, droppedWordIndex),
+        { id: droppedWord, content: '' },
+        ...testWords.slice(droppedWordIndex + 1),
+      ];
     } else {
-      tmpTwelveWords = [...twelveWords.slice(0, droppedWordIndex), { id: droppedWord, content: '' }, ...twelveWords.slice(droppedWordIndex + 1)];
-      tmpTestWords = [...tmpTwelveWords.slice(0, wordIndex), { id: wordId, content: droppedWordFromDropZone }, ...tmpTwelveWords.slice(wordIndex + 1)];
+      tmpTwelveWords = [
+        ...twelveWords.slice(0, droppedWordIndex),
+        { id: droppedWord, content: '' },
+        ...twelveWords.slice(droppedWordIndex + 1),
+      ];
+      tmpTestWords = [
+        ...tmpTwelveWords.slice(0, wordIndex),
+        { id: wordId, content: droppedWordFromDropZone },
+        ...tmpTwelveWords.slice(wordIndex + 1),
+      ];
     }
 
     setTwelveWords(tmpTwelveWords);
@@ -233,68 +292,107 @@ const TestMe = ({ history, location }: Props) => {
     <DragDropContext onDragEnd={handleDragEnd}>
       <MiddleSectionRow>
         <TestWordsSection>
-          {testWords.map((word: { id: string; content: string }, index: number) => (
-            <Droppable droppableId={`Droppable_Src_${word.id}`} key={word.id}>
-              {(provided) => (
-                <TestWordDroppable ref={provided.innerRef} {...provided.droppableProps}>
-                  <Draggable draggableId={`Draggable_Src_${word.id}`} index={index}>
-                    {(provided, snapshot) => (
-                      <TestWordContainer
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        {...provided.dragHandleProps}
-                        isDragging={snapshot.isDragging}
-                        isDropped={!!word.content}
-                      >
-                        <WhiteText>{word.content}</WhiteText>
-                      </TestWordContainer>
-                    )}
-                  </Draggable>
-                  {provided.placeholder}
-                </TestWordDroppable>
-              )}
-            </Droppable>
-          ))}
-        </TestWordsSection>
-        <WordsSection>
-          {twelveWords.map((word: { id: string; content: string }, index: number) => (
-            <WordWrapper key={word.id}>
-              <IndexWrapper>
-                <Index>{`${index + 1}`}</Index>
-              </IndexWrapper>
-              <Droppable droppableId={`Droppable_Dest_${word.id}`}>
-                {(provided, snapshot) => (
-                  <WordDroppable ref={provided.innerRef} {...provided.droppableProps} isDraggingOver={snapshot.isDraggingOver} isDropped={!!word.content}>
-                    <Draggable draggableId={`Draggable_Dest_${word.id}`} index={index}>
-                      {(provided) => (
-                        <WordContainer ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps} isDraggingOver={snapshot.isDraggingOver}>
-                          <Text>{word.content}</Text>
-                        </WordContainer>
+          {testWords.map(
+            (word: { id: string; content: string }, index: number) => (
+              <Droppable droppableId={`Droppable_Src_${word.id}`} key={word.id}>
+                {(provided) => (
+                  <TestWordDroppable
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                  >
+                    <Draggable
+                      draggableId={`Draggable_Src_${word.id}`}
+                      index={index}
+                    >
+                      {(provided, snapshot) => (
+                        <TestWordContainer
+                          ref={provided.innerRef}
+                          {...provided.draggableProps}
+                          {...provided.dragHandleProps}
+                          isDragging={snapshot.isDragging}
+                          isDropped={!!word.content}
+                        >
+                          <WhiteText>{word.content}</WhiteText>
+                        </TestWordContainer>
                       )}
                     </Draggable>
-                  </WordDroppable>
+                    {provided.placeholder}
+                  </TestWordDroppable>
                 )}
               </Droppable>
-            </WordWrapper>
-          ))}
+            )
+          )}
+        </TestWordsSection>
+        <WordsSection>
+          {twelveWords.map(
+            (word: { id: string; content: string }, index: number) => (
+              <WordWrapper key={word.id}>
+                <IndexWrapper>
+                  <Index>{`${index + 1}`}</Index>
+                </IndexWrapper>
+                <Droppable droppableId={`Droppable_Dest_${word.id}`}>
+                  {(provided, snapshot) => (
+                    <WordDroppable
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      isDraggingOver={snapshot.isDraggingOver}
+                      isDropped={!!word.content}
+                    >
+                      <Draggable
+                        draggableId={`Draggable_Dest_${word.id}`}
+                        index={index}
+                      >
+                        {(provided) => (
+                          <WordContainer
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            {...provided.dragHandleProps}
+                            isDraggingOver={snapshot.isDraggingOver}
+                          >
+                            <Text>{word.content}</Text>
+                          </WordContainer>
+                        )}
+                      </Draggable>
+                    </WordDroppable>
+                  )}
+                </Droppable>
+              </WordWrapper>
+            )
+          )}
         </WordsSection>
       </MiddleSectionRow>
     </DragDropContext>
   );
 
   return [
-    <WrapperWith2SideBars width={920} header="CONFIRM YOUR 12 WORDS BACKUP" key="1" isDarkMode={isDarkMode}>
-      <SubHeader>Drag each of the four words below to its matching number in your paper backup word list</SubHeader>
+    <WrapperWith2SideBars
+      width={920}
+      header="CONFIRM YOUR 12 WORDS BACKUP"
+      key="1"
+      isDarkMode={isDarkMode}
+    >
+      <SubHeader>
+        Drag each of the four words below to its matching number in your paper
+        backup word list
+      </SubHeader>
       {renderDragAndDropArea()}
       <BottomRow>
         <Link onClick={openBackupGuide} text="BACKUP GUIDE" />
-        <Button onClick={isTestSuccess ? navigateToWallet : resetTest} text={`${isTestSuccess ? 'DONE' : 'TRY AGAIN'}`} isPrimary={isTestSuccess} />
+        <Button
+          onClick={isTestSuccess ? navigateToWallet : resetTest}
+          text={`${isTestSuccess ? 'DONE' : 'TRY AGAIN'}`}
+          isPrimary={isTestSuccess}
+        />
       </BottomRow>
     </WrapperWith2SideBars>,
     dropsCounter === 4 && (
       <NotificationBoxOuter key="2" isDarkMode={isDarkMode}>
-        <NotificationBox color={isTestSuccess ? smColors.green : smColors.orange}>
-          {isTestSuccess ? 'All right! Your 12 word backup is confirmed.' : 'That confirmation isn’t correct, please try again'}
+        <NotificationBox
+          color={isTestSuccess ? smColors.green : smColors.orange}
+        >
+          {isTestSuccess
+            ? 'All right! Your 12 word backup is confirmed.'
+            : 'That confirmation isn’t correct, please try again'}
         </NotificationBox>
       </NotificationBoxOuter>
     ),

--- a/app/screens/backup/TwelveWordsBackup.tsx
+++ b/app/screens/backup/TwelveWordsBackup.tsx
@@ -20,7 +20,8 @@ const TextWrapper = styled.div`
 const Text = styled.span`
   font-size: 14px;
   line-height: 24px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const GreenText = styled.span`
@@ -71,7 +72,8 @@ const IndexWrapper = styled.div`
 `;
 
 const Index = styled(Text)`
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.darkGray)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.darkGray};
 `;
 
 const WordWrapper = styled.div`
@@ -116,17 +118,34 @@ const TwelveWordsBackup = ({ history }: RouteComponentProps) => {
   const openBackupGuide = () => window.open(ExternalLinks.BackupGuide);
 
   return (
-    <WrapperWith2SideBars width={920} header="YOUR 12 WORDS BACKUP" isDarkMode={isDarkMode}>
+    <WrapperWith2SideBars
+      width={920}
+      header="YOUR 12 WORDS BACKUP"
+      isDarkMode={isDarkMode}
+    >
       <TextWrapper>
         <Text>
-          A paper backup is a numbered list of words written down on a paper. Write down or print this numbered word list and store the paper in a a safe place, or copy & paste it
-          into your password manager
+          A paper backup is a numbered list of words written down on a paper.
+          Write down or print this numbered word list and store the paper in a a
+          safe place, or copy & paste it into your password manager
         </Text>
       </TextWrapper>
       <MiddleSectionRow>
         <ButtonsSection>
-          <Button onClick={print12Words} text="PRINT WORDS" width={172} isPrimary={false} style={{ marginBottom: 35 }} />
-          <Button onClick={copy12Words} text="COPY WORDS" width={172} isPrimary={false} style={{ marginBottom: 35 }} />
+          <Button
+            onClick={print12Words}
+            text="PRINT WORDS"
+            width={172}
+            isPrimary={false}
+            style={{ marginBottom: 35 }}
+          />
+          <Button
+            onClick={copy12Words}
+            text="COPY WORDS"
+            width={172}
+            isPrimary={false}
+            style={{ marginBottom: 35 }}
+          />
           {isCopied && <GreenText>Copied to clipboard</GreenText>}
         </ButtonsSection>
         <WordsSection>

--- a/app/screens/contacts/Contacts.tsx
+++ b/app/screens/contacts/Contacts.tsx
@@ -38,7 +38,8 @@ const SubHeader = styled.div`
 const SubHeaderText = styled.div`
   font-size: 15px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const SubHeaderInner = styled.div`
@@ -47,7 +48,10 @@ const SubHeaderInner = styled.div`
   justify-content: space-between;
 `;
 
-const SubHeaderBtnUpperPart = styled.div<{ color?: string; hoverColor?: string }>`
+const SubHeaderBtnUpperPart = styled.div<{
+  color?: string;
+  hoverColor?: string;
+}>`
   position: absolute;
   top: 0;
   left: 5px;
@@ -140,7 +144,8 @@ const ContactsSubHeaderText = styled.div`
   font-family: SourceCodeProBold;
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
   margin-right: 20px;
 `;
 
@@ -179,7 +184,8 @@ const ContactText = styled.div`
   flex: 1;
   font-size: 16px;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.grey100Alpha)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.grey100Alpha};
   :nth-child(3) {
     justify-content: center;
   }
@@ -224,7 +230,9 @@ const SortingElement = styled.div<{ isInDropDown?: boolean }>`
   color: ${smColors.black};
   padding: 5px;
   cursor: inherit;
-  ${({ isInDropDown }) => isInDropDown && `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
+  ${({ isInDropDown }) =>
+    isInDropDown &&
+    `opacity: 0.5; border-bottom: 1px solid ${smColors.disabledGray};`}
   &:hover {
     opacity: 1;
     color: ${smColors.darkGray50Alpha};
@@ -258,15 +266,22 @@ const Contacts = ({ history }: RouteComponentProps) => {
   const [addressToAdd, setAddressToAdd] = useState('');
   const [tmpSearchTerm, setTmpSearchTerm] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
-  const [showCreateNewContactModal, setShowCreateNewContactModal] = useState(false);
+  const [showCreateNewContactModal, setShowCreateNewContactModal] = useState(
+    false
+  );
   const [selectedSorting, setSelectedSorting] = useState(0);
   const [isNewContactCreated, setIsNewContactCreated] = useState(false);
   const [shouldShowPasswordModal, setShouldShowPasswordModal] = useState(false);
-  const [contactForDelete, setContactForDelete] = useState({ address: '', nickname: '' });
+  const [contactForDelete, setContactForDelete] = useState({
+    address: '',
+    nickname: '',
+  });
   const dispatch = useDispatch();
 
   const contacts = useSelector((state: RootState) => state.wallet.contacts);
-  const lastUsedContacts = useSelector((state: RootState) => state.wallet.lastUsedContacts);
+  const lastUsedContacts = useSelector(
+    (state: RootState) => state.wallet.lastUsedContacts
+  );
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
 
   useEffect(() => {
@@ -278,8 +293,10 @@ const Contacts = ({ history }: RouteComponentProps) => {
   });
 
   const contactFilter = (contact: Contact) => {
-    const nicknameMatch = contact.nickname && contact.nickname.toLowerCase().includes(searchTerm);
-    const addressMatch = contact.address && contact.address.toLowerCase().includes(searchTerm);
+    const nicknameMatch =
+      contact.nickname && contact.nickname.toLowerCase().includes(searchTerm);
+    const addressMatch =
+      contact.address && contact.address.toLowerCase().includes(searchTerm);
     return nicknameMatch || addressMatch;
   };
 
@@ -338,14 +355,36 @@ const Contacts = ({ history }: RouteComponentProps) => {
     if (lastUsedContacts && lastUsedContacts.length) {
       // @ts-ignore
       return lastUsedContacts.map((contact: Contact) => (
-        <SubHeaderBtnWrapper color={smColors.realBlack} onClick={() => navigateToSendCoins({ contact })} key={contact.address}>
-          <SubHeaderBtnUpperPart color={smColors.black} hoverColor={smColors.realBlack}>
+        <SubHeaderBtnWrapper
+          color={smColors.realBlack}
+          onClick={() => navigateToSendCoins({ contact })}
+          key={contact.address}
+        >
+          <SubHeaderBtnUpperPart
+            color={smColors.black}
+            hoverColor={smColors.realBlack}
+          >
             <ClockImg src={clock} />
-            <LastUsedNickname>{contact.nickname || 'UNKNOWN ADDRESS'}</LastUsedNickname>
-            <LastUsedAddress>{getAbbreviatedText(contact.address)}</LastUsedAddress>
-            {!contact.nickname && <LastUsedAddContact onClick={(e: React.MouseEvent) => openAddNewContactModal(e, contact)}>+</LastUsedAddContact>}
+            <LastUsedNickname>
+              {contact.nickname || 'UNKNOWN ADDRESS'}
+            </LastUsedNickname>
+            <LastUsedAddress>
+              {getAbbreviatedText(contact.address)}
+            </LastUsedAddress>
+            {!contact.nickname && (
+              <LastUsedAddContact
+                onClick={(e: React.MouseEvent) =>
+                  openAddNewContactModal(e, contact)
+                }
+              >
+                +
+              </LastUsedAddContact>
+            )}
           </SubHeaderBtnUpperPart>
-          <SubHeaderBtnLowerPart color={smColors.black} hoverColor={smColors.realBlack} />
+          <SubHeaderBtnLowerPart
+            color={smColors.black}
+            hoverColor={smColors.realBlack}
+          />
         </SubHeaderBtnWrapper>
       ));
     }
@@ -354,10 +393,21 @@ const Contacts = ({ history }: RouteComponentProps) => {
 
   const renderSubHeader = () => {
     if (showCreateNewContactModal) {
-      return <CreateNewContact initialAddress={addressToAdd} onCompleteAction={createdNewContact} onCancel={cancelCreateNewContact} />;
+      return (
+        <CreateNewContact
+          initialAddress={addressToAdd}
+          onCompleteAction={createdNewContact}
+          onCancel={cancelCreateNewContact}
+        />
+      );
     }
     if (isNewContactCreated) {
-      return <CreatedNewContact contact={contacts[0]} action={() => navigateToSendCoins({ contact: contacts[0] })} />;
+      return (
+        <CreatedNewContact
+          contact={contacts[0]}
+          action={() => navigateToSendCoins({ contact: contacts[0] })}
+        />
+      );
     }
     return (
       <SubHeader>
@@ -367,15 +417,24 @@ const Contacts = ({ history }: RouteComponentProps) => {
           --
         </SubHeaderText>
         <SubHeaderInner>
-          <SubHeaderBtnWrapper onClick={() => setShowCreateNewContactModal(true)} color={smColors.darkerPurple}>
-            <SubHeaderBtnUpperPart color={smColors.purple} hoverColor={smColors.darkerPurple}>
+          <SubHeaderBtnWrapper
+            onClick={() => setShowCreateNewContactModal(true)}
+            color={smColors.darkerPurple}
+          >
+            <SubHeaderBtnUpperPart
+              color={smColors.purple}
+              hoverColor={smColors.darkerPurple}
+            >
               <CreateNewContactText>
                 CREATE NEW
                 <br />
                 CONTACT
               </CreateNewContactText>
             </SubHeaderBtnUpperPart>
-            <SubHeaderBtnLowerPart color={smColors.purple} hoverColor={smColors.darkerPurple} />
+            <SubHeaderBtnLowerPart
+              color={smColors.purple}
+              hoverColor={smColors.darkerPurple}
+            />
           </SubHeaderBtnWrapper>
           {renderLastUsedContacts()}
         </SubHeaderInner>
@@ -383,7 +442,13 @@ const Contacts = ({ history }: RouteComponentProps) => {
     );
   };
 
-  const renderSortElementElement = ({ label, isMain }: { label: string; isMain: boolean }) => (
+  const renderSortElementElement = ({
+    label,
+    isMain,
+  }: {
+    label: string;
+    isMain: boolean;
+  }) => (
     <SortingElement key={label} isInDropDown={!isMain}>
       {label}
     </SortingElement>
@@ -392,7 +457,9 @@ const Contacts = ({ history }: RouteComponentProps) => {
   const renderContacts = () => {
     const filteredContacts = contacts.filter(contactFilter);
     if (filteredContacts.length === 0) {
-      return <ContactText>{`No contacts matching criteria "${searchTerm}" found`}</ContactText>;
+      return (
+        <ContactText>{`No contacts matching criteria "${searchTerm}" found`}</ContactText>
+      );
     }
     const sortedContacts = filteredContacts.sort(sortContacts);
     return (
@@ -406,7 +473,9 @@ const Contacts = ({ history }: RouteComponentProps) => {
           {sortedContacts.map((contact: Contact) => (
             <ContactRow key={`${contact.nickname}_${contact.address}`}>
               <ContactText onClick={() => navigateToSendCoins({ contact })}>
-                <TextCursorPointer>{contact.nickname || 'UNKNOWN ADDRESS'}</TextCursorPointer>
+                <TextCursorPointer>
+                  {contact.nickname || 'UNKNOWN ADDRESS'}
+                </TextCursorPointer>
               </ContactText>
               <ContactText>
                 <Address full address={contact.address} />
@@ -414,7 +483,14 @@ const Contacts = ({ history }: RouteComponentProps) => {
               <DeleteText onClick={() => handleDeleteButton(contact)}>
                 <TextCursorPointer>DELETE</TextCursorPointer>
               </DeleteText>
-              {!contact.nickname && <CreateNewContactImg onClick={(e: React.MouseEvent) => openAddNewContactModal(e, contact)} src={addContact} />}
+              {!contact.nickname && (
+                <CreateNewContactImg
+                  onClick={(e: React.MouseEvent) =>
+                    openAddNewContactModal(e, contact)
+                  }
+                  src={addContact}
+                />
+              )}
             </ContactRow>
           ))}
         </ContactsList>
@@ -423,7 +499,12 @@ const Contacts = ({ history }: RouteComponentProps) => {
   };
 
   return (
-    <WrapperWith2SideBars width={1000} height={500} header="CONTACTS" isDarkMode={isDarkMode}>
+    <WrapperWith2SideBars
+      width={1000}
+      height={500}
+      header="CONTACTS"
+      isDarkMode={isDarkMode}
+    >
       <SearchWrapper>
         <SearchIcon src={searchIcon} />
         <Input
@@ -452,8 +533,21 @@ const Contacts = ({ history }: RouteComponentProps) => {
           bgColor={smColors.white}
         />
       </ContactsSubHeader>
-      {contacts && contacts.length ? renderContacts() : <ContactText>{searchTerm ? 'No contacts matching criteria' : 'No contacts added yet'}</ContactText>}
-      {shouldShowPasswordModal && <EnterPasswordModal submitAction={deleteContact} closeModal={() => setShouldShowPasswordModal(false)} />}
+      {contacts && contacts.length ? (
+        renderContacts()
+      ) : (
+        <ContactText>
+          {searchTerm
+            ? 'No contacts matching criteria'
+            : 'No contacts added yet'}
+        </ContactText>
+      )}
+      {shouldShowPasswordModal && (
+        <EnterPasswordModal
+          submitAction={deleteContact}
+          closeModal={() => setShouldShowPasswordModal(false)}
+        />
+      )}
     </WrapperWith2SideBars>
   );
 };

--- a/app/screens/dashboard/Dashboard.tsx
+++ b/app/screens/dashboard/Dashboard.tsx
@@ -23,7 +23,13 @@ const Dashboard = () => {
     return eventsService.destroyBrowserView;
   }, [isDarkMode]);
 
-  return <AnimatedIcon size={250} src={isDarkMode ? loaderWhite : loader} alt="Loading" />;
+  return (
+    <AnimatedIcon
+      size={250}
+      src={isDarkMode ? loaderWhite : loader}
+      alt="Loading"
+    />
+  );
 };
 
 export default Dashboard;

--- a/app/screens/index.ts
+++ b/app/screens/index.ts
@@ -15,7 +15,13 @@ export {
 export { Main } from './main';
 export { Node, NodeSetup } from './node';
 export { Wallet, Overview, SendCoins, RequestCoins, Vault } from './wallet';
-export { Backup, BackupOptions, TwelveWordsBackup, TestMe, FileBackup } from './backup';
+export {
+  Backup,
+  BackupOptions,
+  TwelveWordsBackup,
+  TestMe,
+  FileBackup,
+} from './backup';
 export { Transactions } from './transactions';
 export { Contacts } from './contacts';
 export { Network } from './network';

--- a/app/screens/main/Main.tsx
+++ b/app/screens/main/Main.tsx
@@ -4,7 +4,12 @@ import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { logout } from '../../redux/auth/actions';
 import { Logo } from '../../components/common';
-import { SecondaryButton, NavTooltip, NetworkIndicator, SmallHorizontalPanel } from '../../basicComponents';
+import {
+  SecondaryButton,
+  NavTooltip,
+  NetworkIndicator,
+  SmallHorizontalPanel,
+} from '../../basicComponents';
 import { AuthPath, MainPath } from '../../routerPaths';
 import routes from '../../routes';
 import {
@@ -77,7 +82,8 @@ const NavBarLink = styled.div<{ isActive?: boolean }>`
   line-height: 15px;
   text-decoration-line: ${({ isActive }) => (isActive ? 'underline' : 'none')};
   text-transform: uppercase;
-  color: ${({ isActive }) => (isActive ? smColors.purple : smColors.navLinkGrey)};
+  color: ${({ isActive }) =>
+    isActive ? smColors.purple : smColors.navLinkGrey};
   cursor: pointer;
 `;
 
@@ -128,7 +134,14 @@ type State = {
 };
 
 class Main extends Component<Props, State> {
-  private static readonly navRoutes = [MainPath.Smeshing, MainPath.Network, MainPath.Wallet, MainPath.Contacts, MainPath.Dashboard, MainPath.Settings];
+  private static readonly navRoutes = [
+    MainPath.Smeshing,
+    MainPath.Network,
+    MainPath.Wallet,
+    MainPath.Contacts,
+    MainPath.Dashboard,
+    MainPath.Settings,
+  ];
 
   constructor(props: Props) {
     super(props);
@@ -149,8 +162,14 @@ class Main extends Component<Props, State> {
     const signOut = isDarkMode ? signOutIconBlack : signOutIcon;
     const bntStyle = { marginRight: 15, marginTop: 10 };
     const bgColor = isDarkMode ? smColors.white : smColors.black;
-    // eslint-disable-next-line no-nested-ternary
-    const indicatorColor = nodeError || netId === -1 ? smColors.red : isWalletOnly || status?.isSynced ? smColors.green : smColors.orange;
+    /* eslint-disable no-nested-ternary */
+    const indicatorColor =
+      nodeError || netId === -1
+        ? smColors.red
+        : isWalletOnly || status?.isSynced
+        ? smColors.green
+        : smColors.orange;
+    /* eslint-enable no-nested-ternary */
 
     return (
       <Wrapper>
@@ -159,7 +178,11 @@ class Main extends Component<Props, State> {
           <NavBar>
             <NavBarPart>
               <NavLinksWrapper>
-                {this.renderNavBarLink('SMESHING', 'MANAGE SMESHING', MainPath.Smeshing)}
+                {this.renderNavBarLink(
+                  'SMESHING',
+                  'MANAGE SMESHING',
+                  MainPath.Smeshing
+                )}
                 {this.renderNavBarLink(
                   <>
                     <NetworkIndicator color={indicatorColor} />
@@ -168,8 +191,16 @@ class Main extends Component<Props, State> {
                   'NETWORK',
                   MainPath.Network
                 )}
-                {this.renderNavBarLink('WALLET', 'SEND / RECEIVE SMH', MainPath.Wallet)}
-                {this.renderNavBarLink('CONTACTS', 'MANAGE CONTACTS', MainPath.Contacts)}
+                {this.renderNavBarLink(
+                  'WALLET',
+                  'SEND / RECEIVE SMH',
+                  MainPath.Wallet
+                )}
+                {this.renderNavBarLink(
+                  'CONTACTS',
+                  'MANAGE CONTACTS',
+                  MainPath.Contacts
+                )}
                 {this.renderNavBarLink('DASH', 'DASHBOARD', MainPath.Dashboard)}
               </NavLinksWrapper>
             </NavBarPart>
@@ -190,7 +221,9 @@ class Main extends Component<Props, State> {
               </TooltipWrapper>
               <TooltipWrapper>
                 <SecondaryButton
-                  onClick={() => this.handleOpenLink(ExternalLinks.GetCoinGuide)}
+                  onClick={() =>
+                    this.handleOpenLink(ExternalLinks.GetCoinGuide)
+                  }
                   img={getCoins}
                   imgHeight={30}
                   imgWidth={30}
@@ -236,7 +269,11 @@ class Main extends Component<Props, State> {
             <SmallHorizontalPanel isDarkMode={isDarkMode} />
             <Switch>
               {routes.main.map((route) => (
-                <Route key={route.path} path={route.path} component={route.component} />
+                <Route
+                  key={route.path}
+                  path={route.path}
+                  component={route.component}
+                />
               ))}
             </Switch>
           </RoutesWrapper>
@@ -253,11 +290,18 @@ class Main extends Component<Props, State> {
     getNetworkDefinitions();
   }
 
-  renderNavBarLink = (label: string | ReactNode, tooltip: string, route: string) => {
+  renderNavBarLink = (
+    label: string | ReactNode,
+    tooltip: string,
+    route: string
+  ) => {
     const { isDarkMode } = this.props;
     return (
       <TooltipWrapper>
-        <NavBarLink onClick={() => this.handleNavRoute(route)} isActive={this.isActive(route)}>
+        <NavBarLink
+          onClick={() => this.handleNavRoute(route)}
+          isActive={this.isActive(route)}
+        >
           {label}
         </NavBarLink>
         <CustomTooltip text={tooltip} isDarkMode={isDarkMode} />
@@ -267,11 +311,14 @@ class Main extends Component<Props, State> {
 
   static getDerivedStateFromProps(props: Props) {
     const { pathname } = props.location;
-    const nextActiveIndex = Main.navRoutes.findIndex((route) => pathname.startsWith(route));
+    const nextActiveIndex = Main.navRoutes.findIndex((route) =>
+      pathname.startsWith(route)
+    );
     return { activeRouteIndex: nextActiveIndex };
   }
 
-  getRouteIndex = (route: string) => Main.navRoutes.findIndex((navRoute) => navRoute.startsWith(route));
+  getRouteIndex = (route: string) =>
+    Main.navRoutes.findIndex((navRoute) => navRoute.startsWith(route));
 
   handleNavRoute = (route: string) => {
     if (this.isActive(route)) return;

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -2,9 +2,18 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import { eventsService } from '../../infra/eventsService';
-import { getCurrentLayer, getNetworkDefinitions } from '../../redux/network/actions';
+import {
+  getCurrentLayer,
+  getNetworkDefinitions,
+} from '../../redux/network/actions';
 import { NetworkStatus } from '../../components/NetworkStatus';
-import { WrapperWith2SideBars, Link, Tooltip, CustomTimeAgo, Button } from '../../basicComponents';
+import {
+  WrapperWith2SideBars,
+  Link,
+  Tooltip,
+  CustomTimeAgo,
+  Button,
+} from '../../basicComponents';
 import { smColors } from '../../vars';
 import { network } from '../../assets/images';
 import { RootState } from '../../types';
@@ -39,7 +48,10 @@ const DetailsRow = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  border-bottom: ${({ theme }) => `1px solid ${theme.isDarkMode ? smColors.white : smColors.darkGray10Alpha};`};
+  border-bottom: ${({ theme }) =>
+    `1px solid ${
+      theme.isDarkMode ? smColors.white : smColors.darkGray10Alpha
+    };`};
   &:last-child {
     border-bottom-color: transparent;
   }
@@ -49,7 +61,8 @@ const DetailsText = styled.div`
   font-size: 16px;
   line-height: 20px;
   margin: 10px 0;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const GrayText = styled.div`
@@ -58,7 +71,8 @@ const GrayText = styled.div`
   align-items: center;
   font-size: 14px;
   text-transform: uppercase;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.dark75Alpha)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.dark75Alpha};
 `;
 
 const DetailsTextWrap = styled.div`
@@ -74,7 +88,9 @@ const Network = ({ history }) => {
   const status = useSelector((state: RootState) => state.node.status);
   const nodeError = useSelector((state: RootState) => state.node.error);
   const netId = useSelector((state: RootState) => state.network.netId || -1);
-  const netName = useSelector((state: RootState) => state.network.netName || 'UNKNOWN NETWORK NAME');
+  const netName = useSelector(
+    (state: RootState) => state.network.netName || 'UNKNOWN NETWORK NAME'
+  );
 
   useEffect(() => {
     if (netId > -1) {
@@ -83,7 +99,9 @@ const Network = ({ history }) => {
     }
   }, [netId, dispatch]);
 
-  const genesisTime = useSelector((state: RootState) => state.network.genesisTime);
+  const genesisTime = useSelector(
+    (state: RootState) => state.network.genesisTime
+  );
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
   const remoteApi = useSelector(getRemoteApi);
   const [isRestarting, setRestarting] = useState(false);
@@ -102,9 +120,22 @@ const Network = ({ history }) => {
     if (!nodeError) return null;
 
     return isWalletMode ? (
-      <Button text="SWITCH API PROVIDER" width={150} isPrimary onClick={requestSwitchApiProvider} style={{ marginLeft: 'auto' }} />
+      <Button
+        text="SWITCH API PROVIDER"
+        width={150}
+        isPrimary
+        onClick={requestSwitchApiProvider}
+        style={{ marginLeft: 'auto' }}
+      />
     ) : (
-      <Button text={isRestarting ? 'RESTARTING...' : 'RESTART NODE'} width={150} isPrimary onClick={requestNodeRestart} style={{ marginLeft: 'auto' }} isDisabled={isRestarting} />
+      <Button
+        text={isRestarting ? 'RESTARTING...' : 'RESTART NODE'}
+        width={150}
+        isPrimary
+        onClick={requestNodeRestart}
+        style={{ marginLeft: 'auto' }}
+        isDisabled={isRestarting}
+      />
     );
   };
 
@@ -125,35 +156,60 @@ const Network = ({ history }) => {
           <Tooltip width={250} text="tooltip Status" isDarkMode={isDarkMode} />
         </DetailsTextWrap>
         <GrayText>
-          <NetworkStatus status={status} error={nodeError} isRestarting={isRestarting} isWalletMode={isWalletMode} />
+          <NetworkStatus
+            status={status}
+            error={nodeError}
+            isRestarting={isRestarting}
+            isWalletMode={isWalletMode}
+          />
         </GrayText>
       </DetailsRow>
       <DetailsRow>
         <DetailsTextWrap>
           <DetailsText>Current Layer</DetailsText>
-          <Tooltip width={250} text="tooltip Current Layer" isDarkMode={isDarkMode} />
+          <Tooltip
+            width={250}
+            text="tooltip Current Layer"
+            isDarkMode={isDarkMode}
+          />
         </DetailsTextWrap>
         <GrayText>{status?.topLayer || 0}</GrayText>
       </DetailsRow>
       <DetailsRow>
         <DetailsTextWrap>
           <DetailsText>Verified Layer</DetailsText>
-          <Tooltip width={250} text="tooltip Verified Layer" isDarkMode={isDarkMode} />
+          <Tooltip
+            width={250}
+            text="tooltip Verified Layer"
+            isDarkMode={isDarkMode}
+          />
         </DetailsTextWrap>
         <GrayText>{status?.verifiedLayer || 0}</GrayText>
       </DetailsRow>
       <DetailsRow>
         <DetailsTextWrap>
           <DetailsText>Connection Type</DetailsText>
-          <Tooltip width={250} text="tooltip Connection Type" isDarkMode={isDarkMode} />
+          <Tooltip
+            width={250}
+            text="tooltip Connection Type"
+            isDarkMode={isDarkMode}
+          />
         </DetailsTextWrap>
-        <GrayText>{isWalletMode ? `Remote API provider: ${remoteApi}` : 'Managed p2p node'}</GrayText>
+        <GrayText>
+          {isWalletMode
+            ? `Remote API provider: ${remoteApi}`
+            : 'Managed p2p node'}
+        </GrayText>
       </DetailsRow>
       {!isWalletMode && (
         <DetailsRow>
           <DetailsTextWrap>
             <DetailsText>Connected neighbors</DetailsText>
-            <Tooltip width={250} text="tooltip Connected neighbors" isDarkMode={isDarkMode} />
+            <Tooltip
+              width={250}
+              text="tooltip Connected neighbors"
+              isDarkMode={isDarkMode}
+            />
           </DetailsTextWrap>
           <GrayText>8</GrayText>
         </DetailsRow>
@@ -164,7 +220,12 @@ const Network = ({ history }) => {
   const renderNoNetwork = () => (
     <DetailsWrap>
       <DetailsRow>
-        <Button text="CHOOSE THE NETWORK" width={150} isPrimary onClick={() => goToSwitchNetwork(history, isWalletMode)} />
+        <Button
+          text="CHOOSE THE NETWORK"
+          width={150}
+          isPrimary
+          onClick={() => goToSwitchNetwork(history, isWalletMode)}
+        />
       </DetailsRow>
     </DetailsWrap>
   );
@@ -174,7 +235,12 @@ const Network = ({ history }) => {
   };
 
   return (
-    <WrapperWith2SideBars width={1000} header="NETWORK" headerIcon={network} isDarkMode={isDarkMode}>
+    <WrapperWith2SideBars
+      width={1000}
+      header="NETWORK"
+      headerIcon={network}
+      isDarkMode={isDarkMode}
+    >
       <SubHeader>
         {netName}
         {nodeError && <ErrorMessage>{nodeError.msg}</ErrorMessage>}
@@ -182,8 +248,14 @@ const Network = ({ history }) => {
       <Container>
         {netId > -1 ? renderNetworkDetails() : renderNoNetwork()}
         <FooterWrap>
-          {!isWalletMode && <Link onClick={openLogFile} text="BROWSE LOG FILE" />}
-          <Tooltip width={250} text="tooltip BROWSE LOG FILE" isDarkMode={isDarkMode} />
+          {!isWalletMode && (
+            <Link onClick={openLogFile} text="BROWSE LOG FILE" />
+          )}
+          <Tooltip
+            width={250}
+            text="tooltip BROWSE LOG FILE"
+            isDarkMode={isDarkMode}
+          />
           {renderActionButton()}
         </FooterWrap>
       </Container>

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -3,10 +3,24 @@ import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { SmesherIntro } from '../../components/node';
-import { WrapperWith2SideBars, Button, ProgressBar, Link } from '../../basicComponents';
+import {
+  WrapperWith2SideBars,
+  Button,
+  ProgressBar,
+  Link,
+} from '../../basicComponents';
 import { hideSmesherLeftPanel, setUiError } from '../../redux/ui/actions';
 import { formatBytes, getFormattedTimestamp } from '../../infra/utils';
-import { posIcon, posSmesher, posDirectoryBlack, posDirectoryWhite, pauseIcon, playIcon, walletSecond, posSmesherOrange } from '../../assets/images';
+import {
+  posIcon,
+  posSmesher,
+  posDirectoryBlack,
+  posDirectoryWhite,
+  pauseIcon,
+  playIcon,
+  walletSecond,
+  posSmesherOrange,
+} from '../../assets/images';
 import { smColors } from '../../vars';
 import { BITS, RootState } from '../../types';
 import { HexString, NodeStatus, PostSetupState } from '../../../shared/types';
@@ -29,7 +43,8 @@ const Text = styled.div`
   font-size: 15px;
   display: flex;
   line-height: 20px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
   &.progress {
     min-width: 170px;
   }
@@ -94,7 +109,8 @@ const LineWrap = styled.div`
     left: 0;
     width: 100%;
     height: 1px;
-    background: ${({ theme }) => (theme.isDarkMode ? smColors.disabledGray10Alpha : smColors.black)};
+    background: ${({ theme }) =>
+      theme.isDarkMode ? smColors.disabledGray10Alpha : smColors.black};
   }
 `;
 
@@ -182,7 +198,15 @@ const getStatus = (state: PostSetupState, isPaused: boolean) => {
   }
 };
 
-const SmesherStatus = ({ smesherId, status, networkName }: { smesherId: HexString; status: NodeStatus | null; networkName: string }) => (
+const SmesherStatus = ({
+  smesherId,
+  status,
+  networkName,
+}: {
+  smesherId: HexString;
+  status: NodeStatus | null;
+  networkName: string;
+}) => (
   <SubHeader>
     Smesher
     <SmesherId>
@@ -203,14 +227,20 @@ const Node = ({ history, location }: Props) => {
   const coinbase = useSelector((state: RootState) => state.smesher.coinbase);
   const posDataPath = useSelector((state: RootState) => state.smesher.dataDir);
   const smesherConfig = useSelector((state: RootState) => state.smesher.config);
-  const commitmentSize = useSelector((state: RootState) => state.smesher.commitmentSize);
+  const commitmentSize = useSelector(
+    (state: RootState) => state.smesher.commitmentSize
+  );
   const isSmeshing = useSelector(SmesherSelectors.isSmeshing);
   const isCreatingPostData = useSelector(SmesherSelectors.isCreatingPostData);
   const isPausedSmeshing = useSelector(SmesherSelectors.isSmeshingPaused);
   const postProgressError = useSelector(SmesherSelectors.getPostProgressError);
   const isSmesherActive = isSmeshing || isCreatingPostData || isPausedSmeshing;
-  const postSetupState = useSelector((state: RootState) => state.smesher.postSetupState);
-  const numLabelsWritten = useSelector((state: RootState) => state.smesher.numLabelsWritten);
+  const postSetupState = useSelector(
+    (state: RootState) => state.smesher.postSetupState
+  );
+  const numLabelsWritten = useSelector(
+    (state: RootState) => state.smesher.numLabelsWritten
+  );
   // const rewards = useSelector((state: RootState) => state.smesher.rewards);
   // const rewardsAddress = useSelector((state: RootState) => state.node.rewardsAddress);
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
@@ -219,9 +249,15 @@ const Node = ({ history, location }: Props) => {
   const dispatch = useDispatch();
 
   let smesherInitTimestamp = localStorage.getItem('smesherInitTimestamp');
-  smesherInitTimestamp = smesherInitTimestamp ? getFormattedTimestamp(JSON.parse(smesherInitTimestamp)) : '';
-  let smesherSmeshingTimestamp = localStorage.getItem('smesherSmeshingTimestamp');
-  smesherSmeshingTimestamp = smesherSmeshingTimestamp ? getFormattedTimestamp(JSON.parse(smesherSmeshingTimestamp)) : '';
+  smesherInitTimestamp = smesherInitTimestamp
+    ? getFormattedTimestamp(JSON.parse(smesherInitTimestamp))
+    : '';
+  let smesherSmeshingTimestamp = localStorage.getItem(
+    'smesherSmeshingTimestamp'
+  );
+  smesherSmeshingTimestamp = smesherSmeshingTimestamp
+    ? getFormattedTimestamp(JSON.parse(smesherSmeshingTimestamp))
+    : '';
 
   type RowData = [string, string | JSX.Element];
   const renderTable = (data: RowData[]) =>
@@ -237,10 +273,18 @@ const Node = ({ history, location }: Props) => {
     });
 
   const getTableData = (): RowData[] => {
-    const setupStarted: RowData[] = smesherInitTimestamp ? [['Setup Started', smesherInitTimestamp]] : [];
-    const setupFinished: RowData[] = isSmeshing && smesherSmeshingTimestamp ? [['Setup Finished', smesherSmeshingTimestamp]] : [];
+    const setupStarted: RowData[] = smesherInitTimestamp
+      ? [['Setup Started', smesherInitTimestamp]]
+      : [];
+    const setupFinished: RowData[] =
+      isSmeshing && smesherSmeshingTimestamp
+        ? [['Setup Finished', smesherSmeshingTimestamp]]
+        : [];
 
-    const progress = ((numLabelsWritten * smesherConfig.bitsPerLabel) / (BITS * commitmentSize)) * 100;
+    const progress =
+      ((numLabelsWritten * smesherConfig.bitsPerLabel) /
+        (BITS * commitmentSize)) *
+      100;
     const progressRow: RowData[] = !isSmeshing
       ? [
           [
@@ -250,7 +294,10 @@ const Node = ({ history, location }: Props) => {
             ) : (
               <Text>
                 <Text className="progress">
-                  {formatBytes((numLabelsWritten * smesherConfig.bitsPerLabel) / BITS)} / {formatBytes(commitmentSize)}, {progress.toFixed(2)}%
+                  {formatBytes(
+                    (numLabelsWritten * smesherConfig.bitsPerLabel) / BITS
+                  )}{' '}
+                  / {formatBytes(commitmentSize)}, {progress.toFixed(2)}%
                 </Text>
                 <ProgressBarWrapper>
                   <ProgressBar progress={progress} />
@@ -262,7 +309,14 @@ const Node = ({ history, location }: Props) => {
       : [];
 
     return [
-      ['Smesher ID', <Address key="smesherId" type={AddressType.SMESHER} address={smesherId} />],
+      [
+        'Smesher ID',
+        <Address
+          key="smesherId"
+          type={AddressType.SMESHER}
+          address={smesherId}
+        />,
+      ],
       ['Status', getStatus(postSetupState, isPausedSmeshing)],
       ...progressRow,
       ...setupStarted,
@@ -270,12 +324,21 @@ const Node = ({ history, location }: Props) => {
       [
         'Data Directory',
         <React.Fragment key="pos-data-dir">
-          <PosFolderIcon src={isDarkMode ? posDirectoryWhite : posDirectoryBlack} />
+          <PosFolderIcon
+            src={isDarkMode ? posDirectoryWhite : posDirectoryBlack}
+          />
           <PathDir>{posDataPath}</PathDir>
         </React.Fragment>,
       ],
       ['Data Size', formatBytes(commitmentSize)],
-      ['Rewards Address', <Address key="smesherCoinbase" type={AddressType.ACCOUNT} address={coinbase} />],
+      [
+        'Rewards Address',
+        <Address
+          key="smesherCoinbase"
+          type={AddressType.ACCOUNT}
+          address={coinbase}
+        />,
+      ],
     ];
   };
 
@@ -295,7 +358,9 @@ const Node = ({ history, location }: Props) => {
         {renderTable(getTableData())}
         <Footer>
           <Button
-            onClick={() => history.push(MainPath.SmeshingSetup, { modifyPostData: true })}
+            onClick={() =>
+              history.push(MainPath.SmeshingSetup, { modifyPostData: true })
+            }
             img={posDirectoryWhite}
             text="EDIT"
             isPrimary={false}
@@ -304,9 +369,25 @@ const Node = ({ history, location }: Props) => {
             width={180}
           />
           {postSetupState === PostSetupState.STATE_IN_PROGRESS && (
-            <Button onClick={handlePauseSmeshing} text="PAUSE POST DATA GENERATION" img={pauseIcon} isPrimary={false} width={280} imgPosition="before" />
+            <Button
+              onClick={handlePauseSmeshing}
+              text="PAUSE POST DATA GENERATION"
+              img={pauseIcon}
+              isPrimary={false}
+              width={280}
+              imgPosition="before"
+            />
           )}
-          {isPausedSmeshing && <Button onClick={handleResumeSmeshing} text="RESUME POST DATA GENERATION" img={playIcon} isPrimary width={280} imgPosition="before" />}
+          {isPausedSmeshing && (
+            <Button
+              onClick={handleResumeSmeshing}
+              text="RESUME POST DATA GENERATION"
+              img={playIcon}
+              isPrimary
+              width={280}
+              imgPosition="before"
+            />
+          )}
         </Footer>
       </>
     );
@@ -319,18 +400,31 @@ const Node = ({ history, location }: Props) => {
 
   const renderMainSection = () => {
     if (showIntro) {
-      return <SmesherIntro hideIntro={() => setShowIntro(false)} isDarkMode={isDarkMode} />;
+      return (
+        <SmesherIntro
+          hideIntro={() => setShowIntro(false)}
+          isDarkMode={isDarkMode}
+        />
+      );
     } else if (!isSmesherActive && !postProgressError) {
       return (
         <>
-          <SmesherStatus smesherId={smesherId} status={status} networkName={networkName} />
+          <SmesherStatus
+            smesherId={smesherId}
+            status={status}
+            networkName={networkName}
+          />
           <TextWrapperFirst>
             <PosSmesherIcon src={posSmesher} />
             <BoldText>Proof of Space Status</BoldText>
           </TextWrapperFirst>
           <Text>Proof of Space data is not setup yet</Text>
           <br />
-          <Button onClick={buttonHandler} text="SETUP PROOF OF SPACE" width={250} />
+          <Button
+            onClick={buttonHandler}
+            text="SETUP PROOF OF SPACE"
+            width={250}
+          />
         </>
       );
     }
@@ -342,7 +436,9 @@ const Node = ({ history, location }: Props) => {
   const handleSetupSmesher = () => {
     return eventsService
       .switchApiProvider(LOCAL_NODE_API_URL)
-      .then(() => history.push(AuthPath.Unlock, { redirect: MainPath.SmeshingSetup }))
+      .then(() =>
+        history.push(AuthPath.Unlock, { redirect: MainPath.SmeshingSetup })
+      )
       .catch((err) => {
         console.error(err); // eslint-disable-line no-console
         dispatch(setUiError(err));
@@ -354,18 +450,24 @@ const Node = ({ history, location }: Props) => {
       <>
         <Row>
           <RowText color={smColors.purple} weight={700}>
-            <Icon src={walletSecond} /> Your app is currently in wallet-only mode and smeshing is not set up.
+            <Icon src={walletSecond} /> Your app is currently in wallet-only
+            mode and smeshing is not set up.
           </RowText>
         </Row>
         <Row>
           <RowText color={smColors.darkOrange} weight={400}>
             <IconSmesher src={posSmesherOrange} />
-            Click on the setup semsher button below to start using a local managed full Spacemesh p2p node and to smesh.
+            Click on the setup semsher button below to start using a local
+            managed full Spacemesh p2p node and to smesh.
           </RowText>
         </Row>
         <BottomPart>
           <Link onClick={navigateToExplanation} text="SMESHER GUIDE" />
-          <Button width={120} onClick={handleSetupSmesher} text="SETUP SMESHER" />
+          <Button
+            width={120}
+            onClick={handleSetupSmesher}
+            text="SETUP SMESHER"
+          />
         </BottomPart>
       </>
     );
@@ -373,7 +475,13 @@ const Node = ({ history, location }: Props) => {
 
   return (
     <Wrapper>
-      <WrapperWith2SideBars width={650} height={450} header="SMESHER" headerIcon={posIcon} isDarkMode={isDarkMode}>
+      <WrapperWith2SideBars
+        width={650}
+        height={450}
+        header="SMESHER"
+        headerIcon={posIcon}
+        isDarkMode={isDarkMode}
+      >
         {isWalletMode ? renderWalletOnlyMode() : renderMainSection()}
       </WrapperWith2SideBars>
       {/*

--- a/app/screens/node/NodeSetup.tsx
+++ b/app/screens/node/NodeSetup.tsx
@@ -2,9 +2,19 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
-import { deletePosData, pauseSmeshing, startSmeshing } from '../../redux/smesher/actions';
+import {
+  deletePosData,
+  pauseSmeshing,
+  startSmeshing,
+} from '../../redux/smesher/actions';
 import { CorneredContainer, BackButton } from '../../components/common';
-import { PoSModifyPostData, PoSDirectory, PoSSize, PoSProvider, PoSSummary } from '../../components/node';
+import {
+  PoSModifyPostData,
+  PoSDirectory,
+  PoSSize,
+  PoSProvider,
+  PoSSummary,
+} from '../../components/node';
 import { StepsContainer } from '../../basicComponents';
 import { posIcon } from '../../assets/images';
 import { formatBytes, getAddress } from '../../infra/utils';
@@ -23,7 +33,13 @@ const Bold = styled.div`
   color: ${smColors.green};
 `;
 
-const headers = ['PROOF OF SPACE DATA', 'PROOF OF SPACE DIRECTORY', 'PROOF OF SPACE SIZE', 'POS PROCESSOR', 'POS SETUP'];
+const headers = [
+  'PROOF OF SPACE DATA',
+  'PROOF OF SPACE DIRECTORY',
+  'PROOF OF SPACE SIZE',
+  'POS PROCESSOR',
+  'POS SETUP',
+];
 const subHeaders = [
   '',
   '',
@@ -53,11 +69,17 @@ interface Props extends RouteComponentProps {
 const NodeSetup = ({ history, location }: Props) => {
   const accounts = useSelector((state: RootState) => state.wallet.accounts);
   const status = useSelector((state: RootState) => state.node.status);
-  const postSetupComputeProviders = useSelector((state: RootState) => state.smesher.postSetupComputeProviders);
-  const existingDataDir = useSelector((state: RootState) => state.smesher.dataDir);
+  const postSetupComputeProviders = useSelector(
+    (state: RootState) => state.smesher.postSetupComputeProviders
+  );
+  const existingDataDir = useSelector(
+    (state: RootState) => state.smesher.dataDir
+  );
   const smesherConfig = useSelector((state: RootState) => state.smesher.config);
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
-  const hideSmesherLeftPanel = useSelector((state: RootState) => state.ui.hideSmesherLeftPanel);
+  const hideSmesherLeftPanel = useSelector(
+    (state: RootState) => state.ui.hideSmesherLeftPanel
+  );
   const [mode, setMode] = useState(location?.state?.modifyPostData ? 0 : 1);
   const [dataDir, setDataDir] = useState(existingDataDir || '');
   const [freeSpace, setFreeSpace] = useState('');
@@ -67,13 +89,18 @@ const NodeSetup = ({ history, location }: Props) => {
 
   const dispatch: AppThDispatch = useDispatch();
 
-  const commitmentSize = (smesherConfig.labelsPerUnit * smesherConfig.bitsPerLabel * smesherConfig.minNumUnits) / BITS;
+  const commitmentSize =
+    (smesherConfig.labelsPerUnit *
+      smesherConfig.bitsPerLabel *
+      smesherConfig.minNumUnits) /
+    BITS;
   const formattedCommitmentSize = formatBytes(commitmentSize);
   const getPosDirectorySubheader = () => (
     <>
       {Number.isNaN(commitmentSize) ? (
         <ErrorMessage align="left" oneLine={false}>
-          The node is down. Please, restart the node first on the Network screen.
+          The node is down. Please, restart the node first on the Network
+          screen.
         </ErrorMessage>
       ) : (
         <>
@@ -89,7 +116,15 @@ const NodeSetup = ({ history, location }: Props) => {
 
   const setupAndInitMining = async () => {
     if (!provider) return; // TODO
-    const done = await dispatch(startSmeshing({ coinbase: `0x${getAddress(accounts[0].publicKey)}`, dataDir, numUnits, provider: provider.id, throttle }));
+    const done = await dispatch(
+      startSmeshing({
+        coinbase: `0x${getAddress(accounts[0].publicKey)}`,
+        dataDir,
+        numUnits,
+        provider: provider.id,
+        throttle,
+      })
+    );
     if (done) {
       history.push(MainPath.Smeshing, { showIntro: true });
     }
@@ -124,7 +159,13 @@ const NodeSetup = ({ history, location }: Props) => {
   const renderRightSection = () => {
     switch (mode) {
       case 0:
-        return <PoSModifyPostData modify={handleModifyPosData} deleteData={handleDeletePosData} isDarkMode={isDarkMode} />;
+        return (
+          <PoSModifyPostData
+            modify={handleModifyPosData}
+            deleteData={handleDeletePosData}
+            isDarkMode={isDarkMode}
+          />
+        );
       case 1:
         return (
           <PoSDirectory
@@ -141,10 +182,19 @@ const NodeSetup = ({ history, location }: Props) => {
         );
       case 2: {
         const commitments: Commitment[] = [];
-        const singleCommitmentSize = (smesherConfig.bitsPerLabel * smesherConfig.labelsPerUnit) / BITS;
-        for (let i = smesherConfig.minNumUnits; i <= smesherConfig.maxNumUnits; i += 1) {
+        const singleCommitmentSize =
+          (smesherConfig.bitsPerLabel * smesherConfig.labelsPerUnit) / BITS;
+        for (
+          let i = smesherConfig.minNumUnits;
+          i <= smesherConfig.maxNumUnits;
+          i += 1
+        ) {
           const calculationResult = i * singleCommitmentSize;
-          commitments.push({ label: formatBytes(calculationResult), size: calculationResult, numUnits: i });
+          commitments.push({
+            label: formatBytes(calculationResult),
+            size: calculationResult,
+            numUnits: i,
+          });
         }
         // TODO: Make a well default instead of logic inside view and rerendering comp:
         numUnits === 0 && setNumUnits(commitments[0].numUnits);
@@ -179,7 +229,16 @@ const NodeSetup = ({ history, location }: Props) => {
           <PoSSummary
             isDarkMode={isDarkMode}
             dataDir={dataDir}
-            commitmentSize={smesherConfig ? formatBytes((smesherConfig.bitsPerLabel * smesherConfig.labelsPerUnit * numUnits) / BITS) : '0'}
+            commitmentSize={
+              smesherConfig
+                ? formatBytes(
+                    (smesherConfig.bitsPerLabel *
+                      smesherConfig.labelsPerUnit *
+                      numUnits) /
+                      BITS
+                  )
+                : '0'
+            }
             provider={provider}
             throttle={throttle}
             nextAction={handleNextAction}
@@ -194,8 +253,21 @@ const NodeSetup = ({ history, location }: Props) => {
 
   return (
     <Wrapper>
-      {!hideSmesherLeftPanel && <StepsContainer steps={['SETUP WALLET', 'SETUP PROOF OF SPACE']} currentStep={1} isDarkMode={isDarkMode} />}
-      <CorneredContainer isDarkMode={isDarkMode} width={!hideSmesherLeftPanel ? 650 : 760} height={450} header={headers[mode]} headerIcon={posIcon} subHeader={subHeader}>
+      {!hideSmesherLeftPanel && (
+        <StepsContainer
+          steps={['SETUP WALLET', 'SETUP PROOF OF SPACE']}
+          currentStep={1}
+          isDarkMode={isDarkMode}
+        />
+      )}
+      <CorneredContainer
+        isDarkMode={isDarkMode}
+        width={!hideSmesherLeftPanel ? 650 : 760}
+        height={450}
+        header={headers[mode]}
+        headerIcon={posIcon}
+        subHeader={subHeader}
+      >
         {hasBackButton && <BackButton action={handlePrevAction} />}
         {renderRightSection()}
       </CorneredContainer>

--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -2,10 +2,23 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
-import { updateWalletName, updateAccountName, createNewAccount, switchApiProvider, closeWallet } from '../../redux/wallet/actions';
+import {
+  updateWalletName,
+  updateAccountName,
+  createNewAccount,
+  switchApiProvider,
+  closeWallet,
+} from '../../redux/wallet/actions';
 import { getGlobalStateHash } from '../../redux/network/actions';
 import { setUiError, switchTheme } from '../../redux/ui/actions';
-import { SettingsSection, SettingRow, ChangePassword, SideMenu, EnterPasswordModal, SignMessage } from '../../components/settings';
+import {
+  SettingsSection,
+  SettingRow,
+  ChangePassword,
+  SideMenu,
+  EnterPasswordModal,
+  SignMessage,
+} from '../../components/settings';
 import { Input, Link, Button } from '../../basicComponents';
 import { eventsService } from '../../infra/eventsService';
 import { getAddress, getFormattedTimestamp } from '../../infra/utils';
@@ -138,7 +151,9 @@ class Settings extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     const { displayName, accounts } = props;
-    const accountDisplayNames = accounts.map((account: Account) => account.displayName);
+    const accountDisplayNames = accounts.map(
+      (account: Account) => account.displayName
+    );
     this.state = {
       walletDisplayName: displayName,
       canEditDisplayName: false,
@@ -162,7 +177,22 @@ class Settings extends Component<Props, State> {
   }
 
   render() {
-    const { displayName, accounts, netName, netId, genesisTime, rootHash, build, version, backupTime, switchTheme, isDarkMode, isWalletOnly, history, dataPath } = this.props;
+    const {
+      displayName,
+      accounts,
+      netName,
+      netId,
+      genesisTime,
+      rootHash,
+      build,
+      version,
+      backupTime,
+      switchTheme,
+      isDarkMode,
+      isWalletOnly,
+      history,
+      dataPath,
+    } = this.props;
     const {
       walletDisplayName,
       canEditDisplayName,
@@ -180,85 +210,205 @@ class Settings extends Component<Props, State> {
 
     return (
       <Wrapper>
-        <SideMenu isDarkMode={isDarkMode} items={['GENERAL', 'WALLETS', 'ACCOUNTS', 'INFO', 'ADVANCED']} currentItem={currentSettingIndex} onClick={this.scrollToRef} />
+        <SideMenu
+          isDarkMode={isDarkMode}
+          items={['GENERAL', 'WALLETS', 'ACCOUNTS', 'INFO', 'ADVANCED']}
+          currentItem={currentSettingIndex}
+          onClick={this.scrollToRef}
+        />
         <AllSettingsWrapper>
           <AllSettingsInnerWrapper>
-            <SettingsSection title="GENERAL" refProp={this.myRef1} isDarkMode={isDarkMode}>
-              <SettingRow upperPartRight={<Button onClick={switchTheme} text="TOGGLE DARK MODE" width={180} />} rowName="Dark Mode" />
+            <SettingsSection
+              title="GENERAL"
+              refProp={this.myRef1}
+              isDarkMode={isDarkMode}
+            >
               <SettingRow
-                upperPartLeft={`Auto start Spacemesh when your computer starts: ${isAutoStartEnabled ? 'ON' : 'OFF'}`}
+                upperPartRight={
+                  <Button
+                    onClick={switchTheme}
+                    text="TOGGLE DARK MODE"
+                    width={180}
+                  />
+                }
+                rowName="Dark Mode"
+              />
+              <SettingRow
+                upperPartLeft={`Auto start Spacemesh when your computer starts: ${
+                  isAutoStartEnabled ? 'ON' : 'OFF'
+                }`}
                 isUpperPartLeftText
-                upperPartRight={<Button onClick={this.toggleAutoStart} text="TOGGLE AUTO START" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={this.toggleAutoStart}
+                    text="TOGGLE AUTO START"
+                    width={180}
+                  />
+                }
                 rowName="Wallet Auto Start"
               />
               <SettingRow
-                upperPart={[<Text key={1}>Read our&nbsp;</Text>, <Link onClick={() => this.externalNavigation(ExternalLinks.Disclaimer)} text="disclaimer" key={2} />]}
+                upperPart={[
+                  <Text key={1}>Read our&nbsp;</Text>,
+                  <Link
+                    onClick={() =>
+                      this.externalNavigation(ExternalLinks.Disclaimer)
+                    }
+                    text="disclaimer"
+                    key={2}
+                  />,
+                ]}
                 rowName="Legal"
               />
               <SettingRow
                 upperPartLeft="Learn more in our extensive user guide"
                 isUpperPartLeftText
-                upperPartRight={<Button onClick={() => this.externalNavigation(ExternalLinks.UserGuide)} text="GUIDE" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={() =>
+                      this.externalNavigation(ExternalLinks.UserGuide)
+                    }
+                    text="GUIDE"
+                    width={180}
+                  />
+                }
                 rowName="User Guide"
               />
             </SettingsSection>
-            <SettingsSection title="WALLETS" refProp={this.myRef2} isDarkMode={isDarkMode}>
+            <SettingsSection
+              title="WALLETS"
+              refProp={this.myRef2}
+              isDarkMode={isDarkMode}
+            >
               {isWalletOnly ? (
                 <SettingRow
                   rowName="Application mode"
                   upperPartLeft="Wallet only"
-                  upperPartRight={<Button onClick={this.switchToLocalNode} text="SWITCH TO LOCAL NODE" width={180} />}
+                  upperPartRight={
+                    <Button
+                      onClick={this.switchToLocalNode}
+                      text="SWITCH TO LOCAL NODE"
+                      width={180}
+                    />
+                  }
                 />
               ) : (
                 <SettingRow
                   rowName="Application mode"
                   upperPartLeft="Local node"
-                  upperPartRight={<Button onClick={this.switchToRemoteApi} text="SWITCH TO WALLET ONLY" width={180} />}
+                  upperPartRight={
+                    <Button
+                      onClick={this.switchToRemoteApi}
+                      text="SWITCH TO WALLET ONLY"
+                      width={180}
+                    />
+                  }
                 />
               )}
               <SettingRow
                 rowName="Current network"
                 upperPartLeft={`${netName} (${netId})`}
-                upperPartRight={<Button onClick={() => goToSwitchNetwork(history, isWalletOnly)} text="SWITCH THE NETWORK" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={() => goToSwitchNetwork(history, isWalletOnly)}
+                    text="SWITCH THE NETWORK"
+                    width={180}
+                  />
+                }
               />
               <SettingRow
-                upperPartLeft={canEditDisplayName ? <Input value={walletDisplayName} onChange={this.editWalletDisplayName} maxLength="100" /> : <Name>{walletDisplayName}</Name>}
+                upperPartLeft={
+                  canEditDisplayName ? (
+                    <Input
+                      value={walletDisplayName}
+                      onChange={this.editWalletDisplayName}
+                      maxLength="100"
+                    />
+                  ) : (
+                    <Name>{walletDisplayName}</Name>
+                  )
+                }
                 upperPartRight={
                   canEditDisplayName ? (
                     [
-                      <Link onClick={this.saveEditedWalletDisplayName} text="SAVE" style={{ marginRight: 15 }} key="save" />,
-                      <Link onClick={this.cancelEditingWalletDisplayName} text="CANCEL" style={{ color: smColors.darkGray }} key="cancel" />,
+                      <Link
+                        onClick={this.saveEditedWalletDisplayName}
+                        text="SAVE"
+                        style={{ marginRight: 15 }}
+                        key="save"
+                      />,
+                      <Link
+                        onClick={this.cancelEditingWalletDisplayName}
+                        text="CANCEL"
+                        style={{ color: smColors.darkGray }}
+                        key="cancel"
+                      />,
                     ]
                   ) : (
-                    <Button onClick={this.startEditingWalletDisplayName} text="RENAME" width={180} />
+                    <Button
+                      onClick={this.startEditingWalletDisplayName}
+                      text="RENAME"
+                      width={180}
+                    />
                   )
                 }
                 rowName="Display name"
               />
-              <SettingRow upperPart={<ChangePassword />} rowName="Wallet password" />
               <SettingRow
-                upperPartLeft={`Last Backup ${backupTime ? `at ${new Date(backupTime).toLocaleString()}` : 'was never backed-up.'}`}
+                upperPart={<ChangePassword />}
+                rowName="Wallet password"
+              />
+              <SettingRow
+                upperPartLeft={`Last Backup ${
+                  backupTime
+                    ? `at ${new Date(backupTime).toLocaleString()}`
+                    : 'was never backed-up.'
+                }`}
                 isUpperPartLeftText
-                upperPartRight={<Button onClick={this.navigateToWalletBackup} text="BACKUP NOW" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={this.navigateToWalletBackup}
+                    text="BACKUP NOW"
+                    width={180}
+                  />
+                }
                 rowName="Wallet Backup"
               />
               <SettingRow
                 upperPartLeft="Restore wallet from backup file or 12 words"
                 isUpperPartLeftText
-                upperPartRight={<Button onClick={this.navigateToWalletRestore} text="RESTORE" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={this.navigateToWalletRestore}
+                    text="RESTORE"
+                    width={180}
+                  />
+                }
                 rowName="Wallet Restore"
               />
               <SettingRow
                 upperPartLeft="Use at your own risk!"
                 isUpperPartLeftText
-                upperPartRight={<Button onClick={this.deleteWallet} text="DELETE WALLET" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={this.deleteWallet}
+                    text="DELETE WALLET"
+                    width={180}
+                  />
+                }
                 rowName="Delete Wallet"
               />
               <SettingRow
                 rowName="Close the wallet"
                 upperPartLeft={walletDisplayName}
                 isUpperPartLeftText
-                upperPartRight={<Button onClick={this.closeWallet} text="LOG OUT" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={this.closeWallet}
+                    text="LOG OUT"
+                    width={180}
+                  />
+                }
               />
               <SettingRow
                 rowName="Open another wallet file"
@@ -266,22 +416,50 @@ class Settings extends Component<Props, State> {
                 isUpperPartLeftText
                 upperPartRight={
                   <>
-                    <Button onClick={this.openWalletFile} text="OPEN WALLET FILE" width={180} style={{ marginRight: '1em' }} />
-                    <Button onClick={this.restoreFromMnemonics} text="RESTORE FROM 12 WORDS" width={180} />
+                    <Button
+                      onClick={this.openWalletFile}
+                      text="OPEN WALLET FILE"
+                      width={180}
+                      style={{ marginRight: '1em' }}
+                    />
+                    <Button
+                      onClick={this.restoreFromMnemonics}
+                      text="RESTORE FROM 12 WORDS"
+                      width={180}
+                    />
                   </>
                 }
               />
               <SettingRow
                 upperPartLeft="You will be signed out of current wallet"
                 isUpperPartLeftText
-                upperPartRight={<Button onClick={this.createNewWallet} text="CREATE" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={this.createNewWallet}
+                    text="CREATE"
+                    width={180}
+                  />
+                }
                 rowName="Create a new wallet"
               />
             </SettingsSection>
-            <SettingsSection title="ACCOUNTS" refProp={this.myRef3} isDarkMode={isDarkMode}>
+            <SettingsSection
+              title="ACCOUNTS"
+              refProp={this.myRef3}
+              isDarkMode={isDarkMode}
+            >
               <SettingRow
-                upperPartLeft={[<Text key={1}>New accounts will be added to&nbsp;</Text>, <GreenText key={2}>{displayName}</GreenText>]}
-                upperPartRight={<Button onClick={this.createNewAccountWrapper} text="ADD ACCOUNT" width={180} />}
+                upperPartLeft={[
+                  <Text key={1}>New accounts will be added to&nbsp;</Text>,
+                  <GreenText key={2}>{displayName}</GreenText>,
+                ]}
+                upperPartRight={
+                  <Button
+                    onClick={this.createNewAccountWrapper}
+                    text="ADD ACCOUNT"
+                    width={180}
+                  />
+                }
                 rowName="Add a new account"
               />
               {accounts.map((account, index) => (
@@ -290,7 +468,14 @@ class Settings extends Component<Props, State> {
                     editedAccountIndex !== index ? (
                       <Name>{accountDisplayNames[index]}</Name>
                     ) : (
-                      <Input value={accountDisplayNames[index]} onChange={({ value }) => this.editAccountDisplayName({ value, index })} maxLength="100" autofocus />
+                      <Input
+                        value={accountDisplayNames[index]}
+                        onChange={({ value }) =>
+                          this.editAccountDisplayName({ value, index })
+                        }
+                        maxLength="100"
+                        autofocus
+                      />
                     )
                   }
                   rowName={`0x${getAddress(account.publicKey)}`}
@@ -298,14 +483,36 @@ class Settings extends Component<Props, State> {
                     <AccountCmdBtnWrapper>
                       {editedAccountIndex === index ? (
                         [
-                          <Link onClick={() => this.saveEditedAccountDisplayName({ index })} text="SAVE" style={{ marginRight: 15 }} key="save" />,
-                          <Link onClick={() => this.cancelEditingAccountDisplayName({ index })} text="CANCEL" style={{ color: smColors.darkGray }} key="cancel" />,
+                          <Link
+                            onClick={() =>
+                              this.saveEditedAccountDisplayName({ index })
+                            }
+                            text="SAVE"
+                            style={{ marginRight: 15 }}
+                            key="save"
+                          />,
+                          <Link
+                            onClick={() =>
+                              this.cancelEditingAccountDisplayName({ index })
+                            }
+                            text="CANCEL"
+                            style={{ color: smColors.darkGray }}
+                            key="cancel"
+                          />,
                         ]
                       ) : (
-                        <Link onClick={() => this.startEditingAccountDisplayName({ index })} text="RENAME" />
+                        <Link
+                          onClick={() =>
+                            this.startEditingAccountDisplayName({ index })
+                          }
+                          text="RENAME"
+                        />
                       )}
                       <AccountCmdBtnSeparator />
-                      <Link onClick={() => this.toggleSignMessageModal({ index })} text="SIGN TEXT" />
+                      <Link
+                        onClick={() => this.toggleSignMessageModal({ index })}
+                        text="SIGN TEXT"
+                      />
                       <AccountCmdBtnSeparator />
                     </AccountCmdBtnWrapper>
                   }
@@ -313,21 +520,60 @@ class Settings extends Component<Props, State> {
                 />
               ))}
             </SettingsSection>
-            <SettingsSection title="INFO" refProp={this.myRef4} isDarkMode={isDarkMode}>
-              <SettingRow upperPartLeft={getFormattedTimestamp(genesisTime)} isUpperPartLeftText rowName="Genesis time" />
+            <SettingsSection
+              title="INFO"
+              refProp={this.myRef4}
+              isDarkMode={isDarkMode}
+            >
+              <SettingRow
+                upperPartLeft={getFormattedTimestamp(genesisTime)}
+                isUpperPartLeftText
+                rowName="Genesis time"
+              />
               {!isWalletOnly && (
                 <>
-                  <SettingRow upperPart={build} isUpperPartLeftText rowName="Node Build" />
-                  <SettingRow upperPart={version} isUpperPartLeftText rowName="Node Version" />
-                  <SettingRow upperPart={rootHash} isUpperPartLeftText rowName="State root hash" />
-                  <SettingRow upperPartRight={<Button onClick={this.openLogFile} text="View Logs" width={180} />} rowName="View logs file" />
+                  <SettingRow
+                    upperPart={build}
+                    isUpperPartLeftText
+                    rowName="Node Build"
+                  />
+                  <SettingRow
+                    upperPart={version}
+                    isUpperPartLeftText
+                    rowName="Node Version"
+                  />
+                  <SettingRow
+                    upperPart={rootHash}
+                    isUpperPartLeftText
+                    rowName="State root hash"
+                  />
+                  <SettingRow
+                    upperPartRight={
+                      <Button
+                        onClick={this.openLogFile}
+                        text="View Logs"
+                        width={180}
+                      />
+                    }
+                    rowName="View logs file"
+                  />
                 </>
               )}
             </SettingsSection>
-            <SettingsSection title="ADVANCED" refProp={this.myRef5} isDarkMode={isDarkMode}>
+            <SettingsSection
+              title="ADVANCED"
+              refProp={this.myRef5}
+              isDarkMode={isDarkMode}
+            >
               <SettingRow
                 upperPartLeft={dataPath}
-                upperPartRight={<Button onClick={eventsService.changeDataDir} text="CHANGE DIRECTORY" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={eventsService.changeDataDir}
+                    text="CHANGE DIRECTORY"
+                    width={180}
+                  />
+                }
                 rowName="Move mesh data directory (will restart the node)"
               />
               <SettingRow
@@ -335,29 +581,56 @@ class Settings extends Component<Props, State> {
                   isPortSet ? (
                     <Text>Please restart application to apply changes</Text>
                   ) : (
-                    <Input value={changedPort} onChange={({ value }) => this.setState({ changedPort: value })} maxLength="10" />
+                    <Input
+                      value={changedPort}
+                      onChange={({ value }) =>
+                        this.setState({ changedPort: value })
+                      }
+                      maxLength="10"
+                    />
                   )
                 }
-                upperPartRight={<Button onClick={this.setPort} text="SET PORT" width={180} />}
+                upperPartRight={
+                  <Button onClick={this.setPort} text="SET PORT" width={180} />
+                }
                 rowName="Local Smesher TCP and UDP port numbers"
               />
               <SettingRow
                 upperPartLeft="Delete all wallets and app data, and restart it"
                 isUpperPartLeftText
-                upperPartRight={<Button onClick={this.cleanAllAppDataAndSettings} text="REINSTALL" width={180} />}
+                upperPartRight={
+                  <Button
+                    onClick={this.cleanAllAppDataAndSettings}
+                    text="REINSTALL"
+                    width={180}
+                  />
+                }
                 rowName="Reinstall App"
               />
             </SettingsSection>
           </AllSettingsInnerWrapper>
         </AllSettingsWrapper>
         {showPasswordModal && (
-          <EnterPasswordModal walletName={displayName} submitAction={passwordModalSubmitAction} closeModal={() => this.setState({ showPasswordModal: false })} />
+          <EnterPasswordModal
+            walletName={displayName}
+            submitAction={passwordModalSubmitAction}
+            closeModal={() => this.setState({ showPasswordModal: false })}
+          />
         )}
-        {signMessageModalAccountIndex !== -1 && <SignMessage index={signMessageModalAccountIndex} close={() => this.toggleSignMessageModal({ index: -1 })} />}
+        {signMessageModalAccountIndex !== -1 && (
+          <SignMessage
+            index={signMessageModalAccountIndex}
+            close={() => this.toggleSignMessageModal({ index: -1 })}
+          />
+        )}
         {showModal && (
           <Modal header="Error" subHeader={'number must be >= 1024'}>
             <ButtonsWrapper>
-              <Button onClick={() => this.setState({ showModal: false })} isPrimary text="OK" />
+              <Button
+                onClick={() => this.setState({ showModal: false })}
+                isPrimary
+                text="OK"
+              />
             </ButtonsWrapper>
           </Modal>
         )}
@@ -377,9 +650,14 @@ class Settings extends Component<Props, State> {
   }
 
   static getDerivedStateFromProps(props: Props, prevState: State) {
-    if (props.accounts && props.accounts.length > prevState.accountDisplayNames.length) {
+    if (
+      props.accounts &&
+      props.accounts.length > prevState.accountDisplayNames.length
+    ) {
       const updatedAccountDisplayNames = [...prevState.accountDisplayNames];
-      updatedAccountDisplayNames.push(props.accounts[props.accounts.length - 1].displayName);
+      updatedAccountDisplayNames.push(
+        props.accounts[props.accounts.length - 1].displayName
+      );
       return { accountDisplayNames: updatedAccountDisplayNames };
     }
     return null;
@@ -433,15 +711,21 @@ class Settings extends Component<Props, State> {
     });
   };
 
-  editWalletDisplayName = ({ value }: { value: string }) => this.setState({ walletDisplayName: value });
+  editWalletDisplayName = ({ value }: { value: string }) =>
+    this.setState({ walletDisplayName: value });
 
-  startEditingWalletDisplayName = () => this.setState({ canEditDisplayName: true });
+  startEditingWalletDisplayName = () =>
+    this.setState({ canEditDisplayName: true });
 
   saveEditedWalletDisplayName = () => {
     const { displayName, updateWalletName } = this.props;
     const { walletDisplayName } = this.state;
     this.setState({ canEditDisplayName: false });
-    if (!!walletDisplayName && !!walletDisplayName.trim() && walletDisplayName !== displayName) {
+    if (
+      !!walletDisplayName &&
+      !!walletDisplayName.trim() &&
+      walletDisplayName !== displayName
+    ) {
       // @ts-ignore
       updateWalletName({ displayName: walletDisplayName });
     }
@@ -449,7 +733,10 @@ class Settings extends Component<Props, State> {
 
   cancelEditingWalletDisplayName = () => {
     const { displayName } = this.props;
-    this.setState({ walletDisplayName: displayName, canEditDisplayName: false });
+    this.setState({
+      walletDisplayName: displayName,
+      canEditDisplayName: false,
+    });
   };
 
   deleteWallet = async () => {
@@ -475,7 +762,13 @@ class Settings extends Component<Props, State> {
     this.setState({ isAutoStartEnabled: !isAutoStartEnabled });
   };
 
-  editAccountDisplayName = ({ value, index }: { value: string; index: number }) => {
+  editAccountDisplayName = ({
+    value,
+    index,
+  }: {
+    value: string;
+    index: number;
+  }) => {
     const { accountDisplayNames } = this.state;
     const updatedAccountDisplayNames = [...accountDisplayNames];
     updatedAccountDisplayNames[index] = value;
@@ -490,7 +783,11 @@ class Settings extends Component<Props, State> {
       passwordModalSubmitAction: ({ password }: { password: string }) => {
         this.setState({ editedAccountIndex: -1, showPasswordModal: false });
         // @ts-ignore
-        updateAccountName({ accountIndex: index, name: accountDisplayNames[index], password });
+        updateAccountName({
+          accountIndex: index,
+          name: accountDisplayNames[index],
+          password,
+        });
       },
     });
   };
@@ -500,7 +797,10 @@ class Settings extends Component<Props, State> {
     const { accountDisplayNames } = this.state;
     const updatedAccountDisplayNames = [...accountDisplayNames];
     updatedAccountDisplayNames[index] = accounts[index].displayName;
-    this.setState({ editedAccountIndex: -1, accountDisplayNames: updatedAccountDisplayNames });
+    this.setState({
+      editedAccountIndex: -1,
+      accountDisplayNames: updatedAccountDisplayNames,
+    });
   };
 
   startEditingAccountDisplayName = ({ index }: { index: number }) => {
@@ -512,7 +812,13 @@ class Settings extends Component<Props, State> {
   };
 
   scrollToRef = ({ index }: { index: number }) => {
-    const ref = [this.myRef1, this.myRef2, this.myRef3, this.myRef4, this.myRef5][index];
+    const ref = [
+      this.myRef1,
+      this.myRef2,
+      this.myRef3,
+      this.myRef4,
+      this.myRef5,
+    ][index];
     this.setState({ currentSettingIndex: index });
     ref.current.scrollIntoView({
       behavior: 'smooth',

--- a/app/screens/transactions/Transactions.tsx
+++ b/app/screens/transactions/Transactions.tsx
@@ -3,13 +3,26 @@ import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { BackButton } from '../../components/common';
-import { TxRow, RewardRow, TransactionsMeta } from '../../components/transactions';
+import {
+  TxRow,
+  RewardRow,
+  TransactionsMeta,
+} from '../../components/transactions';
 import { CreateNewContact } from '../../components/contacts';
-import { Link, WrapperWith2SideBars, CorneredWrapper, DropDown } from '../../basicComponents';
+import {
+  Link,
+  WrapperWith2SideBars,
+  CorneredWrapper,
+  DropDown,
+} from '../../basicComponents';
 import { getAddress } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
-import { getTxAndRewards, RewardView, TxView } from '../../redux/wallet/selectors';
+import {
+  getTxAndRewards,
+  RewardView,
+  TxView,
+} from '../../redux/wallet/selectors';
 import { TxState, HexString } from '../../../shared/types';
 import { isReward, isTx } from '../../../shared/types/guards';
 import { ExternalLinks } from '../../../shared/constants';
@@ -23,7 +36,8 @@ const Wrapper = styled.div`
 const Text = styled.span`
   font-size: 16px;
   line-height: 22px;
-  color: ${({ theme }) => (theme.isDarkMode ? smColors.white : smColors.realBlack)};
+  color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.white : smColors.realBlack};
 `;
 
 const TransactionsListWrapper = styled.div`
@@ -35,7 +49,8 @@ const TransactionsListWrapper = styled.div`
 `;
 
 const RightPaneWrapper = styled(CorneredWrapper)`
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
   display: flex;
   flex-direction: column;
   width: 260px;
@@ -56,14 +71,23 @@ const TimeSpanEntry = styled.div<{ isInDropDown: boolean }>`
   }
 `;
 
-const getNumOfCoinsFromTransactions = (publicKey: HexString, transactions: (TxView | RewardView)[]) => {
+const getNumOfCoinsFromTransactions = (
+  publicKey: HexString,
+  transactions: (TxView | RewardView)[]
+) => {
   const coins = { mined: 0, sent: 0, received: 0 };
   const address = getAddress(publicKey);
   return transactions.reduce((coins, txOrReward: TxView | RewardView) => {
     if (isTx(txOrReward)) {
       const { status, sender, amount } = txOrReward;
-      if (status !== TxState.TRANSACTION_STATE_REJECTED && status !== TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS && status !== TxState.TRANSACTION_STATE_CONFLICTING) {
-        return sender === address ? { ...coins, sent: coins.sent + amount } : { ...coins, received: coins.received + amount };
+      if (
+        status !== TxState.TRANSACTION_STATE_REJECTED &&
+        status !== TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS &&
+        status !== TxState.TRANSACTION_STATE_CONFLICTING
+      ) {
+        return sender === address
+          ? { ...coins, sent: coins.sent + amount }
+          : { ...coins, received: coins.received + amount };
       }
     } else if (isReward(txOrReward)) {
       const { amount } = txOrReward;
@@ -83,13 +107,22 @@ const Transactions = ({ history }: RouteComponentProps) => {
   const [selectedTimeSpan, setSelectedTimeSpan] = useState(0);
   const [addressToAdd, setAddressToAdd] = useState('');
 
-  const publicKey = useSelector((state: RootState) => state.wallet.accounts[state.wallet.currentAccountIndex].publicKey);
+  const publicKey = useSelector(
+    (state: RootState) =>
+      state.wallet.accounts[state.wallet.currentAccountIndex].publicKey
+  );
   const transactions = useSelector(getTxAndRewards(publicKey));
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
 
   const getCoinStatistics = (filteredTransactions: (TxView | RewardView)[]) => {
-    const coins = getNumOfCoinsFromTransactions(publicKey, filteredTransactions);
-    const totalCoins = getNumOfCoinsFromTransactions(publicKey, transactions || []);
+    const coins = getNumOfCoinsFromTransactions(
+      publicKey,
+      filteredTransactions
+    );
+    const totalCoins = getNumOfCoinsFromTransactions(
+      publicKey,
+      transactions || []
+    );
     return {
       ...coins,
       totalMined: totalCoins.mined,
@@ -110,7 +143,9 @@ const Transactions = ({ history }: RouteComponentProps) => {
     const oneDayInMs = 86400000;
     const spanInDays = TIME_SPANS[selectedTimeSpan].days || 1;
     const startDate = Date.now() - spanInDays * oneDayInMs;
-    return transactions.filter((tx) => (tx.timestamp && tx.timestamp >= startDate) || !tx.timestamp);
+    return transactions.filter(
+      (tx) => (tx.timestamp && tx.timestamp >= startDate) || !tx.timestamp
+    );
   };
 
   const cancelCreatingNewContact = () => {
@@ -119,22 +154,51 @@ const Transactions = ({ history }: RouteComponentProps) => {
 
   const navigateToGuide = () => window.open(ExternalLinks.WalletGuide);
 
-  const ddStyle = { width: 120, position: 'absolute', right: 12, top: 5, color: isDarkMode ? smColors.white : smColors.black };
+  const ddStyle = {
+    width: 120,
+    position: 'absolute',
+    right: 12,
+    top: 5,
+    color: isDarkMode ? smColors.white : smColors.black,
+  };
 
   const filteredTransactions = filterTransactions();
   const coinStats = getCoinStatistics(filteredTransactions);
-  const { mined, sent, received, totalMined, totalSent, totalReceived } = coinStats;
+  const {
+    mined,
+    sent,
+    received,
+    totalMined,
+    totalSent,
+    totalReceived,
+  } = coinStats;
   return (
     <Wrapper>
       <BackButton action={history.goBack} width={7} height={10} />
-      <WrapperWith2SideBars width={680} header="TRANSACTION LOG" style={{ marginRight: 10 }} isDarkMode={isDarkMode}>
+      <WrapperWith2SideBars
+        width={680}
+        header="TRANSACTION LOG"
+        style={{ marginRight: 10 }}
+        isDarkMode={isDarkMode}
+      >
         <TransactionsListWrapper>
           {transactions && transactions.length ? (
             transactions.map((tx: TxView | RewardView) =>
               isReward(tx) ? (
-                <RewardRow key={`${publicKey}_reward_${tx.layer}`} publicKey={publicKey} tx={tx} />
+                <RewardRow
+                  key={`${publicKey}_reward_${tx.layer}`}
+                  publicKey={publicKey}
+                  tx={tx}
+                />
               ) : (
-                <TxRow key={`tx_${tx.id}`} tx={tx} publicKey={publicKey} addAddressToContacts={({ address }) => setAddressToAdd(`0x${address}`)} />
+                <TxRow
+                  key={`tx_${tx.id}`}
+                  tx={tx}
+                  publicKey={publicKey}
+                  addAddressToContacts={({ address }) =>
+                    setAddressToAdd(`0x${address}`)
+                  }
+                />
               )
             )
           ) : (
@@ -144,12 +208,19 @@ const Transactions = ({ history }: RouteComponentProps) => {
         <Link onClick={navigateToGuide} text="TRANSACTIONS GUIDE" />
       </WrapperWith2SideBars>
       {addressToAdd ? (
-        <CreateNewContact isStandalone initialAddress={addressToAdd} onCompleteAction={handleCompleteAction} onCancel={cancelCreatingNewContact} />
+        <CreateNewContact
+          isStandalone
+          initialAddress={addressToAdd}
+          onCompleteAction={handleCompleteAction}
+          onCancel={cancelCreatingNewContact}
+        />
       ) : (
         <RightPaneWrapper>
           <DropDown
             data={TIME_SPANS}
-            DdElement={({ label, isMain }) => <TimeSpanEntry isInDropDown={!isMain}>{label}</TimeSpanEntry>}
+            DdElement={({ label, isMain }) => (
+              <TimeSpanEntry isInDropDown={!isMain}>{label}</TimeSpanEntry>
+            )}
             onClick={handlePress}
             selectedItemIndex={selectedTimeSpan}
             rowHeight={40}

--- a/app/screens/wallet/Overview.tsx
+++ b/app/screens/wallet/Overview.tsx
@@ -23,7 +23,8 @@ const MiddleSection = styled.div`
   height: 100%;
   margin-right: 10px;
   padding: 25px 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const MiddleSectionHeader = styled.div`
@@ -42,16 +43,28 @@ const MiddleSectionText = styled.div`
 `;
 
 const Overview = ({ history }: RouteComponentProps) => {
-  const account = useSelector((state: RootState) => state.wallet.accounts[state.wallet.currentAccountIndex]);
-  const isSmeshing = useSelector((state: RootState) => state.smesher.postSetupState === PostSetupState.STATE_COMPLETE);
-  const isCreatingPosData = useSelector((state: RootState) => state.smesher.postSetupState === PostSetupState.STATE_IN_PROGRESS);
+  const account = useSelector(
+    (state: RootState) =>
+      state.wallet.accounts[state.wallet.currentAccountIndex]
+  );
+  const isSmeshing = useSelector(
+    (state: RootState) =>
+      state.smesher.postSetupState === PostSetupState.STATE_COMPLETE
+  );
+  const isCreatingPosData = useSelector(
+    (state: RootState) =>
+      state.smesher.postSetupState === PostSetupState.STATE_IN_PROGRESS
+  );
 
   const navigateToSendCoins = () => {
     history.push(WalletPath.SendCoins);
   };
 
   const navigateToRequestCoins = () => {
-    history.push(WalletPath.RequestCoins, { account, isSmesherActive: isCreatingPosData || isSmeshing });
+    history.push(WalletPath.RequestCoins, {
+      account,
+      isSmesherActive: isCreatingPosData || isSmeshing,
+    });
   };
 
   const navigateToAllTransactions = () => {
@@ -68,12 +81,36 @@ const Overview = ({ history }: RouteComponentProps) => {
           <br />
           --
         </MiddleSectionHeader>
-        <MiddleSectionText>Send SMH to anyone, or request to receive SMH.</MiddleSectionText>
-        <Button onClick={navigateToSendCoins} text="SEND" isPrimary={false} width={225} img={sendIcon} imgPosition="after" style={{ marginBottom: 20 }} />
-        <Button onClick={navigateToRequestCoins} text="REQUEST" isPrimary={false} img={requestIcon} imgPosition="after" width={225} style={{ marginBottom: 35 }} />
-        <Link onClick={navigateToWalletGuide} text="WALLET GUIDE" style={{ marginRight: 'auto' }} />
+        <MiddleSectionText>
+          Send SMH to anyone, or request to receive SMH.
+        </MiddleSectionText>
+        <Button
+          onClick={navigateToSendCoins}
+          text="SEND"
+          isPrimary={false}
+          width={225}
+          img={sendIcon}
+          imgPosition="after"
+          style={{ marginBottom: 20 }}
+        />
+        <Button
+          onClick={navigateToRequestCoins}
+          text="REQUEST"
+          isPrimary={false}
+          img={requestIcon}
+          imgPosition="after"
+          width={225}
+          style={{ marginBottom: 35 }}
+        />
+        <Link
+          onClick={navigateToWalletGuide}
+          text="WALLET GUIDE"
+          style={{ marginRight: 'auto' }}
+        />
       </MiddleSection>
-      <LatestTransactions navigateToAllTransactions={navigateToAllTransactions} />
+      <LatestTransactions
+        navigateToAllTransactions={navigateToAllTransactions}
+      />
     </Wrapper>
   );
 };

--- a/app/screens/wallet/RequestCoins.tsx
+++ b/app/screens/wallet/RequestCoins.tsx
@@ -17,7 +17,8 @@ const Wrapper = styled.div`
   width: 710px;
   height: 100%;
   padding: 15px 25px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dmBlack2 : smColors.black02Alpha};
 `;
 
 const Header = styled.div`
@@ -145,14 +146,22 @@ const RequestCoins = ({ history, location }: Props) => {
       <Text>* Send this address to anyone you want to receive Smesh from.</Text>
       <ComplexText>
         <Text>* You may also paste this address in the&nbsp;</Text>
-        <Link onClick={navigateToTap} text="Testnet Tap" style={{ fontSize: 16, lineHeight: '22px' }} />
+        <Link
+          onClick={navigateToTap}
+          text="Testnet Tap"
+          style={{ fontSize: 16, lineHeight: '22px' }}
+        />
         <TextElement>.</TextElement>
       </ComplexText>
       <br />
       {!isSmesherActive && (
         <ComplexText>
           <Text>To earn Smesh&nbsp;</Text>
-          <Link onClick={navigateToNodeSetup} text="set up Smeshing" style={{ fontSize: 16, lineHeight: '22px' }} />
+          <Link
+            onClick={navigateToNodeSetup}
+            text="set up Smeshing"
+            style={{ fontSize: 16, lineHeight: '22px' }}
+          />
           <TextElement>.</TextElement>
         </ComplexText>
       )}

--- a/app/screens/wallet/SendCoins.tsx
+++ b/app/screens/wallet/SendCoins.tsx
@@ -3,7 +3,12 @@ import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { sendTransaction } from '../../redux/wallet/actions';
-import { TxParams, TxSummary, TxConfirmation, TxSent } from '../../components/wallet';
+import {
+  TxParams,
+  TxSummary,
+  TxConfirmation,
+  TxSent,
+} from '../../components/wallet';
 import { CreateNewContact } from '../../components/contacts';
 import { ensure0x, validateAddress } from '../../infra/utils';
 import { AppThDispatch, RootState } from '../../types';
@@ -21,7 +26,9 @@ interface Props extends RouteComponentProps {
 
 const SendCoins = ({ history, location }: Props) => {
   const [mode, setMode] = useState<1 | 2 | 3>(1);
-  const [address, setAddress] = useState(location?.state?.contact.address || '');
+  const [address, setAddress] = useState(
+    location?.state?.contact.address || ''
+  );
   const [hasAddressError, setHasAddressError] = useState(false);
   const [amount, setAmount] = useState(0);
   const [hasAmountError, setHasAmountError] = useState(false);
@@ -31,7 +38,10 @@ const SendCoins = ({ history, location }: Props) => {
   const [isCreateNewContactOn, setIsCreateNewContactOn] = useState(false);
 
   const status = useSelector((state: RootState) => state.node.status);
-  const currentAccount = useSelector((state: RootState) => state.wallet.accounts[state.wallet.currentAccountIndex]);
+  const currentAccount = useSelector(
+    (state: RootState) =>
+      state.wallet.accounts[state.wallet.currentAccountIndex]
+  );
   const contacts = useSelector((state: RootState) => state.wallet.contacts);
   // const lastUsedContacts = useSelector((state: RootState) => state.wallet.lastUsedContacts);
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
@@ -56,7 +66,9 @@ const SendCoins = ({ history, location }: Props) => {
   };
 
   const validateAmount = () => {
-    return !!amount && amount + fee < (currentAccount?.currentState?.balance || 0);
+    return (
+      !!amount && amount + fee < (currentAccount?.currentState?.balance || 0)
+    );
   };
 
   const proceedToMode2 = () => {
@@ -74,7 +86,9 @@ const SendCoins = ({ history, location }: Props) => {
 
   const handleSendTransaction = async () => {
     const receiver = address.replace(/^0x/, '');
-    const result = await dispatch(sendTransaction({ receiver, amount, fee, note }));
+    const result = await dispatch(
+      sendTransaction({ receiver, amount, fee, note })
+    );
     if (result?.id) {
       setMode(3);
       setTxId(result.id);
@@ -112,7 +126,14 @@ const SendCoins = ({ history, location }: Props) => {
             key="newContact"
           />
         ) : (
-          <TxSummary address={address} fromAddress={currentAccount.publicKey} amount={parseInt(`${amount}`)} fee={fee} note={note} key="summary" />
+          <TxSummary
+            address={address}
+            fromAddress={currentAccount.publicKey}
+            amount={parseInt(`${amount}`)}
+            fee={fee}
+            note={note}
+            key="summary"
+          />
         )}
       </>
     );

--- a/app/screens/wallet/Vault.tsx
+++ b/app/screens/wallet/Vault.tsx
@@ -2,7 +2,16 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import styled from 'styled-components';
-import { NewVault, VaultType, VaultMasterAccount, VaultMasterAccounts, DailySpending, VaultTx, ReviewNewVault, VaultFinish } from '../../components/vault';
+import {
+  NewVault,
+  VaultType,
+  VaultMasterAccount,
+  VaultMasterAccounts,
+  DailySpending,
+  VaultTx,
+  ReviewNewVault,
+  VaultFinish,
+} from '../../components/vault';
 import { CorneredContainer } from '../../components/common';
 import { vault } from '../../assets/images';
 import { Link, Button } from '../../basicComponents';
@@ -43,7 +52,9 @@ const Vault = ({ history }: RouteComponentProps) => {
   const [masterAccountIndex, setMasterAccountIndex] = useState(0);
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
   const vaultMode = useSelector((state: RootState) => state.wallet.vaultMode);
-  const accounts: Account[] = useSelector((state: RootState) => state.wallet.accounts);
+  const accounts: Account[] = useSelector(
+    (state: RootState) => state.wallet.accounts
+  );
 
   const dispatch = useDispatch();
 
@@ -76,7 +87,8 @@ const Vault = ({ history }: RouteComponentProps) => {
     setMasterAccountIndex(index);
   };
 
-  const navigateToVaultSetup = () => window.open('https://product.spacemesh.io/#/smapp_vaults');
+  const navigateToVaultSetup = () =>
+    window.open('https://product.spacemesh.io/#/smapp_vaults');
 
   const Steps = new Map();
 
@@ -85,39 +97,96 @@ const Vault = ({ history }: RouteComponentProps) => {
     {
       step: 0,
       header: 'NEW VAULT',
-      subHeader: 'A vault is an enhanced account with extra security and spending features.',
-      component: <NewVault vaultName={name} onChangeVaultName={handleChangeVaultName} isDarkMode={isDarkMode} />,
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      subHeader:
+        'A vault is an enhanced account with extra security and spending features.',
+      component: (
+        <NewVault
+          vaultName={name}
+          onChangeVaultName={handleChangeVaultName}
+          isDarkMode={isDarkMode}
+        />
+      ),
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: null,
     },
     {
       step: 1,
       header: 'VAULT TYPE',
       subHeader: 'Select vault’s type from one of the options below.',
-      component: <VaultType handleChangeType={handleChangeType} type={type} isDarkMode={isDarkMode} />,
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      component: (
+        <VaultType
+          handleChangeType={handleChangeType}
+          type={type}
+          isDarkMode={isDarkMode}
+        />
+      ),
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: null,
     },
     {
       step: 2,
       header: 'VAULT MASTER ACCOUNT',
-      subHeader: 'The master account is the account that will be used to perform vault operations such as withdrawing funds.',
-      component: <VaultMasterAccount masterAccountIndex={masterAccountIndex} selectedAccountIndex={selectAccountIndex} isDarkMode={isDarkMode} accountsOption={accountsOption} />,
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      subHeader:
+        'The master account is the account that will be used to perform vault operations such as withdrawing funds.',
+      component: (
+        <VaultMasterAccount
+          masterAccountIndex={masterAccountIndex}
+          selectedAccountIndex={selectAccountIndex}
+          isDarkMode={isDarkMode}
+          accountsOption={accountsOption}
+        />
+      ),
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: null,
     },
     {
       step: 3,
       header: 'DAILY SPENDING',
       subHeader: 'Select vault’s type from one of the options below.',
-      component: <DailySpending masterAccountIndex={masterAccountIndex} selectAccountIndex={selectAccountIndex} accountsOption={accountsOption} isDarkMode={isDarkMode} />,
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      component: (
+        <DailySpending
+          masterAccountIndex={masterAccountIndex}
+          selectAccountIndex={selectAccountIndex}
+          accountsOption={accountsOption}
+          isDarkMode={isDarkMode}
+        />
+      ),
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: <Link onClick={handleModeUp} text="SKIP" />,
     },
     {
       step: 4,
       header: 'CREATE VAULT TRANSACTION',
-      subHeader: 'Select a wallet’s account to execute the create vault transaction and set an amount to transfer from the account to the new vault.',
+      subHeader:
+        'Select a wallet’s account to execute the create vault transaction and set an amount to transfer from the account to the new vault.',
       component: (
         <VaultTx
           selectAccountIndex={selectAccountIndex}
@@ -127,23 +196,54 @@ const Vault = ({ history }: RouteComponentProps) => {
           isDarkMode={isDarkMode}
         />
       ),
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
-      finishButton: <Link onClick={saveAndFinish} text="SAVE AND FINISH LATER" />,
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
+      finishButton: (
+        <Link onClick={saveAndFinish} text="SAVE AND FINISH LATER" />
+      ),
     },
     {
       step: 5,
       header: 'REVIEW NEW VAULT',
       subHeader: 'Review your new vault information.',
       component: <ReviewNewVault isDarkMode={isDarkMode} />,
-      nextButton: <Button text="CREATE VAULT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
-      finishButton: <Button text="CANCEL" onClick={history.goBack} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} isPrimary={false} />,
+      nextButton: (
+        <Button
+          text="CREATE VAULT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
+      finishButton: (
+        <Button
+          text="CANCEL"
+          onClick={history.goBack}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+          isPrimary={false}
+        />
+      ),
     },
     {
       step: 6,
       header: 'NEW VAULT SUBMITTED!',
       subHeader: '',
       component: <VaultFinish isDarkMode={isDarkMode} />,
-      nextButton: <Button text="DONE" onClick={history.goBack} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      nextButton: (
+        <Button
+          text="DONE"
+          onClick={history.goBack}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: null,
     },
   ]);
@@ -152,39 +252,98 @@ const Vault = ({ history }: RouteComponentProps) => {
     {
       step: 0,
       header: 'NEW VAULT',
-      subHeader: 'A vault is an enhanced account with extra security and spending features.',
-      component: <NewVault vaultName={name} onChangeVaultName={handleChangeVaultName} isDarkMode={isDarkMode} />,
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      subHeader:
+        'A vault is an enhanced account with extra security and spending features.',
+      component: (
+        <NewVault
+          vaultName={name}
+          onChangeVaultName={handleChangeVaultName}
+          isDarkMode={isDarkMode}
+        />
+      ),
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: null,
     },
     {
       step: 1,
       header: 'VAULT TYPE',
       subHeader: 'Select vault’s type from one of the options below.',
-      component: <VaultType handleChangeType={handleChangeType} type={type} isDarkMode={isDarkMode} />,
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      component: (
+        <VaultType
+          handleChangeType={handleChangeType}
+          type={type}
+          isDarkMode={isDarkMode}
+        />
+      ),
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: null,
     },
     {
       step: 2,
       header: 'VAULT MASTER ACCOUNT',
-      subHeader: 'The master account is the account that will be used to perform vault operations such as withdrawing funds.',
-      component: <VaultMasterAccounts masterAccountIndex={masterAccountIndex} selectAccountIndex={selectAccountIndex} isDarkMode={isDarkMode} accountsOption={accountsOption} />,
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
-      finishButton: <Link onClick={saveAndFinish} text="SAVE AND FINISH LATER" />,
+      subHeader:
+        'The master account is the account that will be used to perform vault operations such as withdrawing funds.',
+      component: (
+        <VaultMasterAccounts
+          masterAccountIndex={masterAccountIndex}
+          selectAccountIndex={selectAccountIndex}
+          isDarkMode={isDarkMode}
+          accountsOption={accountsOption}
+        />
+      ),
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
+      finishButton: (
+        <Link onClick={saveAndFinish} text="SAVE AND FINISH LATER" />
+      ),
     },
     {
       step: 3,
       header: 'DAILY SPENDING',
       subHeader: 'Select vault’s type from one of the options below.',
-      component: <DailySpending masterAccountIndex={masterAccountIndex} selectAccountIndex={selectAccountIndex} accountsOption={accountsOption} isDarkMode={isDarkMode} />,
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      component: (
+        <DailySpending
+          masterAccountIndex={masterAccountIndex}
+          selectAccountIndex={selectAccountIndex}
+          accountsOption={accountsOption}
+          isDarkMode={isDarkMode}
+        />
+      ),
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: <Link onClick={handleModeUp} text="SKIP" />,
     },
     {
       step: 4,
       header: 'CREATE VAULT TRANSACTION',
-      subHeader: 'Select a wallet’s account to execute the create vault transaction and set an amount to transfer from the account to the new vault.',
+      subHeader:
+        'Select a wallet’s account to execute the create vault transaction and set an amount to transfer from the account to the new vault.',
       component: (
         <VaultTx
           selectAccountIndex={selectAccountIndex}
@@ -194,23 +353,54 @@ const Vault = ({ history }: RouteComponentProps) => {
           isDarkMode={isDarkMode}
         />
       ),
-      nextButton: <Button text="NEXT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
-      finishButton: <Link onClick={saveAndFinish} text="SAVE AND FINISH LATER" />,
+      nextButton: (
+        <Button
+          text="NEXT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
+      finishButton: (
+        <Link onClick={saveAndFinish} text="SAVE AND FINISH LATER" />
+      ),
     },
     {
       step: 5,
       header: 'REVIEW NEW VAULT',
       subHeader: 'Review your new vault information.',
       component: <ReviewNewVault isDarkMode={isDarkMode} />,
-      nextButton: <Button text="CREATE VAULT" onClick={handleModeUp} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
-      finishButton: <Button text="CANCEL" onClick={history.goBack} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} isPrimary={false} />,
+      nextButton: (
+        <Button
+          text="CREATE VAULT"
+          onClick={handleModeUp}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
+      finishButton: (
+        <Button
+          text="CANCEL"
+          onClick={history.goBack}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+          isPrimary={false}
+        />
+      ),
     },
     {
       step: 6,
       header: 'NEW VAULT SUBMITTED!',
       subHeader: '',
       component: <VaultFinish isDarkMode={isDarkMode} />,
-      nextButton: <Button text="DONE" onClick={history.goBack} isDisabled={name.length === 0} style={{ marginTop: 'auto' }} />,
+      nextButton: (
+        <Button
+          text="DONE"
+          onClick={history.goBack}
+          isDisabled={name.length === 0}
+          style={{ marginTop: 'auto' }}
+        />
+      ),
       finishButton: null,
     },
   ]);

--- a/app/screens/wallet/Wallet.tsx
+++ b/app/screens/wallet/Wallet.tsx
@@ -33,7 +33,8 @@ const BackupReminder = styled.div`
   height: 50px;
   margin-top: 10px;
   padding: 0 15px;
-  background-color: ${({ theme }) => (theme.isDarkMode ? smColors.dMBlack1 : smColors.black02Alpha)};
+  background-color: ${({ theme }) =>
+    theme.isDarkMode ? smColors.dMBlack1 : smColors.black02Alpha};
   cursor: pointer;
 `;
 
@@ -101,7 +102,12 @@ const Wallet = ({ history, location }: RouteComponentProps) => {
         <RightSection>
           <Switch>
             {routes.wallet.map((route) => (
-              <Route exact key={route.path} path={route.path} component={route.component} />
+              <Route
+                exact
+                key={route.path}
+                path={route.path}
+                component={route.component}
+              />
             ))}
             <Redirect to="/main/wallet/overview" />
           </Switch>

--- a/app/types/events.ts
+++ b/app/types/events.ts
@@ -9,7 +9,9 @@ type MiscNetParams = {
   explorerUrl: string;
 };
 
-export type NetworkDefinitions = (NetDescriptor & MiscNetParams) | NetDescriptor;
+export type NetworkDefinitions =
+  | (NetDescriptor & MiscNetParams)
+  | NetDescriptor;
 
 export type CurrentLayer = {
   currentLayer: number;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,3 +1,12 @@
-export type { RootState, NetworkState, NodeState, WalletState, UiState, CustomAction, GetState, AppThDispatch } from './redux';
+export type {
+  RootState,
+  NetworkState,
+  NodeState,
+  WalletState,
+  UiState,
+  CustomAction,
+  GetState,
+  AppThDispatch,
+} from './redux';
 export type { Reward } from './smesher';
 export { BITS } from './smesher';

--- a/app/types/redux.ts
+++ b/app/types/redux.ts
@@ -1,5 +1,17 @@
 import { ThunkDispatch } from 'redux-thunk';
-import { AccountWithBalance, Contact, NodeError, NodeStatus, WalletMeta, PostSetupState, PostSetupComputeProvider, SmesherConfig, HexString, Tx, Reward } from '../../shared/types';
+import {
+  AccountWithBalance,
+  Contact,
+  NodeError,
+  NodeStatus,
+  WalletMeta,
+  PostSetupState,
+  PostSetupComputeProvider,
+  SmesherConfig,
+  HexString,
+  Tx,
+  Reward,
+} from '../../shared/types';
 import { UpdaterState } from '../redux/updater/slice';
 
 export interface NetworkState {

--- a/desktop/AccountState.ts
+++ b/desktop/AccountState.ts
@@ -26,14 +26,17 @@ const getDefaultAccountState = (publicKey: string): AccountState => ({
   rewards: {},
 });
 
-const getFilePath = (publicKey: string, baseDir: string) => path.resolve(baseDir, `${publicKey}.json`);
+const getFilePath = (publicKey: string, baseDir: string) =>
+  path.resolve(baseDir, `${publicKey}.json`);
 
 // Side-effects
 const DEFAULT_BASE_DIR = path.resolve(app.getPath('userData'), 'accounts');
 
 const load = (publicKey: string, baseDir = DEFAULT_BASE_DIR): AccountState => {
   try {
-    const raw = fs.readFileSync(getFilePath(publicKey, baseDir), { encoding: 'utf8' });
+    const raw = fs.readFileSync(getFilePath(publicKey, baseDir), {
+      encoding: 'utf8',
+    });
     const parsed = JSON.parse(raw);
     return {
       ...getDefaultAccountState(publicKey),

--- a/desktop/GlobalStateService.ts
+++ b/desktop/GlobalStateService.ts
@@ -19,9 +19,14 @@ interface AccountDataStreamHandlerArg {
   [AccountDataFlag.ACCOUNT_DATA_FLAG_TRANSACTION_RECEIPT]: TransactionReceipt__Output;
 }
 
-type AccountDataValidFlags = Exclude<AccountDataFlag, AccountDataFlag.ACCOUNT_DATA_FLAG_UNSPECIFIED>;
+type AccountDataValidFlags = Exclude<
+  AccountDataFlag,
+  AccountDataFlag.ACCOUNT_DATA_FLAG_UNSPECIFIED
+>;
 type AccountDataStreamKey = Exclude<keyof AccountData__Output, 'datum'>;
-const getKeyByAccoundDataFlag = (flag: AccountDataValidFlags): AccountDataStreamKey => {
+const getKeyByAccoundDataFlag = (
+  flag: AccountDataValidFlags
+): AccountDataStreamKey => {
   const keys: Record<AccountDataValidFlags, AccountDataStreamKey> = {
     [AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD]: 'reward',
     [AccountDataFlag.ACCOUNT_DATA_FLAG_TRANSACTION_RECEIPT]: 'receipt',
@@ -30,7 +35,10 @@ const getKeyByAccoundDataFlag = (flag: AccountDataValidFlags): AccountDataStream
   return keys[flag];
 };
 
-class GlobalStateService extends NetServiceFactory<ProtoGrpcType, 'GlobalStateService'> {
+class GlobalStateService extends NetServiceFactory<
+  ProtoGrpcType,
+  'GlobalStateService'
+> {
   logger = Logger({ className: 'GlobalStateService' });
 
   createService = (apiUrl?: SocketAddress | PublicService) => {
@@ -41,12 +49,23 @@ class GlobalStateService extends NetServiceFactory<ProtoGrpcType, 'GlobalStateSe
     this.callService('GlobalStateHash', {})
       .then((response) => ({
         layer: response.response?.layer?.number || 0,
-        rootHash: response.response?.rootHash ? toHexString(response.response.rootHash) : '',
+        rootHash: response.response?.rootHash
+          ? toHexString(response.response.rootHash)
+          : '',
       }))
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ layer: -1, rootHash: '' }));
 
-  sendAccountDataQuery = ({ filter, offset }: { filter: { accountId: { address: Uint8Array }; accountDataFlags: AccountDataFlag }; offset: number }) =>
+  sendAccountDataQuery = ({
+    filter,
+    offset,
+  }: {
+    filter: {
+      accountId: { address: Uint8Array };
+      accountDataFlags: AccountDataFlag;
+    };
+    offset: number;
+  }) =>
     this.callService('AccountDataQuery', { filter, maxResults: 50, offset })
       .then((response) => ({
         totalResults: response.totalResults,
@@ -55,7 +74,11 @@ class GlobalStateService extends NetServiceFactory<ProtoGrpcType, 'GlobalStateSe
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ totalResults: 0, data: [] }));
 
-  activateAccountDataStream = <K extends AccountDataValidFlags>(address: Uint8Array, accountDataFlags: K, handler: (data: AccountDataStreamHandlerArg[K]) => void) =>
+  activateAccountDataStream = <K extends AccountDataValidFlags>(
+    address: Uint8Array,
+    accountDataFlags: K,
+    handler: (data: AccountDataStreamHandlerArg[K]) => void
+  ) =>
     this.runStream(
       'AccountDataStream',
       {

--- a/desktop/MeshService.ts
+++ b/desktop/MeshService.ts
@@ -24,18 +24,33 @@ class MeshService extends NetServiceFactory<ProtoGrpcType, 'MeshService'> {
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ currentLayer: -1 }));
 
-  sendAccountMeshDataQuery = ({ accountId, offset }: { accountId: Uint8Array; offset: number }) =>
-    this.callService('AccountMeshDataQuery', { filter: { accountId: { address: accountId }, accountMeshDataFlags: 1 }, minLayer: { number: 0 }, maxResults: 50, offset })
+  sendAccountMeshDataQuery = ({
+    accountId,
+    offset,
+  }: {
+    accountId: Uint8Array;
+    offset: number;
+  }) =>
+    this.callService('AccountMeshDataQuery', {
+      filter: { accountId: { address: accountId }, accountMeshDataFlags: 1 },
+      minLayer: { number: 0 },
+      maxResults: 50,
+      offset,
+    })
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ totalResults: 0, data: [] }));
 
-  activateAccountMeshDataStream = (accountId: Uint8Array, handler: (tx: any) => void) =>
+  activateAccountMeshDataStream = (
+    accountId: Uint8Array,
+    handler: (tx: any) => void
+  ) =>
     this.runStream(
       'AccountMeshDataStream',
       {
         filter: {
           accountId: { address: accountId },
-          accountMeshDataFlags: AccountMeshDataFlag.ACCOUNT_MESH_DATA_FLAG_TRANSACTIONS,
+          accountMeshDataFlags:
+            AccountMeshDataFlag.ACCOUNT_MESH_DATA_FLAG_TRANSACTIONS,
         },
       },
       (data: AccountMeshDataStreamResponse__Output) => {

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -7,10 +7,25 @@ import Logger from './logger';
 
 // Types
 type Proto = { spacemesh: { v1: any; [k: string]: any }; [k: string]: any };
-export type Service<P extends Proto, ServiceName extends keyof P['spacemesh']['v1']> = InstanceType<P['spacemesh']['v1'][ServiceName]>;
-export type ServiceOpts<P extends Proto, ServiceName extends keyof P['spacemesh']['v1'], K extends keyof Service<P, ServiceName>> = Parameters<Service<P, ServiceName>[K]>[0];
-export type ServiceCallback<P extends Proto, ServiceName extends keyof P['spacemesh']['v1'], K extends keyof Service<P, ServiceName>> = Parameters<Service<P, ServiceName>[K]>[1];
-export type ServiceCallbackResult<P extends Proto, ServiceName extends keyof P['spacemesh']['v1'], K extends keyof Service<P, ServiceName>> =
+export type Service<
+  P extends Proto,
+  ServiceName extends keyof P['spacemesh']['v1']
+> = InstanceType<P['spacemesh']['v1'][ServiceName]>;
+export type ServiceOpts<
+  P extends Proto,
+  ServiceName extends keyof P['spacemesh']['v1'],
+  K extends keyof Service<P, ServiceName>
+> = Parameters<Service<P, ServiceName>[K]>[0];
+export type ServiceCallback<
+  P extends Proto,
+  ServiceName extends keyof P['spacemesh']['v1'],
+  K extends keyof Service<P, ServiceName>
+> = Parameters<Service<P, ServiceName>[K]>[1];
+export type ServiceCallbackResult<
+  P extends Proto,
+  ServiceName extends keyof P['spacemesh']['v1'],
+  K extends keyof Service<P, ServiceName>
+> =
   // @ts-ignore
   // TODO: It works fine, but TypeScript finds this errorish
   Parameters<ServiceCallback<P, ServiceName, K>>[1];
@@ -24,7 +39,10 @@ const ERROR_CODE_TO_RESTART_STREAM = [
 
 // Abstract Class
 
-class NetServiceFactory<T extends { spacemesh: { v1: any; [k: string]: any }; [k: string]: any }, ServiceName extends keyof T['spacemesh']['v1']> {
+class NetServiceFactory<
+  T extends { spacemesh: { v1: any; [k: string]: any }; [k: string]: any },
+  ServiceName extends keyof T['spacemesh']['v1']
+> {
   protected service: Service<T, ServiceName> | null = null;
 
   protected serviceName: string | null = null;
@@ -33,9 +51,16 @@ class NetServiceFactory<T extends { spacemesh: { v1: any; [k: string]: any }; [k
 
   private apiUrl: SocketAddress | null = null;
 
-  private restartStreamList: Record<keyof Service<T, ServiceName>, () => void> = <typeof this.restartStreamList>{};
+  private restartStreamList: Record<
+    keyof Service<T, ServiceName>,
+    () => void
+  > = <typeof this.restartStreamList>{};
 
-  createNetService = (protoPath: string, apiUrl: SocketAddress | PublicService = LOCAL_NODE_API_URL, serviceName: string) => {
+  createNetService = (
+    protoPath: string,
+    apiUrl: SocketAddress | PublicService = LOCAL_NODE_API_URL,
+    serviceName: string
+  ) => {
     if (this.apiUrl === apiUrl) return;
 
     if (this.service) {
@@ -45,43 +70,72 @@ class NetServiceFactory<T extends { spacemesh: { v1: any; [k: string]: any }; [k
 
     const resolvedProtoPath = path.join(__dirname, '..', protoPath);
     const packageDefinition = loadSync(resolvedProtoPath);
-    const proto = (grpc.loadPackageDefinition(packageDefinition) as unknown) as T;
+    const proto = (grpc.loadPackageDefinition(
+      packageDefinition
+    ) as unknown) as T;
     const Service = proto.spacemesh.v1[serviceName];
-    const connectionType = this.apiUrl.protocol === 'http:' ? grpc.credentials.createInsecure() : grpc.credentials.createSsl();
-    this.service = new Service(`${this.apiUrl.host}:${this.apiUrl.port}`, connectionType);
+    const connectionType =
+      this.apiUrl.protocol === 'http:'
+        ? grpc.credentials.createInsecure()
+        : grpc.credentials.createSsl();
+    this.service = new Service(
+      `${this.apiUrl.host}:${this.apiUrl.port}`,
+      connectionType
+    );
     this.serviceName = serviceName;
   };
 
   ensureService = (): Promise<Service<T, ServiceName>> =>
-    this.service ? Promise.resolve(this.service) : Promise.reject(new Error(`Service "${this.serviceName}" is not running`));
+    this.service
+      ? Promise.resolve(this.service)
+      : Promise.reject(
+          new Error(`Service "${this.serviceName}" is not running`)
+        );
 
-  callService = <K extends keyof Service<T, ServiceName>>(method: K, opts: ServiceOpts<T, ServiceName, K>) => {
+  callService = <K extends keyof Service<T, ServiceName>>(
+    method: K,
+    opts: ServiceOpts<T, ServiceName, K>
+  ) => {
     type ResultArg = ServiceCallbackResult<T, ServiceName, K>;
     type Result = NonNullable<ResultArg>;
     return this.ensureService().then(
       (_service) =>
         new Promise<Result>((resolve, reject) => {
-          _service[method](opts, (error: grpc.ServiceError, result: ResultArg) => {
-            if (error || !result) {
-              const err = error || new Error(`No result or error received: ${this.serviceName}.${method}`);
-              this.logger?.error(`grpc call ${this.serviceName}.${method}`, err);
-              reject(err);
-            } else if (result) {
-              resolve(result as Result); // TODO ?
+          _service[method](
+            opts,
+            (error: grpc.ServiceError, result: ResultArg) => {
+              if (error || !result) {
+                const err =
+                  error ||
+                  new Error(
+                    `No result or error received: ${this.serviceName}.${method}`
+                  );
+                this.logger?.error(
+                  `grpc call ${this.serviceName}.${method}`,
+                  err
+                );
+                reject(err);
+              } else if (result) {
+                resolve(result as Result); // TODO ?
+              }
             }
-          });
+          );
         })
     );
   };
 
   // TODO: Get rid of mixing with `error`
-  normalizeServiceResponse = <ResponseData extends Record<string, any>>(data: ResponseData): ResponseData & { error: null } => ({
+  normalizeServiceResponse = <ResponseData extends Record<string, any>>(
+    data: ResponseData
+  ): ResponseData & { error: null } => ({
     ...data,
     error: null,
   });
 
   // TODO: Get rid of mixing with `error`
-  normalizeServiceError = <D extends Record<string, any>>(defaults: D) => (error: Error) => ({
+  normalizeServiceError = <D extends Record<string, any>>(defaults: D) => (
+    error: Error
+  ) => ({
     ...defaults,
     error,
   });
@@ -114,7 +168,10 @@ class NetServiceFactory<T extends { spacemesh: { v1: any; [k: string]: any }; [k
           clearTimeout(timeout);
           timeout = setTimeout(() => {
             // console.log(`${this.serviceName}.${method} restarting...`); // eslint-disable-line no-console
-            this.logger?.error(`grpc ${this.serviceName}.${method} restarting...`, null);
+            this.logger?.error(
+              `grpc ${this.serviceName}.${method} restarting...`,
+              null
+            );
             startStream(retries - 1);
           }, 5000);
         }
@@ -137,7 +194,8 @@ class NetServiceFactory<T extends { spacemesh: { v1: any; [k: string]: any }; [k
     return cancel;
   };
 
-  restartStreams = () => Object.values(this.restartStreamList).forEach((fn) => fn.call(this));
+  restartStreams = () =>
+    Object.values(this.restartStreamList).forEach((fn) => fn.call(this));
 }
 
 export default NetServiceFactory;

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -7,12 +7,27 @@ import { app, ipcMain, BrowserWindow, dialog } from 'electron';
 import { ChildProcess } from 'node:child_process';
 import { ipcConsts } from '../app/vars';
 import { delay } from '../shared/utils';
-import { NodeError, NodeErrorLevel, NodeStatus, PostSetupOpts, PublicService, SocketAddress } from '../shared/types';
+import {
+  NodeError,
+  NodeErrorLevel,
+  NodeStatus,
+  PostSetupOpts,
+  PublicService,
+  SocketAddress,
+} from '../shared/types';
 import StoreService from './storeService';
 import Logger from './logger';
-import NodeService, { ErrorStreamHandler, StatusStreamHandler } from './NodeService';
+import NodeService, {
+  ErrorStreamHandler,
+  StatusStreamHandler,
+} from './NodeService';
 import SmesherManager from './SmesherManager';
-import { checksum, createDebouncePool, isEmptyDir, isFileExists } from './utils';
+import {
+  checksum,
+  createDebouncePool,
+  isEmptyDir,
+  isFileExists,
+} from './utils';
 import { NODE_CONFIG_FILE } from './main/constants';
 import NodeConfig from './main/NodeConfig';
 import { getNodeLogsPath, readLinesFromBottom } from './main/utils';
@@ -29,14 +44,19 @@ const PROCESS_EXIT_TIMEOUT = 20000; // 20 sec
 const PROCESS_EXIT_CHECK_INTERVAL = 1000; // Check does the process exited
 
 const defaultCrashError = (error?: Error): NodeError => ({
-  msg: "The Spacemesh node software has unexpectedly quit. Click on 'restart node' to start it.",
+  msg:
+    "The Spacemesh node software has unexpectedly quit. Click on 'restart node' to start it.",
   stackTrace: error?.stack || '',
   level: NodeErrorLevel.LOG_LEVEL_FATAL,
   module: 'NodeManager',
 });
 
 type PoolNodeError = { type: 'NodeError'; error: NodeError };
-type PoolExitCode = { type: 'Exit'; code: number | null; signal: NodeJS.Signals | null };
+type PoolExitCode = {
+  type: 'Exit';
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
 type ErrorPoolObject = PoolNodeError | PoolExitCode;
 
 class NodeManager {
@@ -50,51 +70,69 @@ class NodeManager {
 
   private netId: number;
 
-  private pushToErrorPool = createDebouncePool<ErrorPoolObject>(100, async (poolList) => {
-    const exitError = poolList.find((e) => e.type === 'Exit') as PoolExitCode | undefined;
-    // In case if Node exited with 0 code count that
-    // there was no errors and do not notify client about any of
-    // possible errors caused by exiting
-    if (exitError && exitError.code === 0) return;
-    // If pool have some errors, but Node is not closed —
-    // find a most critical within the pool and notify the client about it
-    // Checking for `!exitError` is needed to avoid showing some fatal errors
-    // that are consequence of Node crash
-    // E.G. SIGKILL of Node will also produce a bunch of GRPC errors
-    if (!exitError) {
-      const errors = poolList.filter((a) => a.type === 'NodeError') as PoolNodeError[];
-      if (errors.length > 1) {
-        const mostCriticalError = errors.sort((a, b) => b.error.level - a.error.level)[0].error;
-        this.sendNodeError(mostCriticalError);
+  private pushToErrorPool = createDebouncePool<ErrorPoolObject>(
+    100,
+    async (poolList) => {
+      const exitError = poolList.find((e) => e.type === 'Exit') as
+        | PoolExitCode
+        | undefined;
+      // In case if Node exited with 0 code count that
+      // there was no errors and do not notify client about any of
+      // possible errors caused by exiting
+      if (exitError && exitError.code === 0) return;
+      // If pool have some errors, but Node is not closed —
+      // find a most critical within the pool and notify the client about it
+      // Checking for `!exitError` is needed to avoid showing some fatal errors
+      // that are consequence of Node crash
+      // E.G. SIGKILL of Node will also produce a bunch of GRPC errors
+      if (!exitError) {
+        const errors = poolList.filter(
+          (a) => a.type === 'NodeError'
+        ) as PoolNodeError[];
+        if (errors.length > 1) {
+          const mostCriticalError = errors.sort(
+            (a, b) => b.error.level - a.error.level
+          )[0].error;
+          this.sendNodeError(mostCriticalError);
+          return;
+        }
+      }
+      // Otherwise if Node exited, but there are no critical errors
+      // in the pool — search for fatal error in the logs
+      const lastLines = await readLinesFromBottom(
+        getNodeLogsPath(this.netId),
+        100
+      );
+      const fatalErrorLine = lastLines.find((line) =>
+        /^\{"L":"FATAL",.+\}$/.test(line)
+      );
+      if (!fatalErrorLine) {
+        // If we can't find fatal error — show default crash error
+        this.sendNodeError(defaultCrashError());
         return;
       }
+      // If we found fatal error — parse it and convert to NodeError
+      try {
+        const json = JSON.parse(fatalErrorLine);
+        const fatalError = {
+          msg: json.errmsg || json.M,
+          level: NodeErrorLevel.LOG_LEVEL_FATAL,
+          module: 'NodeManager',
+          stackTrace: '',
+        };
+        this.sendNodeError(fatalError);
+      } catch (err) {
+        // If we can't parse it — show default error message
+        this.sendNodeError(defaultCrashError(err as Error));
+      }
     }
-    // Otherwise if Node exited, but there are no critical errors
-    // in the pool — search for fatal error in the logs
-    const lastLines = await readLinesFromBottom(getNodeLogsPath(this.netId), 100);
-    const fatalErrorLine = lastLines.find((line) => /^\{"L":"FATAL",.+\}$/.test(line));
-    if (!fatalErrorLine) {
-      // If we can't find fatal error — show default crash error
-      this.sendNodeError(defaultCrashError());
-      return;
-    }
-    // If we found fatal error — parse it and convert to NodeError
-    try {
-      const json = JSON.parse(fatalErrorLine);
-      const fatalError = {
-        msg: json.errmsg || json.M,
-        level: NodeErrorLevel.LOG_LEVEL_FATAL,
-        module: 'NodeManager',
-        stackTrace: '',
-      };
-      this.sendNodeError(fatalError);
-    } catch (err) {
-      // If we can't parse it — show default error message
-      this.sendNodeError(defaultCrashError(err as Error));
-    }
-  });
+  );
 
-  constructor(mainWindow: BrowserWindow, netId: number, smesherManager: SmesherManager) {
+  constructor(
+    mainWindow: BrowserWindow,
+    netId: number,
+    smesherManager: SmesherManager
+  ) {
     this.mainWindow = mainWindow;
     this.nodeService = new NodeService();
     this.subscribeToEvents();
@@ -104,11 +142,18 @@ class NodeManager {
   }
 
   subscribeToEvents = () => {
-    ipcMain.handle(ipcConsts.N_M_START_NODE, async () => (this.isNodeRunning() ? true : this.startNode()));
+    ipcMain.handle(ipcConsts.N_M_START_NODE, async () =>
+      this.isNodeRunning() ? true : this.startNode()
+    );
 
     ipcMain.on(ipcConsts.N_M_GET_VERSION_AND_BUILD, () =>
       this.getVersionAndBuild()
-        .then((payload) => this.mainWindow.webContents.send(ipcConsts.N_M_GET_VERSION_AND_BUILD, payload))
+        .then((payload) =>
+          this.mainWindow.webContents.send(
+            ipcConsts.N_M_GET_VERSION_AND_BUILD,
+            payload
+          )
+        )
         .catch((error) => {
           this.sendNodeError(error);
           logger.error('getVersionAndBuild', error);
@@ -129,55 +174,64 @@ class NodeManager {
         })
     );
 
-    ipcMain.handle(ipcConsts.SMESHER_START_SMESHING, async (_event, { postSetupOpts }: { postSetupOpts: PostSetupOpts }) => {
-      if (!postSetupOpts.dataDir) {
-        throw new Error('Can not setup Smeshing without specified data directory');
-      }
-      // Temporary solution of https://github.com/spacemeshos/smapp/issues/823
-      const CURRENT_DATADIR_PATH = await this.smesherManager.getCurrentDataDir();
-      const CURRENT_KEYBIN_PATH = path.resolve(CURRENT_DATADIR_PATH, 'key.bin');
-      const NEXT_KEYBIN_PATH = path.resolve(postSetupOpts.dataDir, 'key.bin');
-
-      const isDefaultKeyFileExist = await isFileExists(CURRENT_KEYBIN_PATH);
-      const isDataDirKeyFileExist = await isFileExists(NEXT_KEYBIN_PATH);
-      const isSameDataDir = CURRENT_DATADIR_PATH === postSetupOpts?.dataDir;
-
-      const startSmeshingAsUsual = async (opts) => {
-        // Next two lines is a normal workflow.
-        // It can be moved back to SmesherManager when issue
-        // https://github.com/spacemeshos/go-spacemesh/issues/2858
-        // will be solved, and all these kludges can be removed.
-        await this.smesherManager.startSmeshing(opts);
-        return this.smesherManager.updateSmeshingConfig(opts);
-      };
-
-      // If post data-dir does not changed and it contains key.bin file
-      // assume that everything is fine and start smeshing as usual
-      if (isSameDataDir && isDataDirKeyFileExist) return startSmeshingAsUsual(postSetupOpts);
-
-      // In other cases:
-      // NextDataDir    CurrentDataDir     Action
-      // Not exist      Exist              Copy key.bin & start
-      // Not exist      Not exist          Update config & restart node
-      // Exist          Not exist          Update config & restart node
-      // Exist          Exist              Compare checksum
-      //                                   - if equal: start as usual
-      //                                   - if not: update config & restart node
-      if (isDefaultKeyFileExist && !isDataDirKeyFileExist) {
-        await fs.promises.copyFile(CURRENT_KEYBIN_PATH, NEXT_KEYBIN_PATH);
-        return startSmeshingAsUsual(postSetupOpts);
-      } else if (isDefaultKeyFileExist && isDataDirKeyFileExist) {
-        const defChecksum = await checksum(CURRENT_KEYBIN_PATH);
-        const dataChecksum = await checksum(NEXT_KEYBIN_PATH);
-        if (defChecksum === dataChecksum) {
-          return startSmeshingAsUsual(postSetupOpts);
+    ipcMain.handle(
+      ipcConsts.SMESHER_START_SMESHING,
+      async (_event, { postSetupOpts }: { postSetupOpts: PostSetupOpts }) => {
+        if (!postSetupOpts.dataDir) {
+          throw new Error(
+            'Can not setup Smeshing without specified data directory'
+          );
         }
+        // Temporary solution of https://github.com/spacemeshos/smapp/issues/823
+        const CURRENT_DATADIR_PATH = await this.smesherManager.getCurrentDataDir();
+        const CURRENT_KEYBIN_PATH = path.resolve(
+          CURRENT_DATADIR_PATH,
+          'key.bin'
+        );
+        const NEXT_KEYBIN_PATH = path.resolve(postSetupOpts.dataDir, 'key.bin');
+
+        const isDefaultKeyFileExist = await isFileExists(CURRENT_KEYBIN_PATH);
+        const isDataDirKeyFileExist = await isFileExists(NEXT_KEYBIN_PATH);
+        const isSameDataDir = CURRENT_DATADIR_PATH === postSetupOpts?.dataDir;
+
+        const startSmeshingAsUsual = async (opts) => {
+          // Next two lines is a normal workflow.
+          // It can be moved back to SmesherManager when issue
+          // https://github.com/spacemeshos/go-spacemesh/issues/2858
+          // will be solved, and all these kludges can be removed.
+          await this.smesherManager.startSmeshing(opts);
+          return this.smesherManager.updateSmeshingConfig(opts);
+        };
+
+        // If post data-dir does not changed and it contains key.bin file
+        // assume that everything is fine and start smeshing as usual
+        if (isSameDataDir && isDataDirKeyFileExist)
+          return startSmeshingAsUsual(postSetupOpts);
+
+        // In other cases:
+        // NextDataDir    CurrentDataDir     Action
+        // Not exist      Exist              Copy key.bin & start
+        // Not exist      Not exist          Update config & restart node
+        // Exist          Not exist          Update config & restart node
+        // Exist          Exist              Compare checksum
+        //                                   - if equal: start as usual
+        //                                   - if not: update config & restart node
+        if (isDefaultKeyFileExist && !isDataDirKeyFileExist) {
+          await fs.promises.copyFile(CURRENT_KEYBIN_PATH, NEXT_KEYBIN_PATH);
+          return startSmeshingAsUsual(postSetupOpts);
+        } else if (isDefaultKeyFileExist && isDataDirKeyFileExist) {
+          const defChecksum = await checksum(CURRENT_KEYBIN_PATH);
+          const dataChecksum = await checksum(NEXT_KEYBIN_PATH);
+          if (defChecksum === dataChecksum) {
+            return startSmeshingAsUsual(postSetupOpts);
+          }
+        }
+        // In other cases — update config first and then restart the node
+        // it will start Smeshing automatically based on the config
+        await this.smesherManager.updateSmeshingConfig(postSetupOpts);
+        return this.restartNode();
       }
-      // In other cases — update config first and then restart the node
-      // it will start Smeshing automatically based on the config
-      await this.smesherManager.updateSmeshingConfig(postSetupOpts);
-      return this.restartNode();
-    });
+    );
 
     ipcMain.handle(ipcConsts.PROMPT_CHANGE_DATADIR, async () => {
       const oldPath = StoreService.get('node.dataPath');
@@ -193,12 +247,15 @@ class NodeManager {
       // Validate new dir
       await fse.ensureDir(newPath);
       if (!(await isEmptyDir(newPath))) {
-        throw new Error(`Can not switch Node Data directory: ${newPath} is not empty`);
+        throw new Error(
+          `Can not switch Node Data directory: ${newPath} is not empty`
+        );
       }
       // Stop the Node
       await this.stopNode();
       // Move old data to new place if needed
-      if (!(await isEmptyDir(oldPath))) await fse.move(oldPath, newPath, { overwrite: true });
+      if (!(await isEmptyDir(oldPath)))
+        await fse.move(oldPath, newPath, { overwrite: true });
       // Update persistent store
       StoreService.set('node.dataPath', newPath);
       // Start the Node
@@ -244,14 +301,35 @@ class NodeManager {
   private spawnNode = async () => {
     if (this.nodeProcess) return;
     const userDataPath = app.getPath('userData');
-    const nodeDir = path.resolve(app.getAppPath(), process.env.NODE_ENV === 'development' ? `../node/${osTargetNames[os.type()]}/` : '../../node/');
-    const nodePath = path.resolve(nodeDir, `go-spacemesh${osTargetNames[os.type()] === 'windows' ? '.exe' : ''}`);
+    const nodeDir = path.resolve(
+      app.getAppPath(),
+      process.env.NODE_ENV === 'development'
+        ? `../node/${osTargetNames[os.type()]}/`
+        : '../../node/'
+    );
+    const nodePath = path.resolve(
+      nodeDir,
+      `go-spacemesh${osTargetNames[os.type()] === 'windows' ? '.exe' : ''}`
+    );
     const nodeDataFilesPath = StoreService.get('node.dataPath');
     const nodeConfig = await NodeConfig.load();
-    const logFilePath = path.resolve(`${userDataPath}`, `spacemesh-log-${nodeConfig.p2p['network-id']}.txt`);
+    const logFilePath = path.resolve(
+      `${userDataPath}`,
+      `spacemesh-log-${nodeConfig.p2p['network-id']}.txt`
+    );
 
-    const logFileStream = fs.createWriteStream(logFilePath, { flags: 'a', encoding: 'utf-8' });
-    const args = ['--config', NODE_CONFIG_FILE, '-d', nodeDataFilesPath, '--log-encoder', 'json'];
+    const logFileStream = fs.createWriteStream(logFilePath, {
+      flags: 'a',
+      encoding: 'utf-8',
+    });
+    const args = [
+      '--config',
+      NODE_CONFIG_FILE,
+      '-d',
+      nodeDataFilesPath,
+      '--log-encoder',
+      'json',
+    ];
 
     logger.log('startNode', 'spawning node', [nodePath, ...args]);
     this.nodeProcess = spawn(nodePath, args, { cwd: nodeDir });
@@ -260,8 +338,13 @@ class NodeManager {
     this.nodeProcess.on('error', (error) => {
       logger.error('Node Process error', error);
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      (process.env.NODE_ENV !== 'production' || process.env.DEBUG_PROD === 'true') && dialog.showErrorBox('Smesher Error', `${error}`);
-      this.pushToErrorPool({ type: 'NodeError', error: defaultCrashError(error) });
+      (process.env.NODE_ENV !== 'production' ||
+        process.env.DEBUG_PROD === 'true') &&
+        dialog.showErrorBox('Smesher Error', `${error}`);
+      this.pushToErrorPool({
+        type: 'NodeError',
+        error: defaultCrashError(error),
+      });
     });
     this.nodeProcess.on('close', (code, signal) => {
       this.pushToErrorPool({ type: 'Exit', code, signal });
@@ -269,12 +352,19 @@ class NodeManager {
   };
 
   // Returns true if finished
-  private waitProcessFinish = async (timeout: number, interval: number): Promise<boolean> => {
+  private waitProcessFinish = async (
+    timeout: number,
+    interval: number
+  ): Promise<boolean> => {
     if (!this.nodeProcess) return true;
     const isFinished = !this.nodeProcess.kill(0);
     if (timeout <= 0) return isFinished;
     if (isFinished) return true;
-    return isFinished ? true : delay(interval).then(() => this.waitProcessFinish(timeout - interval, interval));
+    return isFinished
+      ? true
+      : delay(interval).then(() =>
+          this.waitProcessFinish(timeout - interval, interval)
+        );
   };
 
   stopNode = async () => {
@@ -283,7 +373,10 @@ class NodeManager {
       // Request Node shutdown
       await this.nodeService.shutdown();
       // Wait until the process finish in a proper way
-      !(await this.waitProcessFinish(PROCESS_EXIT_TIMEOUT, PROCESS_EXIT_CHECK_INTERVAL)) &&
+      !(await this.waitProcessFinish(
+        PROCESS_EXIT_TIMEOUT,
+        PROCESS_EXIT_CHECK_INTERVAL
+      )) &&
         // If it still not finished — send SIGINT
         // to force cleaning up and exiting the Node process
         // in a proper way
@@ -291,7 +384,10 @@ class NodeManager {
         this.nodeProcess.kill('SIGINT') &&
         // Then wait up to 20 seconds more to allow
         // the Node finish in a proper way
-        !(await this.waitProcessFinish(PROCESS_EXIT_TIMEOUT, PROCESS_EXIT_CHECK_INTERVAL)) &&
+        !(await this.waitProcessFinish(
+          PROCESS_EXIT_TIMEOUT,
+          PROCESS_EXIT_CHECK_INTERVAL
+        )) &&
         // Send a SIGKILL to force kill the process
         this.nodeProcess.kill('SIGKILL');
       // Finally, drop the reference
@@ -356,10 +452,14 @@ class NodeManager {
     try {
       const status = await this.nodeService.getNodeStatus();
       this.sendNodeStatus(status);
-      this.nodeService.activateStatusStream(this.sendNodeStatus, this.pushNodeError);
+      this.nodeService.activateStatusStream(
+        this.sendNodeStatus,
+        this.pushNodeError
+      );
       return status;
     } catch (error) {
-      if (retries > 0) return delay(200).then(() => this.getNodeStatus(retries - 1));
+      if (retries > 0)
+        return delay(200).then(() => this.getNodeStatus(retries - 1));
       throw error;
     }
   };

--- a/desktop/NodeService.ts
+++ b/desktop/NodeService.ts
@@ -1,6 +1,12 @@
 import { ServiceError } from '@grpc/grpc-js';
 import { ProtoGrpcType } from '../proto/node';
-import { NodeError, NodeErrorLevel, NodeStatus, PublicService, SocketAddress } from '../shared/types';
+import {
+  NodeError,
+  NodeErrorLevel,
+  NodeStatus,
+  PublicService,
+  SocketAddress,
+} from '../shared/types';
 import NetServiceFactory, { Service } from './NetServiceFactory';
 import Logger from './logger';
 
@@ -17,9 +23,13 @@ const normalizeGrpcErrorToNodeError = (error: ServiceError): NodeError => ({
 });
 
 class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
-  private statusStream: ReturnType<Service<ProtoGrpcType, 'NodeService'>['StatusStream']> | null = null;
+  private statusStream: ReturnType<
+    Service<ProtoGrpcType, 'NodeService'>['StatusStream']
+  > | null = null;
 
-  private errorStream: ReturnType<Service<ProtoGrpcType, 'NodeService'>['ErrorStream']> | null = null;
+  private errorStream: ReturnType<
+    Service<ProtoGrpcType, 'NodeService'>['ErrorStream']
+  > | null = null;
 
   logger = Logger({ className: 'NodeService' });
 
@@ -58,7 +68,13 @@ class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
         };
         if (!response.status) return { ...DEFAULTS };
 
-        const { connectedPeers, isSynced, syncedLayer, topLayer, verifiedLayer } = response.status;
+        const {
+          connectedPeers,
+          isSynced,
+          syncedLayer,
+          topLayer,
+          verifiedLayer,
+        } = response.status;
         return {
           connectedPeers: (connectedPeers && connectedPeers.toNumber()) || 0,
           isSynced: !!isSynced,
@@ -76,12 +92,21 @@ class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
       .then(() => true)
       .catch(() => false);
 
-  activateStatusStream = (statusHandler: StatusStreamHandler, errorHandler: ErrorStreamHandler) => {
+  activateStatusStream = (
+    statusHandler: StatusStreamHandler,
+    errorHandler: ErrorStreamHandler
+  ) => {
     if (!this.service) return;
 
     this.statusStream = this.service.StatusStream({});
     this.statusStream.on('data', (response: any) => {
-      const { connectedPeers, isSynced, syncedLayer, topLayer, verifiedLayer } = response.status;
+      const {
+        connectedPeers,
+        isSynced,
+        syncedLayer,
+        topLayer,
+        verifiedLayer,
+      } = response.status;
       statusHandler({
         connectedPeers: parseInt(connectedPeers),
         isSynced: !!isSynced,

--- a/desktop/SmesherService.ts
+++ b/desktop/SmesherService.ts
@@ -1,5 +1,9 @@
 import { ProtoGrpcType } from '../proto/smesher';
-import { PostSetupOpts, PostSetupState, PostSetupStatus } from '../shared/types';
+import {
+  PostSetupOpts,
+  PostSetupState,
+  PostSetupStatus,
+} from '../shared/types';
 
 import { PostSetupStatusStreamResponse__Output } from '../proto/spacemesh/v1/PostSetupStatusStreamResponse';
 import Logger from './logger';
@@ -25,8 +29,13 @@ const PROTO_PATH = 'proto/smesher.proto';
 //   callback: () => this.handleNavigation({ index: 0 })
 // });
 
-class SmesherService extends NetServiceFactory<ProtoGrpcType, 'SmesherService'> {
-  private stream: ReturnType<Service<ProtoGrpcType, 'SmesherService'>['PostSetupStatusStream']> | null = null;
+class SmesherService extends NetServiceFactory<
+  ProtoGrpcType,
+  'SmesherService'
+> {
+  private stream: ReturnType<
+    Service<ProtoGrpcType, 'SmesherService'>['PostSetupStatusStream']
+  > | null = null;
 
   logger = Logger({ className: 'SmesherService' });
 
@@ -49,21 +58,33 @@ class SmesherService extends NetServiceFactory<ProtoGrpcType, 'SmesherService'> 
 
   getSmesherId = () =>
     this.callService('SmesherID', {})
-      .then(({ accountId }) => ({ smesherId: accountId ? toHexString(accountId.address) : '' }))
+      .then(({ accountId }) => ({
+        smesherId: accountId ? toHexString(accountId.address) : '',
+      }))
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ smesherId: '' }));
 
   getSetupComputeProviders = () =>
     this.callService('PostSetupComputeProviders', { benchmark: true })
       .then((response) => ({
-        providers: response.providers.map(({ id, model, computeApi, performance = 0 }) => ({ id, model, computeApi, performance: parseInt(performance.toString()) })),
+        providers: response.providers.map(
+          ({ id, model, computeApi, performance = 0 }) => ({
+            id,
+            model,
+            computeApi,
+            performance: parseInt(performance.toString()),
+          })
+        ),
       }))
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ providers: [] }));
 
   isSmeshing = () =>
     this.callService('IsSmeshing', {})
-      .then((response) => ({ ...response, isSmeshing: response?.isSmeshing || false }))
+      .then((response) => ({
+        ...response,
+        isSmeshing: response?.isSmeshing || false,
+      }))
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ isSmeshing: false }));
 
@@ -92,39 +113,58 @@ class SmesherService extends NetServiceFactory<ProtoGrpcType, 'SmesherService'> 
       return response.status;
     });
 
-  activateProgressStream = (handler: (error: Error, status: Partial<PostSetupStatus>) => void) => this.postDataCreationProgressStream(handler);
+  activateProgressStream = (
+    handler: (error: Error, status: Partial<PostSetupStatus>) => void
+  ) => this.postDataCreationProgressStream(handler);
 
   stopSmeshing = ({ deleteFiles }: { deleteFiles: boolean }) =>
-    this.callService('StopSmeshing', { deleteFiles }).then(this.normalizeServiceResponse).catch(this.normalizeServiceError({}));
+    this.callService('StopSmeshing', { deleteFiles })
+      .then(this.normalizeServiceResponse)
+      .catch(this.normalizeServiceError({}));
 
   getSmesherID = () =>
     this.callService('SmesherID', {})
-      .then((response) => ({ smesherId: `0x${response.accountId ? toHexString(response.accountId.address) : '00'}` }))
+      .then((response) => ({
+        smesherId: `0x${
+          response.accountId ? toHexString(response.accountId.address) : '00'
+        }`,
+      }))
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ smesherId: '' }));
 
   getCoinbase = () =>
     this.callService('Coinbase', {})
       .then((response) => ({
-        coinbase: response.accountId ? `0x${toHexString(response.accountId.address)}` : '0x00',
+        coinbase: response.accountId
+          ? `0x${toHexString(response.accountId.address)}`
+          : '0x00',
       }))
       .catch(this.normalizeServiceError({}));
 
   setCoinbase = ({ coinbase }: { coinbase: string }) =>
-    this.callService('SetCoinbase', { id: { address: fromHexString(coinbase) } })
+    this.callService('SetCoinbase', {
+      id: { address: fromHexString(coinbase) },
+    })
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({}));
 
   getMinGas = () =>
     this.callService('MinGas', {})
-      .then((response) => ({ minGas: response.mingas ? parseInt(response.mingas.value.toString()) : null }))
+      .then((response) => ({
+        minGas: response.mingas
+          ? parseInt(response.mingas.value.toString())
+          : null,
+      }))
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({}));
 
   getEstimatedRewards = () =>
     this.callService('EstimatedRewards', {})
       .then((response) => {
-        const estimatedRewards = { amount: parseInt(response.amount?.value?.toString() || '0'), commitmentSize: response.numUnits };
+        const estimatedRewards = {
+          amount: parseInt(response.amount?.value?.toString() || '0'),
+          commitmentSize: response.numUnits,
+        };
         return { estimatedRewards };
       })
       .then(this.normalizeServiceResponse)
@@ -138,7 +178,13 @@ class SmesherService extends NetServiceFactory<ProtoGrpcType, 'SmesherService'> 
           throw new Error('PostSetupStatus is null');
         }
         const { state, numLabelsWritten, errorMessage } = status;
-        return { postSetupState: state, numLabelsWritten: numLabelsWritten ? parseInt(numLabelsWritten.toString()) : 0, errorMessage };
+        return {
+          postSetupState: state,
+          numLabelsWritten: numLabelsWritten
+            ? parseInt(numLabelsWritten.toString())
+            : 0,
+          errorMessage,
+        };
       })
       .then(this.normalizeServiceResponse)
       .catch(
@@ -149,26 +195,37 @@ class SmesherService extends NetServiceFactory<ProtoGrpcType, 'SmesherService'> 
         })
       );
 
-  private postDataCreationProgressStream = (handler: (error: any, status: Partial<PostSetupStatus>) => void) => {
+  private postDataCreationProgressStream = (
+    handler: (error: any, status: Partial<PostSetupStatus>) => void
+  ) => {
     if (!this.service) {
       throw new Error(`SmesherService is not running`);
     }
     if (!this.stream) {
       let streamError = null;
       this.stream = this.service.PostSetupStatusStream({});
-      this.stream.on('data', (response: PostSetupStatusStreamResponse__Output) => {
-        const { status } = response;
-        if (status === null) return; // TODO
-        const { state, numLabelsWritten, errorMessage, opts } = status;
-        this.logger.log('grpc PostDataCreationProgressStream', { state, numLabelsWritten, errorMessage });
-        handler(null, {
-          postSetupState: state,
-          numLabelsWritten: numLabelsWritten ? parseInt(numLabelsWritten.toString()) : 0,
-          errorMessage,
-          opts: opts as PostSetupOpts | null,
-        });
-        streamError = null;
-      });
+      this.stream.on(
+        'data',
+        (response: PostSetupStatusStreamResponse__Output) => {
+          const { status } = response;
+          if (status === null) return; // TODO
+          const { state, numLabelsWritten, errorMessage, opts } = status;
+          this.logger.log('grpc PostDataCreationProgressStream', {
+            state,
+            numLabelsWritten,
+            errorMessage,
+          });
+          handler(null, {
+            postSetupState: state,
+            numLabelsWritten: numLabelsWritten
+              ? parseInt(numLabelsWritten.toString())
+              : 0,
+            errorMessage,
+            opts: opts as PostSetupOpts | null,
+          });
+          streamError = null;
+        }
+      );
       this.stream.on('error', (error: any) => {
         this.logger.error('grpc PostDataCreationProgressStream', error);
         // @ts-ignore

--- a/desktop/TransactionService.ts
+++ b/desktop/TransactionService.ts
@@ -6,14 +6,20 @@ import Logger from './logger';
 
 const PROTO_PATH = 'proto/tx.proto';
 
-class TransactionService extends NetServiceFactory<ProtoGrpcType, 'TransactionService'> {
+class TransactionService extends NetServiceFactory<
+  ProtoGrpcType,
+  'TransactionService'
+> {
   logger = Logger({ className: 'TransactionService' });
 
   createService = (apiUrl?: PublicService | SocketAddress) => {
     this.createNetService(PROTO_PATH, apiUrl, 'TransactionService');
   };
 
-  submitTransaction = ({ transaction }) => this.callService('SubmitTransaction', { transaction }).then(this.normalizeServiceResponse).catch(this.normalizeServiceError({}));
+  submitTransaction = ({ transaction }) =>
+    this.callService('SubmitTransaction', { transaction })
+      .then(this.normalizeServiceResponse)
+      .catch(this.normalizeServiceError({}));
 
   getTxsState = (txIds: Uint8Array[]) =>
     this.callService('TransactionsState', {
@@ -21,7 +27,10 @@ class TransactionService extends NetServiceFactory<ProtoGrpcType, 'TransactionSe
       includeTransactions: true,
     });
 
-  activateTxStream = (onData: (data: TransactionsStateStreamResponse__Output) => void, txIds: Uint8Array[]) =>
+  activateTxStream = (
+    onData: (data: TransactionsStateStreamResponse__Output) => void,
+    txIds: Uint8Array[]
+  ) =>
     this.runStream(
       'TransactionsStateStream',
       {

--- a/desktop/WalletManager.ts
+++ b/desktop/WalletManager.ts
@@ -1,7 +1,11 @@
 import { ipcMain, BrowserWindow } from 'electron';
 import { ipcConsts } from '../app/vars';
 import { Account, Wallet } from '../shared/types';
-import { isLocalNodeType, isRemoteNodeApi, toSocketAddress } from '../shared/utils';
+import {
+  isLocalNodeType,
+  isRemoteNodeApi,
+  toSocketAddress,
+} from '../shared/utils';
 import { isNodeError } from '../shared/types/guards';
 import { CurrentLayer, GlobalStateHash } from '../app/types/events';
 import MeshService from './MeshService';
@@ -28,10 +32,25 @@ class WalletManager {
     this.meshService = new MeshService();
     this.glStateService = new GlobalStateService();
     this.txService = new TransactionService();
-    this.txManager = new TransactionManager(this.meshService, this.glStateService, this.txService, mainWindow);
+    this.txManager = new TransactionManager(
+      this.meshService,
+      this.glStateService,
+      this.txService,
+      mainWindow
+    );
   }
 
-  __getNewAccountFromTemplate = ({ index, timestamp, publicKey, secretKey }: { index: number; timestamp: string; publicKey: string; secretKey: string }) => ({
+  __getNewAccountFromTemplate = ({
+    index,
+    timestamp,
+    publicKey,
+    secretKey,
+  }: {
+    index: number;
+    timestamp: string;
+    publicKey: string;
+    secretKey: string;
+  }) => ({
     displayName: index > 0 ? `Account ${index}` : 'Main Account',
     created: timestamp,
     path: `0/0/${index}`,
@@ -40,8 +59,14 @@ class WalletManager {
   });
 
   subscribeToEvents = () => {
-    ipcMain.handle(ipcConsts.W_M_GET_CURRENT_LAYER, (): Promise<CurrentLayer> => this.meshService.getCurrentLayer());
-    ipcMain.handle(ipcConsts.W_M_GET_GLOBAL_STATE_HASH, (): Promise<GlobalStateHash> => this.glStateService.getGlobalStateHash());
+    ipcMain.handle(
+      ipcConsts.W_M_GET_CURRENT_LAYER,
+      (): Promise<CurrentLayer> => this.meshService.getCurrentLayer()
+    );
+    ipcMain.handle(
+      ipcConsts.W_M_GET_GLOBAL_STATE_HASH,
+      (): Promise<GlobalStateHash> => this.glStateService.getGlobalStateHash()
+    );
 
     ipcMain.handle(ipcConsts.W_M_SEND_TX, async (_event, request) => {
       const res = await this.txManager.sendTx({ ...request });
@@ -53,7 +78,10 @@ class WalletManager {
     });
     ipcMain.handle(ipcConsts.W_M_SIGN_MESSAGE, async (_event, request) => {
       const { message, accountIndex } = request;
-      const res = await cryptoService.signMessage({ message, secretKey: this.txManager.accounts[accountIndex].secretKey });
+      const res = await cryptoService.signMessage({
+        message,
+        secretKey: this.txManager.accounts[accountIndex].secretKey,
+      });
       return res;
     });
   };

--- a/desktop/cryptoService.ts
+++ b/desktop/cryptoService.ts
@@ -25,13 +25,22 @@ class CryptoService {
     };
     // @ts-ignore
     global.__generateKeyPair(seed, saveKeys); // eslint-disable-line no-undef
-    return { publicKey: toHexString(publicKey), secretKey: toHexString(secretKey) };
+    return {
+      publicKey: toHexString(publicKey),
+      secretKey: toHexString(secretKey),
+    };
   };
 
   /**
    * @return {{secretKey: Uint8Array[64], publicKey: Uint8Array[32]}}
    */
-  static deriveNewKeyPair = ({ mnemonic, index }: { mnemonic: string; index: number }) => {
+  static deriveNewKeyPair = ({
+    mnemonic,
+    index,
+  }: {
+    mnemonic: string;
+    index: number;
+  }) => {
     const seed = bip39.mnemonicToSeedSync(mnemonic);
     let publicKey = new Uint8Array(32);
     let secretKey = new Uint8Array(64);
@@ -45,8 +54,16 @@ class CryptoService {
       secretKey = sk;
     };
     // @ts-ignore
-    global.__deriveNewKeyPair(seed.slice(32), index, saltAsUint8Array, saveKeys); // eslint-disable-line no-undef
-    return { publicKey: toHexString(publicKey), secretKey: toHexString(secretKey) };
+    global.__deriveNewKeyPair(
+      seed.slice(32),
+      index,
+      saltAsUint8Array,
+      saveKeys
+    ); // eslint-disable-line no-undef
+    return {
+      publicKey: toHexString(publicKey),
+      secretKey: toHexString(secretKey),
+    };
   };
 
   /**
@@ -58,21 +75,43 @@ class CryptoService {
    * @param amount - amount to transfer in SMC cents
    * @return {Promise} when resolved returns signature as Uint8Array(64)
    */
-  static signTransaction = ({ accountNonce, receiver, price, amount, secretKey }: { accountNonce: number; receiver: string; price: number; amount: number; secretKey: string }) => {
+  static signTransaction = ({
+    accountNonce,
+    receiver,
+    price,
+    amount,
+    secretKey,
+  }: {
+    accountNonce: number;
+    receiver: string;
+    price: number;
+    amount: number;
+    secretKey: string;
+  }) => {
     const sk = fromHexString(secretKey);
-    const types = xdr.config((xdr1: { struct: (arg0: string, arg1: any[][]) => void; uhyper: () => any; opaque: (arg0: number) => any; lookup: (arg0: string) => any }) => {
-      xdr1.struct('InnerSerializableSignedTransaction', [
-        ['AccountNonce', xdr1.uhyper()],
-        ['Recipient', xdr1.opaque(20)],
-        ['GasLimit', xdr1.uhyper()],
-        ['Fee', xdr1.uhyper()],
-        ['Amount', xdr1.uhyper()],
-      ]);
-      xdr1.struct('SerializableSignedTransaction', [
-        ['InnerSerializableSignedTransaction', xdr1.lookup('InnerSerializableSignedTransaction')],
-        ['Signature', xdr1.opaque(64)],
-      ]);
-    });
+    const types = xdr.config(
+      (xdr1: {
+        struct: (arg0: string, arg1: any[][]) => void;
+        uhyper: () => any;
+        opaque: (arg0: number) => any;
+        lookup: (arg0: string) => any;
+      }) => {
+        xdr1.struct('InnerSerializableSignedTransaction', [
+          ['AccountNonce', xdr1.uhyper()],
+          ['Recipient', xdr1.opaque(20)],
+          ['GasLimit', xdr1.uhyper()],
+          ['Fee', xdr1.uhyper()],
+          ['Amount', xdr1.uhyper()],
+        ]);
+        xdr1.struct('SerializableSignedTransaction', [
+          [
+            'InnerSerializableSignedTransaction',
+            xdr1.lookup('InnerSerializableSignedTransaction'),
+          ],
+          ['Signature', xdr1.opaque(64)],
+        ]);
+      }
+    );
     const message = new types.InnerSerializableSignedTransaction({
       AccountNonce: xdr.UnsignedHyper.fromString(`${accountNonce}`),
       Recipient: fromHexString(receiver),
@@ -100,7 +139,13 @@ class CryptoService {
    * @param message - utf8 string representation of message
    * @return {Promise} when resolved returns signature as Uint8Array(64)
    */
-  static signMessage = ({ message, secretKey }: { message: string; secretKey: string }) => {
+  static signMessage = ({
+    message,
+    secretKey,
+  }: {
+    message: string;
+    secretKey: string;
+  }) => {
     const sk = fromHexString(secretKey);
     return new Promise((resolve) => {
       const enc = new TextEncoder();

--- a/desktop/fileEncryptionService.ts
+++ b/desktop/fileEncryptionService.ts
@@ -15,7 +15,13 @@ class FileEncryptionService {
       throw new Error('missing password');
     }
     // Derive a 32 bytes (256 bits) AES sym enc/dec key from the user provided pin
-    return pbkdf2.pbkdf2Sync(password, encryptionConst.DEFAULT_SALT, 1000000, 32, 'sha512');
+    return pbkdf2.pbkdf2Sync(
+      password,
+      encryptionConst.DEFAULT_SALT,
+      1000000,
+      32,
+      'sha512'
+    );
   };
 
   /**

--- a/desktop/ipcSync.ts
+++ b/desktop/ipcSync.ts
@@ -3,7 +3,11 @@ import { debounce } from 'throttle-debounce';
 
 const id = (a) => a;
 
-const IpcSyncMain = (channel: string, getBV: () => BrowserWindow | undefined, transform: (a) => any = id) => {
+const IpcSyncMain = (
+  channel: string,
+  getBV: () => BrowserWindow | undefined,
+  transform: (a) => any = id
+) => {
   const ipcChannel = 'IPC_SYNC_STORE';
 
   const send = debounce(50, (newState) => {

--- a/desktop/logger.ts
+++ b/desktop/logger.ts
@@ -4,10 +4,19 @@ import { captureEvent } from '@sentry/electron';
 
 const logger = require('electron-log');
 
-const formatLogMessage = (className, fn, res, args) => `${className}, in ${fn}, output: ${JSON.stringify(res)} ${args ? `; args: ${JSON.stringify(args)}` : ''}`;
-const formatErrorMessage = (className, fn, err, args) => `${className}, in ${fn}, error: ${JSON.stringify(err)} ${args ? `; args: ${JSON.stringify(args)}` : ''}`;
+const formatLogMessage = (className, fn, res, args) =>
+  `${className}, in ${fn}, output: ${JSON.stringify(res)} ${
+    args ? `; args: ${JSON.stringify(args)}` : ''
+  }`;
+const formatErrorMessage = (className, fn, err, args) =>
+  `${className}, in ${fn}, error: ${JSON.stringify(err)} ${
+    args ? `; args: ${JSON.stringify(args)}` : ''
+  }`;
 
-logger.transports.file.file = path.join(app.getPath('userData'), '/app-logs.txt');
+logger.transports.file.file = path.join(
+  app.getPath('userData'),
+  '/app-logs.txt'
+);
 logger.transports.console.level = false;
 
 const Logger = ({ className }: { className: string }) => ({

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -49,7 +49,11 @@ init({
 });
 
 (async function () {
-  const filePath = path.resolve(app.getAppPath(), isDev() ? './' : 'desktop/', 'ed25519.wasm');
+  const filePath = path.resolve(
+    app.getAppPath(),
+    isDev() ? './' : 'desktop/',
+    'ed25519.wasm'
+  );
   const bytes = fs.readFileSync(filePath);
   // const bytes = await response.arrayBuffer();
   // @ts-ignore

--- a/desktop/main/Networks.ts
+++ b/desktop/main/Networks.ts
@@ -24,12 +24,17 @@ const getDevNet = async () => ({
   grpcAPI: process.env.DEV_NET_REMOTE_API?.split(',')[0] || '',
 });
 
-const getDiscoveryUrl = () => app.commandLine.getSwitchValue('discovery') || process.env.DISCOVERY_URL || 'https://discover.spacemesh.io/networks.json';
+const getDiscoveryUrl = () =>
+  app.commandLine.getSwitchValue('discovery') ||
+  process.env.DISCOVERY_URL ||
+  'https://discover.spacemesh.io/networks.json';
 
 const update = async (context: AppContext, retry = 2) => {
   try {
     const networks = await fetchJSON(getDiscoveryUrl());
-    const result: Network[] = isDevNet() ? [await getDevNet(), ...networks] : networks;
+    const result: Network[] = isDevNet()
+      ? [await getDevNet(), ...networks]
+      : networks;
     context.networks = result || [];
     return context.networks;
   } catch (err) {
@@ -57,25 +62,41 @@ const listPublicApis = (context: AppContext) => {
   return publicApis;
 };
 
-const list = (context: AppContext) => context.networks.map((net) => ({ ...net, netId: net.netID }));
-const getNetwork = (context: AppContext, netId: number) => context.networks.find((net) => net.netID === netId);
-const hasNetwork = (context: AppContext, netId: number) => !!getNetwork(context, netId);
+const list = (context: AppContext) =>
+  context.networks.map((net) => ({ ...net, netId: net.netID }));
+const getNetwork = (context: AppContext, netId: number) =>
+  context.networks.find((net) => net.netID === netId);
+const hasNetwork = (context: AppContext, netId: number) =>
+  !!getNetwork(context, netId);
 
 const spawnManagers = async (context: AppContext) => {
   const { mainWindow } = context;
-  if (!mainWindow) throw new Error('Cannot spawn managers: MainWindow not found');
-  if (!context.currentNetwork) throw new Error('Cannot spawn managers: Network does not selected');
+  if (!mainWindow)
+    throw new Error('Cannot spawn managers: MainWindow not found');
+  if (!context.currentNetwork)
+    throw new Error('Cannot spawn managers: Network does not selected');
   if (!hasManagers(context)) {
     context.managers.smesher = new SmesherManager(mainWindow, NODE_CONFIG_FILE);
-    context.managers.node = new NodeManager(mainWindow, context.currentNetwork.netID, context.managers.smesher);
-    context.managers.wallet = new WalletManager(mainWindow, context.managers.node);
+    context.managers.node = new NodeManager(
+      mainWindow,
+      context.currentNetwork.netID,
+      context.managers.smesher
+    );
+    context.managers.wallet = new WalletManager(
+      mainWindow,
+      context.managers.node
+    );
   }
 };
 
 const switchNetwork = async (context: AppContext, netId: number) => {
   const newNetwork = getNetwork(context, netId);
   if (!newNetwork) {
-    throw new Error(`Cannot switch to network ${netId}: not found. Have: ${context.networks.map((n) => n.netID).join(', ')}`);
+    throw new Error(
+      `Cannot switch to network ${netId}: not found. Have: ${context.networks
+        .map((n) => n.netID)
+        .join(', ')}`
+    );
   }
   context.currentNetwork = newNetwork;
   await NodeConfig.download(newNetwork);

--- a/desktop/main/NodeConfig.ts
+++ b/desktop/main/NodeConfig.ts
@@ -3,9 +3,11 @@ import { fetchJSON, isFileExists } from '../utils';
 import { NODE_CONFIG_FILE } from './constants';
 import { Network } from './context';
 
-const load = () => fs.readFile(NODE_CONFIG_FILE, { encoding: 'utf8' }).then(JSON.parse);
+const load = () =>
+  fs.readFile(NODE_CONFIG_FILE, { encoding: 'utf8' }).then(JSON.parse);
 
-const loadSmeshingOpts = async () => ((await isFileExists(NODE_CONFIG_FILE)) ? (await load()).smeshing : {});
+const loadSmeshingOpts = async () =>
+  (await isFileExists(NODE_CONFIG_FILE)) ? (await load()).smeshing : {};
 
 const download = async (network: Network) => {
   const nodeConfig = await fetchJSON(network.conf);
@@ -14,7 +16,9 @@ const download = async (network: Network) => {
   const smeshing = await loadSmeshingOpts();
   nodeConfig.smeshing = smeshing;
 
-  await fs.writeFile(NODE_CONFIG_FILE, JSON.stringify(nodeConfig), { encoding: 'utf8' });
+  await fs.writeFile(NODE_CONFIG_FILE, JSON.stringify(nodeConfig), {
+    encoding: 'utf8',
+  });
   return nodeConfig;
 };
 

--- a/desktop/main/autoUpdate.ts
+++ b/desktop/main/autoUpdate.ts
@@ -13,20 +13,32 @@ import { HOUR } from './constants';
 autoUpdater.logger = logger;
 
 // IPC
-const notify = <T extends unknown>(channel: ipcConsts) => (context: AppContext, info: T) =>
-  (context.mainWindow && context.mainWindow.webContents.send(channel, info) && true) || false;
+const notify = <T extends unknown>(channel: ipcConsts) => (
+  context: AppContext,
+  info: T
+) =>
+  (context.mainWindow &&
+    context.mainWindow.webContents.send(channel, info) &&
+    true) ||
+  false;
 
 const notifyUpdateAvailble = notify<UpdateInfo>(ipcConsts.AU_AVAILABLE);
-const notifyDownloadProgress = notify<ProgressInfo>(ipcConsts.AU_DOWNLOAD_PROGRESS);
+const notifyDownloadProgress = notify<ProgressInfo>(
+  ipcConsts.AU_DOWNLOAD_PROGRESS
+);
 const notifyUpdateDownloaded = notify<UpdateInfo>(ipcConsts.AU_DOWNLOADED);
 const notifyDownloadStarted = notify<void>(ipcConsts.AU_DOWNLOAD_STARTED);
 const notifyError = notify<Error>(ipcConsts.AU_ERROR);
 
 // Utils
-const getCurrentVersion = () => (isDev() ? new SemVer(pkg.version) : autoUpdater.currentVersion);
+const getCurrentVersion = () =>
+  isDev() ? new SemVer(pkg.version) : autoUpdater.currentVersion;
 
 //
-export const checkForUpdates = async (context: AppContext, autoDownload = false) => {
+export const checkForUpdates = async (
+  context: AppContext,
+  autoDownload = false
+) => {
   if (!context.currentNetwork) return null;
   const currentVersion = getCurrentVersion();
   const { latestSmappRelease, smappBaseDownloadUrl } = context.currentNetwork;

--- a/desktop/main/context.ts
+++ b/desktop/main/context.ts
@@ -20,7 +20,9 @@ const getDefaultNetwork = () => ({
   nodeBaseDownloadUrl: '',
 });
 
-export type Network = ReturnType<typeof getDefaultNetwork> & { [key: string]: any };
+export type Network = ReturnType<typeof getDefaultNetwork> & {
+  [key: string]: any;
+};
 
 export interface AppContext {
   mainWindow?: BrowserWindow;
@@ -47,4 +49,5 @@ export const getDefaultAppContext = (): AppContext => ({
   managers: {},
 });
 
-export const hasManagers = (context: AppContext) => context.managers.smesher && context.managers.node && context.managers.wallet;
+export const hasManagers = (context: AppContext) =>
+  context.managers.smesher && context.managers.node && context.managers.wallet;

--- a/desktop/main/createTray.ts
+++ b/desktop/main/createTray.ts
@@ -4,7 +4,9 @@ import { AppContext } from './context';
 import { showMainWindow } from './utils';
 
 export default (context: AppContext) => {
-  const tray = new Tray(path.resolve(__dirname, '../../resources/icons/16x16.png'));
+  const tray = new Tray(
+    path.resolve(__dirname, '../../resources/icons/16x16.png')
+  );
   tray.setToolTip('Spacemesh');
   const showSmapp = () => showMainWindow(context);
   const contextMenu = Menu.buildFromTemplate([

--- a/desktop/main/createWindow.ts
+++ b/desktop/main/createWindow.ts
@@ -4,8 +4,14 @@ import MenuBuilder from '../menu';
 import { isDev } from '../utils';
 import { AppContext } from './context';
 
-export default async (context: AppContext, onCloseHandler: (e: Event) => void | Promise<void>) => {
-  const pagePath = `file://${path.resolve(__dirname, isDev() ? '..' : '')}/index.html`;
+export default async (
+  context: AppContext,
+  onCloseHandler: (e: Event) => void | Promise<void>
+) => {
+  const pagePath = `file://${path.resolve(
+    __dirname,
+    isDev() ? '..' : ''
+  )}/index.html`;
   const mainWindow = new BrowserWindow({
     show: false,
     width: 1280,
@@ -42,14 +48,18 @@ export default async (context: AppContext, onCloseHandler: (e: Event) => void | 
   });
 
   // Load page after initialization complete
-  mainWindow.loadURL(`file://${path.resolve(__dirname, isDev() ? '..' : '')}/index.html`);
+  mainWindow.loadURL(
+    `file://${path.resolve(__dirname, isDev() ? '..' : '')}/index.html`
+  );
   mainWindow.loadURL(pagePath);
 
   /**
    * fallback for page fail
    * @see https://github.com/maximegris/angular-electron/issues/15
    */
-  mainWindow.webContents.on('did-fail-load', () => mainWindow.loadURL(pagePath));
+  mainWindow.webContents.on('did-fail-load', () =>
+    mainWindow.loadURL(pagePath)
+  );
 
   context.mainWindow = mainWindow;
   return mainWindow;

--- a/desktop/main/installDevTools.ts
+++ b/desktop/main/installDevTools.ts
@@ -2,9 +2,15 @@ import { isDebug } from '../utils';
 
 export default async () => {
   if (!isDebug()) return;
-  // eslint-disable-next-line global-require
-  const { default: installExtension, REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer');
-  await installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS], { loadExtensionOptions: { allowFileAccess: true }, forceDownload: false }).then(
+  const {
+    default: installExtension,
+    REDUX_DEVTOOLS,
+    REACT_DEVELOPER_TOOLS,
+  } = require('electron-devtools-installer'); // eslint-disable-line global-require
+  await installExtension([REDUX_DEVTOOLS, REACT_DEVELOPER_TOOLS], {
+    loadExtensionOptions: { allowFileAccess: true },
+    forceDownload: false,
+  }).then(
     (names) => console.log('DevTools Installed:', names), // eslint-disable-line no-console
     (err) => console.log('DevTools Installation Error:', err) // eslint-disable-line no-console
   );

--- a/desktop/main/promptBeforeClose.ts
+++ b/desktop/main/promptBeforeClose.ts
@@ -34,7 +34,8 @@ export default (context: AppContext) => {
         return CloseAppPromptResult.CLOSE;
     }
   };
-  const isSmeshing = async () => context.managers.smesher?.isSmeshing() || false;
+  const isSmeshing = async () =>
+    context.managers.smesher?.isSmeshing() || false;
   const notify = () =>
     showNotification(context, {
       title: 'Spacemesh',
@@ -54,7 +55,9 @@ export default (context: AppContext) => {
       quit();
       return;
     }
-    const promptResult = ((await isSmeshing()) && (await showPrompt())) || CloseAppPromptResult.CLOSE;
+    const promptResult =
+      ((await isSmeshing()) && (await showPrompt())) ||
+      CloseAppPromptResult.CLOSE;
     if (promptResult === CloseAppPromptResult.KEEP_SMESHING) {
       setTimeout(notify, 1000);
       mainWindow.hide();

--- a/desktop/main/subscribeIPC.ts
+++ b/desktop/main/subscribeIPC.ts
@@ -1,4 +1,10 @@
-import { BrowserView, BrowserWindow, ipcMain, nativeTheme, shell } from 'electron';
+import {
+  BrowserView,
+  BrowserWindow,
+  ipcMain,
+  nativeTheme,
+  shell,
+} from 'electron';
 import { ipcConsts } from '../../app/vars';
 import { AppContext } from './context';
 
@@ -7,7 +13,10 @@ export default (context: AppContext) => {
   ipcMain.on(ipcConsts.RELOAD_APP, () => context.mainWindow?.reload());
 
   // Theme
-  ipcMain.handle(ipcConsts.GET_OS_THEME_COLOR, () => nativeTheme.shouldUseDarkColors);
+  ipcMain.handle(
+    ipcConsts.GET_OS_THEME_COLOR,
+    () => nativeTheme.shouldUseDarkColors
+  );
   ipcMain.on(ipcConsts.SEND_THEME_COLOR, (_event, request) => {
     context.isDarkMode = request.isDarkMode;
   });
@@ -30,14 +39,27 @@ export default (context: AppContext) => {
         shell.openExternal(url);
       });
       const contentBounds = mainWindow.getContentBounds();
-      browserView.setBounds({ x: 0, y: 90, width: contentBounds.width - 35, height: 600 });
-      browserView.setAutoResize({ width: true, height: true, horizontal: true, vertical: true });
+      browserView.setBounds({
+        x: 0,
+        y: 90,
+        width: contentBounds.width - 35,
+        height: 600,
+      });
+      browserView.setAutoResize({
+        width: true,
+        height: true,
+        horizontal: true,
+        vertical: true,
+      });
       const dashUrl = currentNetwork.dash;
-      browserView.webContents.loadURL(`${dashUrl}?hide-right-line${context.isDarkMode ? '&darkMode' : ''}`);
+      browserView.webContents.loadURL(
+        `${dashUrl}?hide-right-line${context.isDarkMode ? '&darkMode' : ''}`
+      );
     });
 
     ipcMain.on(ipcConsts.DESTROY_BROWSER_VIEW, () => {
-      browserView?.setBounds && browserView.setBounds({ x: 0, y: 0, width: 0, height: 0 });
+      browserView?.setBounds &&
+        browserView.setBounds({ x: 0, y: 0, width: 0, height: 0 });
       // TODO: destroy
     });
   })();
@@ -45,7 +67,13 @@ export default (context: AppContext) => {
   // Open print page with 12 words
   ipcMain.on(ipcConsts.PRINT, (_event, request: { content: string }) => {
     const { mainWindow } = context;
-    const printerWindow = new BrowserWindow({ parent: mainWindow, width: 800, height: 800, show: true, webPreferences: { nodeIntegration: true, devTools: false } });
+    const printerWindow = new BrowserWindow({
+      parent: mainWindow,
+      width: 800,
+      height: 800,
+      show: true,
+      webPreferences: { nodeIntegration: true, devTools: false },
+    });
     const html = `<body>${request.content}</body><script>window.onafterprint = () => setTimeout(window.close, 3000); window.print();</script>`;
     printerWindow.loadURL(`data:text/html;charset=utf-8,${encodeURI(html)}`);
   });

--- a/desktop/main/utils.ts
+++ b/desktop/main/utils.ts
@@ -11,7 +11,10 @@ export const showMainWindow = (context: AppContext) => {
   mainWindow.focus();
 };
 
-export const showNotification = (context: AppContext, { title, body }: { title: string; body: string }) => {
+export const showNotification = (
+  context: AppContext,
+  { title, body }: { title: string; body: string }
+) => {
   if (Notification.isSupported() && !context.mainWindow?.isMaximized()) {
     const options = { title, body, icon: '../app/assets/images/icon.png' };
     const notification = new Notification(options);
@@ -20,7 +23,8 @@ export const showNotification = (context: AppContext, { title, body }: { title: 
   }
 };
 
-export const getNodeLogsPath = (netId?: number) => path.resolve(USERDATA_DIR, `spacemesh-log-${netId || 0}.txt`);
+export const getNodeLogsPath = (netId?: number) =>
+  path.resolve(USERDATA_DIR, `spacemesh-log-${netId || 0}.txt`);
 
 //
 

--- a/desktop/main/walletFile.ts
+++ b/desktop/main/walletFile.ts
@@ -5,7 +5,13 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import * as R from 'ramda';
 
-import { Wallet, WalletFile, WalletMeta, WalletSecrets, WalletSecretsEncrypted } from '../../shared/types';
+import {
+  Wallet,
+  WalletFile,
+  WalletMeta,
+  WalletSecrets,
+  WalletSecretsEncrypted,
+} from '../../shared/types';
 import FileEncryptionService from '../fileEncryptionService';
 import { isFileExists } from '../utils';
 import { DEFAULT_WALLETS_DIRECTORY } from './constants';
@@ -14,9 +20,15 @@ import { DEFAULT_WALLETS_DIRECTORY } from './constants';
 // Encryption
 //
 
-export const decryptWallet = (crypto: WalletSecretsEncrypted, password: string): WalletSecrets => {
+export const decryptWallet = (
+  crypto: WalletSecretsEncrypted,
+  password: string
+): WalletSecrets => {
   const key = FileEncryptionService.createEncryptionKey({ password });
-  const decryptedRaw = FileEncryptionService.decryptData({ data: crypto.cipherText, key });
+  const decryptedRaw = FileEncryptionService.decryptData({
+    data: crypto.cipherText,
+    key,
+  });
   try {
     const decrypted = JSON.parse(decryptedRaw) as WalletSecrets; // TODO: Add validation
     return decrypted;
@@ -25,9 +37,15 @@ export const decryptWallet = (crypto: WalletSecretsEncrypted, password: string):
   }
 };
 
-export const encryptWallet = (cryptoDecrypted: WalletSecrets, password: string): WalletSecretsEncrypted => {
+export const encryptWallet = (
+  cryptoDecrypted: WalletSecrets,
+  password: string
+): WalletSecretsEncrypted => {
   const key = FileEncryptionService.createEncryptionKey({ password });
-  const encrypted = FileEncryptionService.encryptData({ data: JSON.stringify(cryptoDecrypted), key });
+  const encrypted = FileEncryptionService.encryptData({
+    data: JSON.stringify(cryptoDecrypted),
+    key,
+  });
   return { cipher: 'AES-128-CTR', cipherText: encrypted };
 };
 
@@ -40,7 +58,10 @@ export const loadRawWallet = async (path: string): Promise<WalletFile> => {
   return JSON.parse(fileContent) as WalletFile;
 };
 
-export const loadWallet = async (path: string, password: string): Promise<Wallet> => {
+export const loadWallet = async (
+  path: string,
+  password: string
+): Promise<Wallet> => {
   const { crypto, meta } = await loadRawWallet(path);
   const cryptoDecoded = decryptWallet(crypto, password);
   return { meta, crypto: cryptoDecoded };
@@ -48,13 +69,19 @@ export const loadWallet = async (path: string, password: string): Promise<Wallet
 
 export const saveRaw = async (walletPath: string, wallet: WalletFile) => {
   const isFilePath = walletPath.endsWith('.json');
-  const filename = isFilePath ? path.basename(walletPath) : `my_wallet_${wallet.meta.created}.json`;
+  const filename = isFilePath
+    ? path.basename(walletPath)
+    : `my_wallet_${wallet.meta.created}.json`;
   const filepath = isFilePath ? walletPath : path.resolve(walletPath, filename);
   await fs.writeFile(filepath, JSON.stringify(wallet), { encoding: 'utf8' });
   return { filename, filepath };
 };
 
-export const saveWallet = (walletPath: string, password: string, wallet: Wallet): Promise<{ filename: string; filepath: string }> => {
+export const saveWallet = (
+  walletPath: string,
+  password: string,
+  wallet: Wallet
+): Promise<{ filename: string; filepath: string }> => {
   const { meta, crypto } = wallet;
   const encrypted = encryptWallet(crypto, password);
   const fileContent: WalletFile = {
@@ -64,14 +91,21 @@ export const saveWallet = (walletPath: string, password: string, wallet: Wallet)
   return saveRaw(walletPath, fileContent);
 };
 
-export const updateWalletMeta = async (path: string, meta: Partial<WalletMeta>) => {
+export const updateWalletMeta = async (
+  path: string,
+  meta: Partial<WalletMeta>
+) => {
   const wallet = await loadRawWallet(path);
   const newWallet = { ...wallet, meta: { ...wallet.meta, ...meta } };
   await saveRaw(path, newWallet);
   return newWallet;
 };
 
-export const updateWalletSecrets = async (path: string, password: string, crypto: Partial<WalletSecrets>) => {
+export const updateWalletSecrets = async (
+  path: string,
+  password: string,
+  crypto: Partial<WalletSecrets>
+) => {
   const wallet = await loadWallet(path, password);
   const newWallet = { ...wallet, crypto: { ...wallet.crypto, ...crypto } };
   await saveWallet(path, password, newWallet);
@@ -85,13 +119,19 @@ export const copyWalletFile = async (filePath: string, outputDir: string) => {
     const f = path.parse(filename);
     return `${f.name}-copy-${n}${f.ext}`;
   };
-  const getOutputFileName = async (filename: string, n = 0): Promise<string> => {
+  const getOutputFileName = async (
+    filename: string,
+    n = 0
+  ): Promise<string> => {
     const newFileName = formatFilename(filename, n);
     const outputFilePath = path.resolve(outputDir, newFileName);
     const isExist = await isFileExists(outputFilePath);
     return isExist ? getOutputFileName(filename, n + 1) : newFileName;
   };
-  const newFilePath = path.resolve(outputDir, await getOutputFileName(originalFilename, 0));
+  const newFilePath = path.resolve(
+    outputDir,
+    await getOutputFileName(originalFilename, 0)
+  );
   await fs.copyFile(filePath, newFilePath);
   return newFilePath;
 };
@@ -104,14 +144,24 @@ export const listWalletsByPaths = (files: string[]) =>
     })
   );
 
-export const listWalletsInDirectory = async (walletsDir: string = DEFAULT_WALLETS_DIRECTORY) => {
+export const listWalletsInDirectory = async (
+  walletsDir: string = DEFAULT_WALLETS_DIRECTORY
+) => {
   const files = await fs.readdir(walletsDir);
   const regex = new RegExp('(my_wallet_).*.(json)', 'i');
-  const walletFiles = files.filter((filename) => filename.match(regex)).map((filename) => path.join(walletsDir, filename));
+  const walletFiles = files
+    .filter((filename) => filename.match(regex))
+    .map((filename) => path.join(walletsDir, filename));
   return listWalletsByPaths(walletFiles);
 };
 
-export const listWallets = async (walletsDir: string, walletPaths: string[]) => {
+export const listWallets = async (
+  walletsDir: string,
+  walletPaths: string[]
+) => {
   const storedWalletPaths = R.uniq(walletPaths);
-  return R.uniqBy(R.prop('path'), [...(await listWalletsByPaths(storedWalletPaths)), ...(await listWalletsInDirectory(walletsDir))]);
+  return R.uniqBy(R.prop('path'), [
+    ...(await listWalletsByPaths(storedWalletPaths)),
+    ...(await listWalletsInDirectory(walletsDir)),
+  ]);
 };

--- a/desktop/menu.ts
+++ b/desktop/menu.ts
@@ -9,7 +9,10 @@ class MenuBuilder {
   }
 
   buildMenu() {
-    if (process.env.NODE_ENV !== 'production' || process.env.DEBUG_PROD === 'true') {
+    if (
+      process.env.NODE_ENV !== 'production' ||
+      process.env.DEBUG_PROD === 'true'
+    ) {
       this.addInspectElementMenu();
     } else {
       this.addInputAndSelectionMenu();
@@ -40,7 +43,11 @@ class MenuBuilder {
   }
 
   addInputAndSelectionMenu() {
-    const selectionMenu = Menu.buildFromTemplate([{ role: 'copy' }, { type: 'separator' }, { role: 'selectAll' }]);
+    const selectionMenu = Menu.buildFromTemplate([
+      { role: 'copy' },
+      { type: 'separator' },
+      { role: 'selectAll' },
+    ]);
 
     const inputMenu = Menu.buildFromTemplate([
       { role: 'undo' },
@@ -104,19 +111,41 @@ class MenuBuilder {
           { role: 'cut' },
           { role: 'copy' },
           { role: 'paste' },
-          { label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' },
+          {
+            label: 'Select All',
+            accelerator: 'CmdOrCtrl+A',
+            selector: 'selectAll:',
+          },
         ],
       },
       {
         label: 'View',
         submenu:
           process.env.NODE_ENV === 'development'
-            ? [{ role: 'reload' }, { role: 'forcereload' }, { type: 'separator' }, { role: 'toggledevtools' }, { type: 'separator' }, { role: 'togglefullscreen' }]
+            ? [
+                { role: 'reload' },
+                { role: 'forcereload' },
+                { type: 'separator' },
+                { role: 'toggledevtools' },
+                { type: 'separator' },
+                { role: 'togglefullscreen' },
+              ]
             : [{ role: 'togglefullscreen' }],
       },
       {
         label: 'Window',
-        submenu: [{ role: 'minimize' }, { role: 'zoom' }, ...(isMac ? [{ type: 'separator' }, { role: 'front' }, { type: 'separator' }, { role: 'window' }] : [{ role: 'close' }])],
+        submenu: [
+          { role: 'minimize' },
+          { role: 'zoom' },
+          ...(isMac
+            ? [
+                { type: 'separator' },
+                { role: 'front' },
+                { type: 'separator' },
+                { role: 'window' },
+              ]
+            : [{ role: 'close' }]),
+        ],
       },
     ];
   }

--- a/desktop/storeService.ts
+++ b/desktop/storeService.ts
@@ -6,7 +6,10 @@ import { Transaction } from '../proto/spacemesh/v1/Transaction';
 import { _spacemesh_v1_TransactionState_TransactionState } from '../proto/spacemesh/v1/TransactionState';
 import { USERDATA_DIR } from './main/constants';
 
-export type TxStored = Required<Transaction> & { id: string; state: _spacemesh_v1_TransactionState_TransactionState };
+export type TxStored = Required<Transaction> & {
+  id: string;
+  state: _spacemesh_v1_TransactionState_TransactionState;
+};
 
 export interface AccountStore {
   publicKey: string;
@@ -46,15 +49,22 @@ class StoreService {
     }
   }
 
-  static set = <O extends ConfigStore, P extends string>(key: Function.AutoPath<O, P>, property: Object.Path<O, String.Split<P, '.'>>) => {
+  static set = <O extends ConfigStore, P extends string>(
+    key: Function.AutoPath<O, P>,
+    property: Object.Path<O, String.Split<P, '.'>>
+  ) => {
     StoreService.store.set(key, property);
   };
 
-  static get = <O extends ConfigStore, P extends string>(key: Function.AutoPath<O, P>): Object.Path<O, String.Split<P, '.'>> => {
+  static get = <O extends ConfigStore, P extends string>(
+    key: Function.AutoPath<O, P>
+  ): Object.Path<O, String.Split<P, '.'>> => {
     return StoreService.store.get(key);
   };
 
-  static remove = <O extends ConfigStore, P extends string>(key: Function.AutoPath<O, P>) => {
+  static remove = <O extends ConfigStore, P extends string>(
+    key: Function.AutoPath<O, P>
+  ) => {
     StoreService.store.delete(key as keyof ConfigStore); // kludge to workaround StoreService types
   };
 
@@ -64,7 +74,9 @@ class StoreService {
 
   static dump = () => StoreService.store.store;
 
-  static onChange = (cb: (newValue?: ConfigStore, prevValue?: ConfigStore) => void) => {
+  static onChange = (
+    cb: (newValue?: ConfigStore, prevValue?: ConfigStore) => void
+  ) => {
     StoreService.store.onDidAnyChange(cb);
   };
 }

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -12,8 +12,11 @@ export const isProd = () => process.env.NODE_ENV === 'production';
 export const isDev = () => process.env.NODE_ENV === 'development';
 export const isDebug = () => isDev() || process.env.DEBUG_PROD;
 
-export const isDevNet = (proc = process): proc is NodeJS.Process & { env: { NODE_ENV: 'development'; DEV_NET_URL: string } } =>
-  proc.env.NODE_ENV === 'development' && !!proc.env.DEV_NET_URL;
+export const isDevNet = (
+  proc = process
+): proc is NodeJS.Process & {
+  env: { NODE_ENV: 'development'; DEV_NET_URL: string };
+} => proc.env.NODE_ENV === 'development' && !!proc.env.DEV_NET_URL;
 
 // --------------------------------------------------------
 // HexString conversion
@@ -27,13 +30,19 @@ export const fromHexString = (hexString: HexString) => {
   return Uint8Array.from(bytes);
 };
 export const toHexString = (bytes: Uint8Array | Buffer): HexString =>
-  bytes instanceof Buffer ? bytes.toString('hex') : bytes.reduce((str: string, byte: number) => str + byte.toString(16).padStart(2, '0'), '');
+  bytes instanceof Buffer
+    ? bytes.toString('hex')
+    : bytes.reduce(
+        (str: string, byte: number) => str + byte.toString(16).padStart(2, '0'),
+        ''
+      );
 
 // --------------------------------------------------------
 // Network
 // --------------------------------------------------------
 
-export const fetchJSON = async (url?: string) => (url ? fetch(`${url}?no-cache=${Date.now()}`).then((res) => res.json()) : null);
+export const fetchJSON = async (url?: string) =>
+  url ? fetch(`${url}?no-cache=${Date.now()}`).then((res) => res.json()) : null;
 
 export const isNetError = (error: Error) => error.message.startsWith('net::');
 
@@ -81,7 +90,10 @@ export const isEmptyDir = async (path: string) => {
  * X = [1,2,3,4]
  * Y = [5,6]
  */
-export const createDebouncePool = <T extends unknown>(delay: number, callback: (errors: T[]) => void) => {
+export const createDebouncePool = <T extends unknown>(
+  delay: number,
+  callback: (errors: T[]) => void
+) => {
   let bucket: T[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
 

--- a/shared/datetime.ts
+++ b/shared/datetime.ts
@@ -1,11 +1,22 @@
-export const formatDateAsISO = (date: Date) => date.toISOString().replace(/:/g, '-');
+export const formatDateAsISO = (date: Date) =>
+  date.toISOString().replace(/:/g, '-');
 
 export const getISODate = () => formatDateAsISO(new Date());
 
-export const parseISODate = (iso: string) => new Date(iso.replace(/T(\d{2})-(\d{2})-(\d{2}).(\d+)Z/i, 'T$1:$2:$3.$4Z'));
+export const parseISODate = (iso: string) =>
+  new Date(iso.replace(/T(\d{2})-(\d{2})-(\d{2}).(\d+)Z/i, 'T$1:$2:$3.$4Z'));
 
 // E.G. Tuesday, March 3, 2022, 16:50
 export const formatDateAsUS = (date: Date) =>
-  date.toLocaleString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', timeZone: 'UTC', hourCycle: 'h23' });
+  date.toLocaleString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZone: 'UTC',
+    hourCycle: 'h23',
+  });
 
 export const formatISOAsUS = (iso: string) => formatDateAsUS(parseISODate(iso));

--- a/shared/types/guards.ts
+++ b/shared/types/guards.ts
@@ -7,22 +7,42 @@ import { Tx, Reward } from './tx';
 import { WalletSecrets, WalletSecretsEncrypted } from './wallet';
 
 // GRPC Type guards
-export const hasRequiredTxFields = (tx: Transaction__Output): tx is Object.NonNullable<Transaction__Output, 'id' | 'amount' | 'sender'> =>
+export const hasRequiredTxFields = (
+  tx: Transaction__Output
+): tx is Object.NonNullable<Transaction__Output, 'id' | 'amount' | 'sender'> =>
   !!tx.id?.id && !!tx.amount?.value && !!tx.sender?.address;
 
-export const hasRequiredTxStateFields = (txState: TransactionState__Output): txState is Object.NonNullable<TransactionState__Output, 'id' | 'state'> =>
+export const hasRequiredTxStateFields = (
+  txState: TransactionState__Output
+): txState is Object.NonNullable<TransactionState__Output, 'id' | 'state'> =>
   !!txState.id?.id && txState.state !== undefined;
 
-export const hasRequiredRewardFields = (r: Reward__Output): r is Object.NonNullable<Reward__Output, 'coinbase' | 'total' | 'layer' | 'layerReward' | 'layerComputed' | 'smesher'> =>
-  !!(r.coinbase?.address && r.smesher?.id && r.total?.value && r.layer?.number && r.layerReward?.value);
+export const hasRequiredRewardFields = (
+  r: Reward__Output
+): r is Object.NonNullable<
+  Reward__Output,
+  'coinbase' | 'total' | 'layer' | 'layerReward' | 'layerComputed' | 'smesher'
+> =>
+  !!(
+    r.coinbase?.address &&
+    r.smesher?.id &&
+    r.total?.value &&
+    r.layer?.number &&
+    r.layerReward?.value
+  );
 
 // Own Type guards
-export const isTx = (a: any): a is Tx => a && a.id && a.sender && a.receiver && a.amount;
+export const isTx = (a: any): a is Tx =>
+  a && a.id && a.sender && a.receiver && a.amount;
 
-export const isReward = (a: any): a is Reward => a && a.layer && a.coinbase && a.smesher && a.amount;
+export const isReward = (a: any): a is Reward =>
+  a && a.layer && a.coinbase && a.smesher && a.amount;
 
-export const isNodeError = (a: any): a is NodeError => a && a.msg && a.module && a.level;
+export const isNodeError = (a: any): a is NodeError =>
+  a && a.msg && a.module && a.level;
 
-export const isWalletSecretsEncrypted = (a: any): a is WalletSecretsEncrypted => a && a.cipher && a.cipherText;
+export const isWalletSecretsEncrypted = (a: any): a is WalletSecretsEncrypted =>
+  a && a.cipher && a.cipherText;
 
-export const isWalletSecrets = (a: any): a is WalletSecrets => a && a.mnemonic && a.accounts && a.contacts;
+export const isWalletSecrets = (a: any): a is WalletSecrets =>
+  a && a.mnemonic && a.accounts && a.contacts;

--- a/shared/types/transformers.ts
+++ b/shared/types/transformers.ts
@@ -8,9 +8,16 @@ import { Tx, TxState } from './tx';
 
 const getTxReceiver = (tx: Transaction__Output): HexString =>
   // eslint-disable-next-line no-nested-ternary
-  tx.coinTransfer?.receiver?.address ? toHexString(tx.coinTransfer.receiver.address) : tx.smartContract?.accountId?.address ? toHexString(tx.smartContract.accountId.address) : '0';
+  tx.coinTransfer?.receiver?.address
+    ? toHexString(tx.coinTransfer.receiver.address)
+    : tx.smartContract?.accountId?.address
+    ? toHexString(tx.smartContract.accountId.address)
+    : '0';
 
-export const toTx = (tx: Transaction__Output, txState: TransactionState__Output | null): Tx | null => {
+export const toTx = (
+  tx: Transaction__Output,
+  txState: TransactionState__Output | null
+): Tx | null => {
   if (!hasRequiredTxFields(tx)) return null;
   return {
     id: toHexString(tx.id.id),
@@ -25,7 +32,10 @@ export const toTx = (tx: Transaction__Output, txState: TransactionState__Output 
   };
 };
 
-export const addReceiptToTx = (tx: Tx, receipt: TransactionReceipt__Output): Tx => ({
+export const addReceiptToTx = (
+  tx: Tx,
+  receipt: TransactionReceipt__Output
+): Tx => ({
   ...tx,
   layer: receipt.layer?.number || tx.layer,
   receipt: {

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -9,7 +9,10 @@ export const delay = (ms: number) =>
 
 // promisifed debounce function with multiple consumers
 // can not be cancelled
-export const debounce = <T extends unknown>(delay: number, cb: (...args: any[]) => T | Promise<T>) => {
+export const debounce = <T extends unknown>(
+  delay: number,
+  cb: (...args: any[]) => T | Promise<T>
+) => {
   type PromiseHandler = (T) => any;
 
   let t: ReturnType<typeof setTimeout> | null = null;
@@ -17,7 +20,8 @@ export const debounce = <T extends unknown>(delay: number, cb: (...args: any[]) 
   let thenRejecters: PromiseHandler[] = [];
   let catchResolvers: PromiseHandler[] = [];
 
-  const resolve = (r: any) => thenResolvers.forEach((fn: PromiseHandler) => fn(r));
+  const resolve = (r: any) =>
+    thenResolvers.forEach((fn: PromiseHandler) => fn(r));
   const reject = (r: any) => {
     thenRejecters.forEach((fn: PromiseHandler) => fn(r));
     catchResolvers.forEach((fn: PromiseHandler) => fn(r));
@@ -65,13 +69,17 @@ export const debounce = <T extends unknown>(delay: number, cb: (...args: any[]) 
 };
 
 // Func utils
-export const shallowEq = <T extends Record<string, any> | Array<any>>(a: T, b: T) => {
+export const shallowEq = <T extends Record<string, any> | Array<any>>(
+  a: T,
+  b: T
+) => {
   if (a === b) return true;
 
   if (Array.isArray(a) && Array.isArray(b)) {
     return a.reduce((acc, next, idx) => acc && next === b[idx], true);
   }
-  if (typeof a !== typeof b || Array.isArray(a) || Array.isArray(b) || !a || !b) return false;
+  if (typeof a !== typeof b || Array.isArray(a) || Array.isArray(b) || !a || !b)
+    return false;
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);
   if (aKeys.length !== bKeys.length) return false;
@@ -94,17 +102,24 @@ export const toSocketAddress = (url?: string): SocketAddress => {
   };
 };
 
-export const stringifySocketAddress = (sa: SocketAddress): string => (sa ? `${sa.protocol}//${sa.host}${sa.port && `:${sa.port}`}` : '');
+export const stringifySocketAddress = (sa: SocketAddress): string =>
+  sa ? `${sa.protocol}//${sa.host}${sa.port && `:${sa.port}`}` : '';
 
-export const isLocalNodeApi = (sa: SocketAddress) => shallowEq(sa, LOCAL_NODE_API_URL);
+export const isLocalNodeApi = (sa: SocketAddress) =>
+  shallowEq(sa, LOCAL_NODE_API_URL);
 
 export const isRemoteNodeApi = (sa: SocketAddress) => !isLocalNodeApi(sa);
 
-export const isWalletOnlyType = (walletType: WalletType) => walletType === WalletType.RemoteApi;
+export const isWalletOnlyType = (walletType: WalletType) =>
+  walletType === WalletType.RemoteApi;
 
-export const isLocalNodeType = (walletType: WalletType) => walletType === WalletType.LocalNode;
+export const isLocalNodeType = (walletType: WalletType) =>
+  walletType === WalletType.LocalNode;
 
-export const toPublicService = (netName: string, url: string): PublicService => ({
+export const toPublicService = (
+  netName: string,
+  url: string
+): PublicService => ({
   name: netName,
   ...toSocketAddress(url),
 });

--- a/tests/datetime.spec.ts
+++ b/tests/datetime.spec.ts
@@ -1,4 +1,8 @@
-import { formatDateAsISO, formatDateAsUS, formatISOAsUS } from '../shared/datetime';
+import {
+  formatDateAsISO,
+  formatDateAsUS,
+  formatISOAsUS,
+} from '../shared/datetime';
 
 describe('datetime utils', () => {
   const genesis = new Date(0);
@@ -11,11 +15,17 @@ describe('datetime utils', () => {
 
   it('formats date in human readable format', () => {
     expect(formatDateAsUS(genesis)).toEqual('Thursday, January 1, 1970, 00:00');
-    expect(formatDateAsUS(btcGenesis)).toEqual('Saturday, January 3, 2009, 18:15');
+    expect(formatDateAsUS(btcGenesis)).toEqual(
+      'Saturday, January 3, 2009, 18:15'
+    );
   });
 
   it('converts ISO to US', () => {
-    expect(formatISOAsUS('1970-01-01T00-00-00.000Z')).toEqual('Thursday, January 1, 1970, 00:00');
-    expect(formatISOAsUS('2009-01-03T18-15-00.000Z')).toEqual('Saturday, January 3, 2009, 18:15');
+    expect(formatISOAsUS('1970-01-01T00-00-00.000Z')).toEqual(
+      'Thursday, January 1, 1970, 00:00'
+    );
+    expect(formatISOAsUS('2009-01-03T18-15-00.000Z')).toEqual(
+      'Saturday, January 3, 2009, 18:15'
+    );
   });
 });

--- a/tests/walletFiles.spec.ts
+++ b/tests/walletFiles.spec.ts
@@ -13,21 +13,35 @@ import {
   updateWalletMeta,
   updateWalletSecrets,
 } from '../desktop/main/walletFile';
-import { Wallet, WalletSecrets, WalletSecretsEncrypted, WalletType } from '../shared/types';
+import {
+  Wallet,
+  WalletSecrets,
+  WalletSecretsEncrypted,
+  WalletType,
+} from '../shared/types';
 
 const FIXTURES_DIRECTORY = path.resolve(__dirname, './fixtures');
-const VALID_WALLET_PATH = path.resolve(FIXTURES_DIRECTORY, './my_wallet_valid.json');
+const VALID_WALLET_PATH = path.resolve(
+  FIXTURES_DIRECTORY,
+  './my_wallet_valid.json'
+);
 
 describe('Encryption/Decryption wallet file', () => {
-  const secrets: WalletSecrets = { mnemonic: 'this is just a test so it does not matter what mnemonics here', accounts: [], contacts: [] };
+  const secrets: WalletSecrets = {
+    mnemonic: 'this is just a test so it does not matter what mnemonics here',
+    accounts: [],
+    contacts: [],
+  };
   const cipher: WalletSecretsEncrypted = {
     cipher: 'AES-128-CTR',
     cipherText:
       '715066e1109e89e8d638e703fdc6038d7bb25a81df6b6d2aebeba26488f7b4b47bc805b61302c125c6998ebcbb15a40c5802e8386c4edbdca832db3d8e1d27c36e68357a840d0cc623a92c498cde40c6205d715013cb5ecd2d676212d6ed2b30061fc85b70890eb2',
   };
 
-  it('encrypts the wallet file', () => expect(encryptWallet(secrets, 'password')).toStrictEqual(cipher));
-  it('decrypts the wallet file', () => expect(decryptWallet(cipher, 'password')).toStrictEqual(secrets));
+  it('encrypts the wallet file', () =>
+    expect(encryptWallet(secrets, 'password')).toStrictEqual(cipher));
+  it('decrypts the wallet file', () =>
+    expect(decryptWallet(cipher, 'password')).toStrictEqual(secrets));
   it('decrypt throws an error in case of wrong password', async () => {
     expect(() => decryptWallet(cipher, 'wrong')).toThrowError('Wrong password');
   });
@@ -42,7 +56,9 @@ describe('Load wallet file', () => {
         meta: {
           displayName: expect.any(String),
           created: expect.any(String),
-          type: expect.stringMatching(new RegExp(`^${WalletType.LocalNode}|${WalletType.RemoteApi}$`)),
+          type: expect.stringMatching(
+            new RegExp(`^${WalletType.LocalNode}|${WalletType.RemoteApi}$`)
+          ),
           netId: expect.any(Number),
           remoteApi: expect.any(String),
           meta: {
@@ -78,7 +94,11 @@ describe('Save/update wallet file', () => {
     outDir = await fs.mkdtemp(path.resolve(os.tmpdir(), 'walletFiles-test'));
   });
   afterEach(async () => {
-    await fs.readdir(outDir).then((files) => Promise.all(files.map((file) => fs.unlink(`${outDir}/${file}`))));
+    await fs
+      .readdir(outDir)
+      .then((files) =>
+        Promise.all(files.map((file) => fs.unlink(`${outDir}/${file}`)))
+      );
   });
   it('saves wallet file', async () => {
     const wallet = await loadWallet(VALID_WALLET_PATH, '1');
@@ -90,7 +110,10 @@ describe('Save/update wallet file', () => {
   it('updates wallet meta', async () => {
     const walletPath = path.resolve(outDir, path.basename(VALID_WALLET_PATH));
     await fs.copyFile(VALID_WALLET_PATH, walletPath);
-    const result = await updateWalletMeta(walletPath, { displayName: 'It works!', netId: 5 });
+    const result = await updateWalletMeta(walletPath, {
+      displayName: 'It works!',
+      netId: 5,
+    });
     // Meta updated
     expect(result).toMatchObject({
       meta: {
@@ -114,7 +137,9 @@ describe('Save/update wallet file', () => {
     // Secret part is updated
     expect(updatedWallet.crypto.mnemonic).toEqual('It works!');
     // Part of it is untouched
-    expect(updatedWallet.crypto.accounts).toStrictEqual(original.crypto.accounts);
+    expect(updatedWallet.crypto.accounts).toStrictEqual(
+      original.crypto.accounts
+    );
     // Public part of wallet file is untoched
     expect(original.meta).toStrictEqual(updatedWallet.meta);
   });
@@ -136,7 +161,10 @@ describe('List wallet files', () => {
   };
 
   it('by paths', async () => {
-    const wallets = await listWalletsByPaths([VALID_WALLET_PATH, VALID_WALLET_PATH]);
+    const wallets = await listWalletsByPaths([
+      VALID_WALLET_PATH,
+      VALID_WALLET_PATH,
+    ]);
     expectWalletList(2, wallets);
   });
   it('within directory', async () => {
@@ -155,7 +183,11 @@ describe('copyWalletFile', () => {
     tmpDir = await fs.mkdtemp(path.resolve(os.tmpdir(), 'walletFiles-test'));
   });
   afterEach(async () => {
-    await fs.readdir(tmpDir).then((files) => Promise.all(files.map((file) => fs.unlink(`${tmpDir}/${file}`))));
+    await fs
+      .readdir(tmpDir)
+      .then((files) =>
+        Promise.all(files.map((file) => fs.unlink(`${tmpDir}/${file}`)))
+      );
   });
 
   it('copies wallet file & increment name', async () => {


### PR DESCRIPTION
There is no issue.

### Rationale
1. There was a conflicting rule (`max-len` vs `prettier`)
2. Max line length was 180 chars, which is incredibly long. As a consequence eslint requires to write long and hardly-readably one-line expressions instead of clean multiline ones.

### Solution
- get rid of conflicting rule `max-len` and let prettier do the work
- move prettier config into eslint config and get rid of `.prettierrc` (ignored by eslint)