### PR TITLE
fix navbar color by theme and active status

### DIFF
--- a/app/screens/main/Main.tsx
+++ b/app/screens/main/Main.tsx
@@ -60,6 +60,12 @@ const NavLinksWrapper = styled.div`
   margin-left: 140px;
 `;
 
+const getNavLinkColorTheme = (theme: DefaultTheme, isActive?: boolean) => {
+  let { color } = theme.navBar;
+  color = theme.isDarkMode ? smColors.navLinkGrey : color;
+  return isActive ? smColors.purple : color;
+};
+
 const NavBarLink = styled(BoldText)<{ isActive?: boolean }>`
   display: flex;
   flex-direction: row;
@@ -69,12 +75,7 @@ const NavBarLink = styled(BoldText)<{ isActive?: boolean }>`
   line-height: 15px;
   text-decoration-line: ${({ isActive }) => (isActive ? 'underline' : 'none')};
   text-transform: uppercase;
-  color: ${({
-    isActive,
-    theme: {
-      navBar: { color },
-    },
-  }) => (isActive ? smColors.purple : color)};
+  color: ${({ isActive, theme }) => getNavLinkColorTheme(theme, isActive)};
   cursor: pointer;
 `;
 


### PR DESCRIPTION
It closes #963

Dark mode:
![Navbar-dark-mode](https://user-images.githubusercontent.com/5428168/189033591-05bceecc-3118-414a-9e02-6722f2bc5332.jpg)
Light mode:
![Navbar-light-mode](https://user-images.githubusercontent.com/5428168/189033595-1d79ac01-1ba4-4e77-b8e4-f35e0626f26a.jpg)
