### PR TITLE
Fix recovering wallet from mnemonics and tweaked UX

### DIFF
--- a/app/basicComponents/Input.tsx
+++ b/app/basicComponents/Input.tsx
@@ -102,11 +102,13 @@ const ExtraTxt = styled.div`
 `;
 
 type Props = {
+  onKeyDown?: (event: React.KeyboardEvent) => void;
   onChange?: ({ value }: { value: string }) => void;
   onChangeDebounced?: ({ value }: { value: string | number }) => void;
   onEnterPress?: () => void | Promise<any>;
   onFocus?: ({ target }: { target: EventTarget | null }) => void;
   onPaste?: () => void;
+  inputRef?: (element: HTMLInputElement | null) => void;
   value: any;
   isDisabled?: boolean;
   placeholder?: string;
@@ -120,11 +122,13 @@ type Props = {
 };
 
 const Input = ({
+  onKeyDown = () => {},
   onChange = () => {},
   onChangeDebounced = () => {},
   onFocus = () => {},
   onEnterPress = () => {},
   onPaste = () => {},
+  inputRef,
   value,
   isDisabled = false,
   placeholder = '',
@@ -176,6 +180,7 @@ const Input = ({
   return (
     <Wrapper isDisabled={isDisabled} isFocused={isFocused} style={style}>
       <ActualInput
+        ref={inputRef}
         iconLeft={iconLeft}
         value={value}
         readOnly={isDisabled}
@@ -184,6 +189,7 @@ const Input = ({
         onChange={handleChange}
         onFocus={handleFocus}
         onBlur={() => setIsFocused(false)}
+        onKeyDown={onKeyDown}
         type={type}
         maxLength={maxLength}
         autoFocus={autofocus}

--- a/app/screens/auth/SwitchNetwork.tsx
+++ b/app/screens/auth/SwitchNetwork.tsx
@@ -78,18 +78,21 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
       : [{ label: 'NO NETWORKS AVAILABLE', isDisabled: true }];
 
   const goNext = (netId: number) => {
-    const { creatingWallet, isWalletOnly } = location.state;
+    const { creatingWallet, isWalletOnly, mnemonic } = location.state;
     if (creatingWallet) {
-      if (netId === -1)
-        return history.push(AuthPath.CreateWallet, { netId, isWalletOnly });
-      if (isWalletOnly)
+      if (isWalletOnly && netId !== -1)
         return history.push(AuthPath.ConnectToAPI, {
           redirect: AuthPath.CreateWallet,
           netId,
           isWalletOnly,
           creatingWallet,
+          mnemonic,
         });
-      return history.push(AuthPath.CreateWallet, { netId, isWalletOnly });
+      return history.push(AuthPath.CreateWallet, {
+        netId,
+        isWalletOnly,
+        mnemonic,
+      });
     }
     if (netId > -1 && isWalletOnly) {
       return history.push(AuthPath.ConnectToAPI, {
@@ -97,6 +100,7 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
         netId,
         isWalletOnly,
         creatingWallet,
+        mnemonic,
       });
     }
     return history.push(location?.state?.redirect || AuthPath.Unlock);

--- a/app/screens/auth/WalletConnectionType.tsx
+++ b/app/screens/auth/WalletConnectionType.tsx
@@ -83,13 +83,21 @@ const BottomPart = styled.div`
   align-items: flex-end;
 `;
 
-const WalletConnectionType = ({ history }: AuthRouterParams) => {
+const WalletConnectionType = ({ history, location }: AuthRouterParams) => {
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
 
   const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
 
   const handleNextStep = (walletOnly: boolean) => () => {
-    history.push(AuthPath.WalletType, { isWalletOnly: walletOnly });
+    if (location?.state?.mnemonic) {
+      history.push(AuthPath.SwitchNetwork, {
+        isWalletOnly: walletOnly,
+        mnemonic: location.state.mnemonic,
+        creatingWallet: true,
+      });
+    } else {
+      history.push(AuthPath.WalletType, { isWalletOnly: walletOnly });
+    }
   };
 
   return (

--- a/app/screens/auth/WordsRestore.tsx
+++ b/app/screens/auth/WordsRestore.tsx
@@ -1,3 +1,4 @@
+import * as R from 'ramda';
 import * as bip39 from 'bip39';
 import React, { useState, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
@@ -15,6 +16,8 @@ import { RootState } from '../../types';
 import { AuthPath } from '../../routerPaths';
 import { ExternalLinks } from '../../../shared/constants';
 import { AuthRouterParams } from './routerParams';
+
+const WORDS_AMOUNT = 12;
 
 const Table = styled.div`
   display: flex;
@@ -57,10 +60,11 @@ const getInputStyle = (hasError: boolean) => ({
 });
 
 const WordsRestore = ({ history }: AuthRouterParams) => {
-  const [words, setWords] = useState(Array(12).fill(''));
+  const [words, setWords] = useState(Array(WORDS_AMOUNT).fill(''));
   const [hasError, setHasError] = useState(false);
 
   const isDarkMode = useSelector((state: RootState) => state.ui.isDarkMode);
+  const inputRefs = React.useRef<(HTMLInputElement | null)[]>([]);
 
   const handleInputChange = ({
     value,
@@ -69,8 +73,14 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
     value: string;
     index: number;
   }) => {
-    const newWords = [...words];
-    newWords[index] = value;
+    const input = value
+      .split(' ')
+      .filter(Boolean)
+      .slice(0, WORDS_AMOUNT - index);
+    const newWords = (input.length ? input : ['']).reduce(
+      (acc, val, idx) => R.adjust(index + idx, R.always(val), acc),
+      words
+    );
     setWords(newWords);
     setHasError(false);
   };
@@ -107,6 +117,10 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
     },
     [restoreWith12Words]
   );
+  const nextInput = (index: number) => {
+    const next = Math.max(0, Math.min(WORDS_AMOUNT, index + 1));
+    inputRefs.current[next]?.focus();
+  };
 
   useEffect(() => {
     window.addEventListener('keyup', handleKeyUp, false);
@@ -125,8 +139,12 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
         <InputWrapper key={`input${index}`}>
           <InputCounter>{index + 1}</InputCounter>
           <Input
+            inputRef={(el) => {
+              inputRefs.current[index] = el;
+            }}
             value={words[index]}
             onChange={({ value }) => handleInputChange({ value, index })}
+            onKeyDown={(event) => event.code === 'Space' && nextInput(index)}
             style={getInputStyle(hasError)}
             autofocus={index === 0}
           />

--- a/app/screens/auth/WordsRestore.tsx
+++ b/app/screens/auth/WordsRestore.tsx
@@ -102,7 +102,7 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
   const restoreWith12Words = useCallback(() => {
     const mnemonic = Object.values(words).join(' ');
     if (validateMnemonic({ mnemonic })) {
-      history.push(AuthPath.CreateWallet, { mnemonic });
+      history.push(AuthPath.ConnectionType, { mnemonic });
     } else {
       setHasError(true);
     }

--- a/app/screens/auth/WordsRestore.tsx
+++ b/app/screens/auth/WordsRestore.tsx
@@ -160,7 +160,7 @@ const WordsRestore = ({ history }: AuthRouterParams) => {
       width={800}
       height={480}
       isDarkMode={isDarkMode}
-      header="WALLET 12 WORDS RESTORE"
+      header="RESTORE WALLET FROM 12 WORDS"
       subHeader="Please enter the 12 words in the right order."
     >
       <BackButton action={history.goBack} />


### PR DESCRIPTION
It fixes #933

Also, in the first commit, I've improved the UX of the "RESTORE WALLET FROM 12 WORDS" screen by:
1. When you type a space, it automatically focuses on the next input
2. Now you're able just to paste your mnemonics. It will use space as a divider and will put words in the corresponding inputs. Check it out ;)
3. Btw, I've changed the screen header from "WALLET 12 WORDS RESTORE" to "RESTORE WALLET FROM 12 WORDS" ;)