### PR TITLE
Bunch of core fixes and improvements

### DIFF
--- a/desktop/NodeService.ts
+++ b/desktop/NodeService.ts
@@ -126,6 +126,13 @@ class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
     });
   };
 
+  cancelStatusStream = () => {
+    if (!this.statusStream) return false;
+    this.statusStream.cancel();
+    this.statusStream = null;
+    return true;
+  };
+
   activateErrorStream = (handler: ErrorStreamHandler) => {
     if (!this.service) return;
 
@@ -144,6 +151,13 @@ class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
       this.logger.log('grpc ErrorStream ended', null);
       this.errorStream = null;
     });
+  };
+
+  cancelErrorStream = () => {
+    if (!this.errorStream) return false;
+    this.errorStream.cancel();
+    this.errorStream = null;
+    return true;
   };
 }
 

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -75,16 +75,22 @@ class SmesherManager {
     );
   };
 
+  updateSmesherState = async () => {
+    await this.sendSmesherSettingsAndStartupState();
+    await this.sendPostSetupComputeProviders();
+  };
+
   serviceStartupFlow = async () => {
     const cfg = await this.sendSmesherConfig();
     if (cfg?.start) {
+      // Unsubscribe first
+      this.smesherService.deactivateProgressStream();
       // Subscribe on PoST cration progress stream ASAP
       this.smesherService.activateProgressStream(
         this.handlePostDataCreationStatusStream
       );
     }
-    await this.sendSmesherSettingsAndStartupState();
-    await this.sendPostSetupComputeProviders();
+    await this.updateSmesherState();
   };
 
   sendSmesherSettingsAndStartupState = async () => {

--- a/desktop/SmesherService.ts
+++ b/desktop/SmesherService.ts
@@ -119,6 +119,15 @@ class SmesherService extends NetServiceFactory<
     handler: (error: Error, status: Partial<PostSetupStatus>) => void
   ) => this.postDataCreationProgressStream(handler);
 
+  deactivateProgressStream = () => {
+    if (this.stream) {
+      this.stream.cancel();
+      this.stream = null;
+      return true;
+    }
+    return false;
+  };
+
   stopSmeshing = ({ deleteFiles }: { deleteFiles: boolean }) =>
     this.callService('StopSmeshing', { deleteFiles })
       .then(this.normalizeServiceResponse)

--- a/desktop/main/Wallet.ts
+++ b/desktop/main/Wallet.ts
@@ -18,6 +18,7 @@ import CryptoService from '../cryptoService';
 import encryptionConst from '../encryptionConst';
 import { getISODate } from '../../shared/datetime';
 import { CreateWalletRequest } from '../../shared/ipcMessages';
+import { LOCAL_NODE_API_URL } from '../../shared/constants';
 import StoreService from '../storeService';
 import { DOCUMENTS_DIR, DEFAULT_WALLETS_DIRECTORY } from './constants';
 import { AppContext } from './context';
@@ -177,7 +178,10 @@ export const createWallet = async ({
   const wallet = create(files?.length || 0, existingMnemonic);
 
   wallet.meta.netId = netId;
-  wallet.meta.remoteApi = apiUrl ? stringifySocketAddress(apiUrl) : '';
+  wallet.meta.remoteApi =
+    apiUrl && apiUrl !== LOCAL_NODE_API_URL
+      ? stringifySocketAddress(apiUrl)
+      : '';
   wallet.meta.type = type;
 
   const walletPath = path.resolve(

--- a/desktop/main/createMainWindow.ts
+++ b/desktop/main/createMainWindow.ts
@@ -82,5 +82,6 @@ export default () => {
     $isAppClosing,
     $showWindowOnLoad,
     $isWindowReady,
+    $isSmappActivated: $activate,
   };
 };

--- a/desktop/main/promptBeforeClose.ts
+++ b/desktop/main/promptBeforeClose.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, dialog } from 'electron';
 import { firstValueFrom, Subject } from 'rxjs';
 import { ipcConsts } from '../../app/vars';
-import { Managers } from './Networks';
+import { Managers } from './app.types';
 import { showNotification } from './utils';
 
 enum CloseAppPromptResult {
@@ -44,9 +44,13 @@ const promptBeforeClose = (
       body: 'Smesher is running in the background.',
     });
 
-  const quit = () => {
-    $isAppClosing.next(true);
-    app.quit();
+  const quit = async () => {
+    try {
+      await managers.node?.stopNode();
+    } finally {
+      $isAppClosing.next(true);
+      app.quit();
+    }
   };
 
   const handleClosingApp = async (event: Electron.Event) => {

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -95,7 +95,7 @@ export const ifTruish = <V extends any, R extends Record<any, any>>(
 
 // GRPC APIs
 export const toSocketAddress = (url?: string): SocketAddress => {
-  if (!url) return LOCAL_NODE_API_URL;
+  if (!url || url === 'http://localhost:9092') return LOCAL_NODE_API_URL;
 
   const u = new URL(url.startsWith('http') ? url : `http://${url}`);
   if (u.protocol !== 'http:' && u.protocol !== 'https:') {
@@ -103,7 +103,7 @@ export const toSocketAddress = (url?: string): SocketAddress => {
   }
   return {
     host: u.hostname,
-    port: u.port || u.protocol === 'https:' ? '443' : '9090',
+    port: u.port || u.protocol === 'https:' ? '443' : '9092',
     protocol: u.protocol,
   };
 };


### PR DESCRIPTION
1. If a GRPC service is unavailable for a long time — do not stop retrying to reach the service.
   _OUT OF SCOPE: It might be improved by making a single queue of retries, so only one request will retry in a loop until it finally gets a response. Requires further wrapping of data into reactive streams._
2. In previous refactoring I lost an essential part of code: calling `StopNode` GRPC API before closing Smapp. Returned it to its place. Probably it may help with some known bugs of go-spacemesh.
3. Force update of NodeStatus and Smesher data on each to activate Smapp (basically, when the window is shown). Fixes bug when User runs Smapp in the background and then opens it again, it shows default (empty) state until gets updates from streams.
4. Do not store default `http://localhost:9092` as `remoteApi` prop in wallet file.
     In addition, handle it normally in case if it is stored in the wallet file.