### PR TITLE
feat: log rotation for stdout/stderr

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "fs-reverse": "^0.0.3",
     "history": "4",
     "js-xdr": "1.3.0",
+    "logrotator": "^1.1.0",
     "pbkdf2": "3.1.2",
     "ramda": "^0.28.0",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11878,6 +11878,11 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
   integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
 
+logrotator@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/logrotator/-/logrotator-1.1.0.tgz#b0fe5aa44485848572569429cfd0d47f772b4e25"
+  integrity sha512-uzwrAFK7KBzcwBO48wqK7q+Q/bd4fEUZEvAkdRHjGpO3eFoUpVWHgGGcoE8O3WVunCj575mfxesMkyuLOWDTEw==
+
 lolex@^5.0.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"


### PR DESCRIPTION
It closes #680 

How it works
We have a log file for the Spacemesh node, based on node config. Checking every 30m file size and compress old logs to a separate file and clean up current one, rotate logs when the file will reach file size limit, right now 500 mb.

Why I didn't use https://www.npmjs.com/package/node-log-rotate
This solution for log and for rotation, we need only rotate log file, because we're logging with electron-log and second painful moment, they creating log file for us, based on timestamp and deleting this file based on this date time, we have different logic for our logs

Demo:

https://user-images.githubusercontent.com/54288612/185711588-0dd5253f-4c90-42bf-a83b-50ac2dd06dea.mov


