### PR TITLE
Show rewards in transactions log and tweak storage

### DIFF
--- a/desktop/AccountState.ts
+++ b/desktop/AccountState.ts
@@ -1,29 +1,38 @@
 import path from 'path';
 import fs from 'fs';
 import { app } from 'electron';
-import { AccountBalance } from '../shared/types';
+import { AccountBalance, HexString } from '../shared/types';
 import { Tx, Reward } from '../shared/types/tx';
 import { debounce } from '../shared/utils';
+import Logger from './logger';
+
+const logger = Logger({ className: 'AccountState' });
 
 // Types
-
 export interface AccountState {
   publicKey: string;
-  account: Required<AccountBalance>;
-  txs: { [txId: Tx['id']]: Tx };
-  rewards: { [layer: number]: Reward };
+  [k: number]: {
+    account: Required<AccountBalance>;
+    txs: { [txId: Tx['id']]: Tx };
+    rewards: { [layer: number]: Reward };
+  };
 }
 
 // Utils
 
-const getDefaultAccountState = (publicKey: string): AccountState => ({
+const getDefaultAccountState = (
+  publicKey: string,
+  netId: number
+): AccountState => ({
   publicKey,
-  account: {
-    currentState: { balance: 0, counter: 0 },
-    projectedState: { balance: 0, counter: 0 },
+  [netId]: {
+    account: {
+      currentState: { balance: 0, counter: 0 },
+      projectedState: { balance: 0, counter: 0 },
+    },
+    txs: {},
+    rewards: {},
   },
-  txs: {},
-  rewards: {},
 });
 
 const getFilePath = (publicKey: string, baseDir: string) =>
@@ -32,22 +41,29 @@ const getFilePath = (publicKey: string, baseDir: string) =>
 // Side-effects
 const DEFAULT_BASE_DIR = path.resolve(app.getPath('userData'), 'accounts');
 
-const load = (publicKey: string, baseDir = DEFAULT_BASE_DIR): AccountState => {
+const load = (
+  publicKey: string,
+  netId: number,
+  baseDir = DEFAULT_BASE_DIR,
+  retry = 0
+): AccountState => {
+  const filePath = getFilePath(publicKey, baseDir);
   try {
-    const raw = fs.readFileSync(getFilePath(publicKey, baseDir), {
+    const raw = fs.readFileSync(filePath, {
       encoding: 'utf8',
     });
     const parsed = JSON.parse(raw);
     return {
-      ...getDefaultAccountState(publicKey),
+      ...getDefaultAccountState(publicKey, netId),
       ...parsed,
     };
   } catch (err) {
-    if ((err as { code: string }).code !== 'ENOENT') {
-      // eslint-disable-next-line no-console
-      console.log('AccountState.load', publicKey, 'error:', err);
+    if ((err as { code: string }).code !== 'ENOENT' && retry !== 1) {
+      logger.log('AccountState.load', err, publicKey);
+      fs.unlinkSync(filePath);
+      return load(publicKey, netId, baseDir, 1);
     }
-    return getDefaultAccountState(publicKey);
+    return getDefaultAccountState(publicKey, netId);
   }
 };
 
@@ -77,9 +93,12 @@ export class AccountStateManager {
 
   private baseDir: string;
 
-  constructor(publicKey, opts = DEFAULT_OPTS) {
-    this.state = load(publicKey, opts.accountStateDir);
+  private netId: number;
+
+  constructor(publicKey: HexString, netId: number, opts = DEFAULT_OPTS) {
+    this.state = load(publicKey, netId, opts.accountStateDir);
     this.baseDir = opts.accountStateDir;
+    this.netId = netId;
     if (opts.autosave) {
       this.autosave = debounce(opts.debounce, this.save);
     }
@@ -94,28 +113,29 @@ export class AccountStateManager {
   // Getters (pure)
   getPublicKey = () => this.state.publicKey;
 
-  getAccount = () => this.state.account;
+  getAccount = () => this.state[this.netId].account;
 
-  getTxs = () => this.state.txs;
+  getTxs = () => this.state[this.netId].txs;
 
-  getTxById = (id: keyof AccountState['txs']) => this.state.txs[id] || null;
+  getTxById = (id: keyof AccountState[number]['txs']) =>
+    this.state[this.netId].txs[id] || null;
 
-  getRewards = () => Object.values(this.state.rewards);
+  getRewards = () => Object.values(this.state[this.netId].rewards);
 
   // Setters. Might be impure if autosave is turned on.
   storeAccountBalance = (balance: Required<AccountBalance>) => {
-    this.state.account = balance;
+    this.state[this.netId].account = balance;
     return this.autosave();
   };
 
   storeTransaction = (tx: Tx) => {
-    const prevTxData = this.state.txs[tx.id] || {};
-    this.state.txs[tx.id] = { ...prevTxData, ...tx };
+    const prevTxData = this.state[this.netId].txs[tx.id] || {};
+    this.state[this.netId].txs[tx.id] = { ...prevTxData, ...tx };
     return this.autosave();
   };
 
   storeReward = (reward: Reward) => {
-    this.state.rewards[reward.layer] = reward;
+    this.state[this.netId].rewards[reward.layer] = reward;
     return this.autosave();
   };
 }

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -151,6 +151,8 @@ class NodeManager {
     this.unsub();
   };
 
+  getNetId = () => this.netId;
+
   subscribeToEvents = () => {
     // Handlers
     const startNode = () => this.startNode();

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -61,11 +61,20 @@ class TransactionManager {
 
   private accountStates: Record<string, AccountStateManager> = {};
 
-  constructor(meshService, glStateService, txService, mainWindow) {
+  private netId: number;
+
+  constructor(
+    meshService: MeshService,
+    glStateService: GlobalStateService,
+    txService: TransactionService,
+    mainWindow: BrowserWindow,
+    netId: number
+  ) {
     this.meshService = meshService;
     this.glStateService = glStateService;
     this.txService = txService;
     this.mainWindow = mainWindow;
+    this.netId = netId;
   }
 
   //
@@ -212,8 +221,7 @@ class TransactionManager {
             .concat(this.accounts.slice(idx + 1))
         : this.accounts;
     this.accounts = [...filtered, account];
-
-    const accManager = new AccountStateManager(account.publicKey);
+    const accManager = new AccountStateManager(account.publicKey, this.netId);
     this.accountStates[account.publicKey] = accManager;
     // Resubscribe
     this.subscribeAccount(account);

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -1,3 +1,4 @@
+import * as R from 'ramda';
 import { BrowserWindow } from 'electron';
 import {
   Account,
@@ -19,7 +20,7 @@ import { Reward__Output } from '../proto/spacemesh/v1/Reward';
 import { Account__Output } from '../proto/spacemesh/v1/Account';
 import { addReceiptToTx, toTx } from '../shared/types/transformers';
 import { hasRequiredRewardFields } from '../shared/types/guards';
-import { debounce } from '../shared/utils';
+import { debounce, delay } from '../shared/utils';
 import cryptoService from './cryptoService';
 import { fromHexString, toHexString } from './utils';
 import TransactionService from './TransactionService';
@@ -30,6 +31,7 @@ import GlobalStateService, {
 } from './GlobalStateService';
 import { AccountStateManager } from './AccountState';
 import Logger from './logger';
+import { GRPC_QUERY_BATCH_SIZE as BATCH_SIZE } from './main/constants';
 
 const DATA_BATCH = 50;
 const IPC_DEBOUNCE = 1000;
@@ -38,7 +40,6 @@ type TxHandlerArg = MeshTransaction__Output | null | undefined;
 type TxHandler = (tx: TxHandlerArg) => void;
 
 type RewardHandlerArg = Reward__Output | null | undefined;
-type RewardHandler = (tx: RewardHandlerArg) => void;
 
 class TransactionManager {
   logger = Logger({ className: 'TransactionManager' });
@@ -152,7 +153,6 @@ class TransactionManager {
     const { publicKey } = account;
     // Cancel account Txs subscription
     this.txStateStream[publicKey]?.();
-
     const binaryAccountId = fromHexString(publicKey.substring(24));
     const addTransaction = this.upsertTransactionFromMesh(publicKey);
     this.retrieveHistoricTxData({
@@ -189,17 +189,13 @@ class TransactionManager {
     // this.glStateService.activateAccountDataStream(binaryAccountId, AccountDataFlag.ACCOUNT_DATA_FLAG_TRANSACTION_RECEIPT, addReceiptToTx);
 
     const addReward = this.addReward(publicKey);
-    this.retrieveRewards({
-      filter: { accountId: { address: binaryAccountId }, accountDataFlags: 2 },
-      offset: 0,
-      handler: addReward,
-      retries: 0,
-    });
-    this.glStateService.activateAccountDataStream(
-      binaryAccountId,
-      AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD,
-      addReward
-    );
+    this.retrieveRewards(binaryAccountId)
+      .then((value) => value.forEach(addReward))
+      .catch((err) => {
+        this.logger.error('Can not retrieve and store rewards', err);
+      });
+
+    this.glStateService.listenRewardsByCoinbase(binaryAccountId, addReward);
 
     this.updateAppStateTxs(publicKey);
     this.updateAppStateRewards(publicKey);
@@ -346,45 +342,6 @@ class TransactionManager {
     this.storeTx(accountId, updatedTx);
   };
 
-  retrieveHistoricTxReceipt = async ({
-    filter,
-    offset,
-    handler,
-    retries,
-  }: {
-    filter: { accountId: { address: Uint8Array }; accountDataFlags: number };
-    offset: number;
-    handler: ({ data }: { data: any }) => void;
-    retries: number;
-  }) => {
-    const {
-      totalResults,
-      data,
-      error,
-    } = await this.glStateService.sendAccountDataQuery({ filter, offset });
-    if (error && retries < 5) {
-      await this.retrieveHistoricTxReceipt({
-        filter,
-        offset,
-        handler,
-        retries: retries + 1,
-      });
-    } else {
-      data &&
-        data.length &&
-        data.length > 0 &&
-        data.forEach((item) => handler({ data: item.receipt }));
-      if (offset + DATA_BATCH < totalResults) {
-        await this.retrieveHistoricTxReceipt({
-          filter,
-          offset: offset + DATA_BATCH,
-          handler,
-          retries: 0,
-        });
-      }
-    }
-  };
-
   addReward = (accountId: HexString) => (reward: RewardHandlerArg) => {
     if (!reward || !hasRequiredRewardFields(reward)) return;
 
@@ -399,42 +356,43 @@ class TransactionManager {
     this.storeReward(accountId, parsedReward);
   };
 
-  retrieveRewards = async ({
-    filter,
-    offset,
-    handler,
-    retries,
-  }: {
-    filter: {
-      accountId: { address: Uint8Array };
-      accountDataFlags: AccountDataValidFlags;
-    };
-    offset: number;
-    handler: RewardHandler;
-    retries: number;
-  }) => {
-    const {
-      totalResults,
-      data,
-      error,
-    } = await this.glStateService.sendAccountDataQuery({ filter, offset });
-    if (error && retries < 5) {
-      await this.retrieveRewards({
-        filter,
-        offset,
-        handler,
-        retries: retries + 1,
-      });
-    } else {
-      data?.length > 0 && data.forEach((reward) => handler(reward.reward));
-      if (offset + DATA_BATCH < totalResults) {
-        await this.retrieveRewards({
-          filter,
-          offset: offset + DATA_BATCH,
-          handler,
-          retries: 0,
-        });
+  retrieveRewards = async (coinbase: Uint8Array): Promise<Reward__Output[]> => {
+    const composeArg = (batchNumber: number) => ({
+      filter: {
+        accountId: { address: coinbase },
+        accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD as AccountDataValidFlags,
+      },
+      offset: batchNumber * BATCH_SIZE,
+    });
+    const getAccountDataQuery = async (batch: number, retries = 5) => {
+      const res = await this.glStateService.sendAccountDataQuery(
+        composeArg(batch)
+      );
+      if (res.error && retries > 0) {
+        await delay(1000);
+        return getAccountDataQuery(batch, retries - 1);
       }
+      return res;
+    };
+    const { totalResults, data } = await getAccountDataQuery(0);
+    if (totalResults <= BATCH_SIZE) {
+      const r: Reward__Output[] = data.filter(
+        (item): item is Reward__Output =>
+          !!item && hasRequiredRewardFields(item)
+      );
+      return r;
+    } else {
+      const nextRewards = await Promise.all(
+        R.compose(
+          R.map((idx) =>
+            this.glStateService
+              .sendAccountDataQuery(composeArg(idx))
+              .then((resp) => resp.data)
+          ),
+          R.range(1)
+        )(Math.ceil(totalResults / BATCH_SIZE))
+      ).then(R.unnest);
+      return data ? [...data, ...nextRewards] : nextRewards;
     }
   };
 

--- a/desktop/WalletManager.ts
+++ b/desktop/WalletManager.ts
@@ -54,7 +54,8 @@ class WalletManager {
       this.meshService,
       this.glStateService,
       this.txService,
-      mainWindow
+      mainWindow,
+      this.nodeManager.getNetId()
     );
   }
 

--- a/desktop/main/reactions/syncToRenderer.ts
+++ b/desktop/main/reactions/syncToRenderer.ts
@@ -11,6 +11,7 @@ import {
   Observable,
   scan,
   skipUntil,
+  startWith,
   Subject,
   withLatestFrom,
 } from 'rxjs';
@@ -182,12 +183,12 @@ export default (
     $nodeVersion.pipe(map(R.objOf('node'))),
     combineLatest([
       $smesherId,
-      $activations,
+      $rewards.pipe(startWith([])),
+      $activations.pipe(startWith([])),
       $nodeConfig,
       $currentLayer,
-      $rewards,
     ]).pipe(
-      map(([smesherId, activations, cfg, curLayer, rewards]) => ({
+      map(([smesherId, rewards, activations, cfg, curLayer]) => ({
         smesher: {
           smesherId: toHexString(smesherId),
           activations,

--- a/desktop/main/sources/smesherInfo.ts
+++ b/desktop/main/sources/smesherInfo.ts
@@ -12,7 +12,7 @@ import {
   Observable,
   of,
   scan,
-  shareReplay,
+  share,
   Subject,
   switchMap,
   withLatestFrom,
@@ -127,7 +127,7 @@ const syncSmesherInfo = (
           fromHexString(coinbase.substring(2)),
           (x) => subscriber.next(x)
         )
-      ).pipe(shareReplay())
+      ).pipe(share())
     )
   );
 
@@ -152,7 +152,7 @@ const syncSmesherInfo = (
           fromHexString(coinbase.substring(2)),
           (atx) => subscriber.next(atx)
         )
-      ).pipe(shareReplay())
+      ).pipe(share())
     )
   );
   const $activationsHistory = combineLatest([$coinbase, $managers]).pipe(


### PR DESCRIPTION
It fixes #932 and fixes #927

Also, it includes a little tweak into `syncToRenderer` which makes `smesher` batch updates more atomic, without the requirement to have any activations and rewards to send the data.