### PR TITLE
Chore: hide explorer and dash links

### DIFF
--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -151,7 +151,12 @@ const Address = (props: Props) => {
         <span>{textToShow}</span>
       </PublicKey>
       {!hideCopy && <CopyIcon onClick={handleCopy} />}
-      {!hideExplorer && (
+      {/* TODO:
+        Until we don't have an explorer that supports new tx&accounts structure
+        we have to hide the explorer button from the UI.
+        To avoid linter errors I've just added `false` into the condition.
+      */}
+      {!hideExplorer && false && (
         <ExplorerIcon src={explorer} onClick={handleExplorer} />
       )}
       {addToContacts && isAccount && (

--- a/app/screens/main/Main.tsx
+++ b/app/screens/main/Main.tsx
@@ -192,7 +192,11 @@ class Main extends Component<Props, State> {
                   'MANAGE CONTACTS',
                   MainPath.Contacts
                 )}
+                {/*
+                TODO: Do not render dashboard link since it is not supports new
+                tx&accounts structure. Should be returned back when it will work.
                 {this.renderNavBarLink('DASH', 'DASHBOARD', MainPath.Dashboard)}
+                */}
               </NavLinksWrapper>
             </NavBarPart>
             <NavBarPart>


### PR DESCRIPTION
Since the explorer and dashboard does not support new transaction and account structures we had to hide it from Smapp for a while.