### PR TITLE
Fix updating of account balances in remote API mode

### DIFF
--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -34,7 +34,6 @@ import Logger from './logger';
 import { GRPC_QUERY_BATCH_SIZE as BATCH_SIZE } from './main/constants';
 
 const DATA_BATCH = 50;
-const IPC_DEBOUNCE = 1000;
 
 type TxHandlerArg = MeshTransaction__Output | null | undefined;
 type TxHandler = (tx: TxHandlerArg) => void;
@@ -83,23 +82,23 @@ class TransactionManager {
   };
 
   // Debounce update functions to avoid excessive IPC calls
-  updateAppStateAccount = debounce(IPC_DEBOUNCE, (publicKey: string) => {
+  updateAppStateAccount = (publicKey: string) => {
     const account = this.accountStates[publicKey].getAccount();
     this.appStateUpdater(ipcConsts.T_M_UPDATE_ACCOUNT, {
       account,
       accountId: publicKey,
     });
-  });
+  };
 
-  updateAppStateTxs = debounce(IPC_DEBOUNCE, (publicKey: string) => {
+  updateAppStateTxs = (publicKey: string) => {
     const txs = this.accountStates[publicKey].getTxs();
     this.appStateUpdater(ipcConsts.T_M_UPDATE_TXS, { txs, publicKey });
-  });
+  };
 
-  updateAppStateRewards = debounce(IPC_DEBOUNCE, (publicKey: string) => {
+  updateAppStateRewards = (publicKey: string) => {
     const rewards = this.accountStates[publicKey].getRewards();
     this.appStateUpdater(ipcConsts.T_M_UPDATE_REWARDS, { rewards, publicKey });
-  });
+  };
 
   private storeTx = (publicKey: string, tx: Tx): Promise<void> =>
     this.accountStates[publicKey]

--- a/desktop/WalletManager.ts
+++ b/desktop/WalletManager.ts
@@ -137,7 +137,7 @@ class WalletManager {
       } else {
         await this.nodeManager.stopNode();
         if (!!apiUrl && isRemoteNodeApi(apiUrl)) {
-          await this.nodeManager.connectToRemoteNode(apiUrl);
+          res = await this.nodeManager.connectToRemoteNode(apiUrl);
         }
       }
       this.meshService.createService(apiUrl);


### PR DESCRIPTION
There is no issue, I found the bug and fixed it :)

### How to reproduce
1. Use Smapp v0.2.6
2. Connect to the remote API
3. Request some smidge from the tap bot or just open a wallet with a positive balance.

You will see an incoming transaction in the log and 0 smidges.