### PR TITLE
Make a robust wallet file encryption using AES-GCM

### DIFF
--- a/desktop/aes-gcm.ts
+++ b/desktop/aes-gcm.ts
@@ -1,0 +1,91 @@
+// Due to documentation we had to import SubtleCrypto
+// with dynamical require until we switch to Node version 19+
+// then we can replace it with
+//   const { subtle } = globalThis.crypto;
+const { subtle } = require('crypto').webcrypto;
+
+export const KDF_DKLEN = 256;
+export const KDF_ITERATIONS = 120000;
+
+// salt should come from `crypto.randomBytes(16)`
+export const pbkdf2Key = async (
+  pass: string,
+  salt: BufferSource
+): Promise<CryptoKey> => {
+  const ec = new TextEncoder();
+  const keyMaterial = await subtle.importKey(
+    'raw',
+    ec.encode(pass),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
+  const key = await subtle.deriveKey(
+    // Recommended PBKDF2 parameters from OWASP
+    // https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-512',
+      salt,
+      iterations: KDF_ITERATIONS,
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: KDF_DKLEN },
+    true,
+    ['encrypt', 'decrypt']
+  );
+  return key;
+};
+
+export const constructAesGcmIv = async (
+  key: CryptoKey,
+  input: BufferSource
+): Promise<ArrayBuffer> => {
+  if (key.algorithm.name !== 'AES-GCM') {
+    throw new Error('Key is not an AES-GCM key');
+  }
+  const rawKey = await subtle.exportKey('raw', key);
+  const hmacKey = await subtle.importKey(
+    'raw',
+    rawKey,
+    { name: 'HMAC', hash: 'SHA-512' },
+    true,
+    ['sign']
+  );
+  const iv = await subtle.sign({ name: 'HMAC' }, hmacKey, input);
+  return iv.slice(0, 12); // IV is 12 bytes
+};
+
+export const encrypt = async (
+  key: CryptoKey,
+  iv: BufferSource,
+  plaintext: BufferSource
+): Promise<ArrayBuffer> => {
+  const ciphertext = await subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv,
+      tagLength: 128,
+    },
+    key,
+    plaintext
+  );
+  return ciphertext;
+};
+
+export const decrypt = async (
+  key: CryptoKey,
+  iv: BufferSource,
+  ciphertext: BufferSource
+): Promise<ArrayBuffer> => {
+  const plaintext = await subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv,
+      tagLength: 128,
+    },
+    key,
+    ciphertext
+  );
+  return plaintext;
+};

--- a/desktop/main/sources/wallet.ipc.ts
+++ b/desktop/main/sources/wallet.ipc.ts
@@ -51,6 +51,7 @@ import {
 } from '../rx.utils';
 import { createNewAccount, createWallet, isNetIdMissing } from '../Wallet';
 import {
+  loadAndMigrateWallet,
   loadWallet,
   saveWallet,
   updateWalletMeta,
@@ -90,6 +91,17 @@ const loadWallet$ = (path: string, password: string) => {
   return from(
     wrapResult(
       loadWallet(path, password).then((wallet) => <WalletData>{ path, wallet })
+    )
+  );
+};
+
+// TODO: Replace it with `loadWallet$` in next release
+const loadAndMigrateWallet$ = (path: string, password: string) => {
+  return from(
+    wrapResult(
+      loadAndMigrateWallet(path, password).then(
+        (wallet) => <WalletData>{ path, wallet }
+      )
     )
   );
 };
@@ -138,7 +150,7 @@ const handleWalletIpcRequests = (
     handleIPC(
       ipcConsts.W_M_UNLOCK_WALLET,
       ({ path, password }: UnlockWalletRequest) =>
-        loadWallet$(path, password).pipe(
+        loadAndMigrateWallet$(path, password).pipe(
           withLatestFrom($networks),
           map(([hr, nets]) =>
             mapResult(

--- a/desktop/main/walletFile.ts
+++ b/desktop/main/walletFile.ts
@@ -3,6 +3,7 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
+import crypto from 'crypto';
 import * as R from 'ramda';
 
 import {
@@ -11,7 +12,19 @@ import {
   WalletMeta,
   WalletSecrets,
   WalletSecretsEncrypted,
+  WalletSecretsEncryptedGCM,
+  WalletSecretsEncryptedLegacy,
 } from '../../shared/types';
+import { isWalletGCMEncrypted } from '../../shared/types/guards';
+import { fromHexString, toHexString } from '../../shared/utils';
+import {
+  constructAesGcmIv,
+  decrypt,
+  encrypt,
+  pbkdf2Key,
+  KDF_DKLEN,
+  KDF_ITERATIONS,
+} from '../aes-gcm';
 import FileEncryptionService from '../fileEncryptionService';
 import { isFileExists } from '../utils';
 import { DEFAULT_WALLETS_DIRECTORY } from './constants';
@@ -22,8 +35,29 @@ export const WRONG_PASSWORD_MESSAGE = 'Wrong password';
 // Encryption
 //
 
-export const decryptWallet = (
-  crypto: WalletSecretsEncrypted,
+const decryptGcm = async (
+  crypto: WalletSecretsEncryptedGCM,
+  password: string
+): Promise<WalletSecrets> => {
+  const dc = new TextDecoder();
+  const key = await pbkdf2Key(password, fromHexString(crypto.kdfparams.salt));
+  const decryptedRaw = dc.decode(
+    await decrypt(
+      key,
+      fromHexString(crypto.cipherParams.iv),
+      fromHexString(crypto.cipherText)
+    )
+  );
+  try {
+    const decrypted = JSON.parse(decryptedRaw) as WalletSecrets; // TODO: Add validation
+    return decrypted;
+  } catch (err) {
+    throw new Error(WRONG_PASSWORD_MESSAGE);
+  }
+};
+
+const decryptLegacy = (
+  crypto: WalletSecretsEncryptedLegacy,
   password: string
 ): WalletSecrets => {
   const key = FileEncryptionService.createEncryptionKey({ password });
@@ -39,16 +73,41 @@ export const decryptWallet = (
   }
 };
 
-export const encryptWallet = (
-  cryptoDecrypted: WalletSecrets,
+export const decryptWallet = async (
+  crypto: WalletSecretsEncrypted,
   password: string
-): WalletSecretsEncrypted => {
-  const key = FileEncryptionService.createEncryptionKey({ password });
-  const encrypted = FileEncryptionService.encryptData({
-    data: JSON.stringify(cryptoDecrypted),
-    key,
-  });
-  return { cipher: 'AES-128-CTR', cipherText: encrypted };
+) => {
+  if (isWalletGCMEncrypted(crypto)) {
+    return decryptGcm(crypto, password);
+  } else {
+    return decryptLegacy(crypto, password);
+  }
+};
+
+export const encryptWallet = async (
+  secrets: WalletSecrets,
+  password: string
+): Promise<WalletSecretsEncryptedGCM> => {
+  const ec = new TextEncoder();
+  const salt = crypto.randomBytes(16);
+  const key = await pbkdf2Key(password, salt);
+  const plaintext = ec.encode(JSON.stringify(secrets));
+  const iv = await constructAesGcmIv(key, plaintext);
+  const cipherText = await encrypt(key, iv, plaintext);
+  return {
+    cipher: 'AES-GCM',
+    cipherText: toHexString(cipherText),
+    cipherParams: {
+      iv: toHexString(iv),
+    },
+    kdf: 'PBKDF2',
+    kdfparams: {
+      dklen: KDF_DKLEN,
+      hash: 'SHA-512',
+      salt: toHexString(salt),
+      iterations: KDF_ITERATIONS,
+    },
+  };
 };
 
 //
@@ -65,7 +124,7 @@ export const loadWallet = async (
   password: string
 ): Promise<Wallet> => {
   const { crypto, meta } = await loadRawWallet(path);
-  const cryptoDecoded = decryptWallet(crypto, password);
+  const cryptoDecoded = await decryptWallet(crypto, password);
   return { meta, crypto: cryptoDecoded };
 };
 
@@ -79,13 +138,13 @@ export const saveRaw = async (walletPath: string, wallet: WalletFile) => {
   return { filename, filepath };
 };
 
-export const saveWallet = (
+export const saveWallet = async (
   walletPath: string,
   password: string,
   wallet: Wallet
 ): Promise<{ filename: string; filepath: string }> => {
   const { meta, crypto } = wallet;
-  const encrypted = encryptWallet(crypto, password);
+  const encrypted = await encryptWallet(crypto, password);
   const fileContent: WalletFile = {
     meta,
     crypto: encrypted,

--- a/shared/types/guards.ts
+++ b/shared/types/guards.ts
@@ -4,7 +4,12 @@ import { Transaction__Output } from '../../proto/spacemesh/v1/Transaction';
 import { TransactionState__Output } from '../../proto/spacemesh/v1/TransactionState';
 import { NodeError } from './node';
 import { Tx, Reward, Activation } from './tx';
-import { WalletSecrets, WalletSecretsEncrypted } from './wallet';
+import {
+  WalletSecrets,
+  WalletSecretsEncrypted,
+  WalletSecretsEncryptedGCM,
+  WalletSecretsEncryptedLegacy,
+} from './wallet';
 
 // GRPC Type guards
 export const hasRequiredTxFields = (
@@ -46,6 +51,14 @@ export const isNodeError = (a: any): a is NodeError =>
 
 export const isWalletSecretsEncrypted = (a: any): a is WalletSecretsEncrypted =>
   a && a.cipher && a.cipherText;
+
+export const isWalletGCMEncrypted = (a: any): a is WalletSecretsEncryptedGCM =>
+  isWalletSecretsEncrypted(a) && a.cipher === 'AES-GCM';
+
+export const isWalletLegacyEncrypted = (
+  a: any
+): a is WalletSecretsEncryptedLegacy =>
+  isWalletSecretsEncrypted(a) && a.cipher === 'AES-128-CTR';
 
 export const isWalletSecrets = (a: any): a is WalletSecrets =>
   a && a.mnemonic && a.accounts && a.contacts;

--- a/shared/types/wallet.ts
+++ b/shared/types/wallet.ts
@@ -1,3 +1,5 @@
+import { HexString } from './misc';
+
 export interface KeyPair {
   displayName: string;
   created: string;
@@ -47,10 +49,29 @@ export interface WalletSecrets {
   contacts: Contact[];
 }
 
-export interface WalletSecretsEncrypted {
-  cipher: string;
+export interface WalletSecretsEncryptedLegacy {
+  cipher: 'AES-128-CTR';
   cipherText: string;
 }
+
+export interface WalletSecretsEncryptedGCM {
+  cipher: 'AES-GCM';
+  cipherParams: {
+    iv: HexString;
+  };
+  kdf: 'PBKDF2';
+  kdfparams: {
+    dklen: number;
+    hash: 'SHA-512';
+    iterations: number;
+    salt: HexString;
+  };
+  cipherText: string;
+}
+
+export type WalletSecretsEncrypted =
+  | WalletSecretsEncryptedLegacy
+  | WalletSecretsEncryptedGCM;
 
 export interface Wallet {
   meta: WalletMeta;

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -158,10 +158,12 @@ export const fromHexString = (hexString: HexString) => {
   }
   return Uint8Array.from(bytes);
 };
-export const toHexString = (bytes: Uint8Array | Buffer): HexString =>
+export const toHexString = (
+  bytes: Uint8Array | Buffer | ArrayBuffer
+): HexString =>
   bytes instanceof Buffer
     ? bytes.toString('hex')
-    : bytes.reduce(
+    : new Uint8Array(bytes).reduce(
         (str: string, byte: number) => str + byte.toString(16).padStart(2, '0'),
         ''
       );

--- a/tests/fixtures/my_wallet_gcm.json
+++ b/tests/fixtures/my_wallet_gcm.json
@@ -1,0 +1,26 @@
+{
+    "meta": {
+        "displayName": "Wallet GCM",
+        "created": "2022-11-02T16-14-40.308Z",
+        "type": "local-node",
+        "netId": 300,
+        "remoteApi": "",
+        "meta": {
+            "salt": "Spacemesh blockmesh"
+        }
+    },
+    "crypto": {
+        "cipher": "AES-GCM",
+        "cipherText": "0669fb71788e4b5a0b626206d2ad2bd21c610d695748dc52dda4a55edafe29b31e8ad2dc54e0cba1a990441eaf18beceb20029a3b84aee7cc4eecbeb961069d7da077874c24e2a88b623778957a84dc82edaecbfa3da5f17d6f3cd8ec2d4d759f50d95ac485161152bc5a2d346443c7e20969c374027866b75e1fc9b770f31c8b02b10f8c63ec6f749937bf3e3e30c8696eb1574937d95e2e0322df8e662af36d7dcf8a344c3bfe3d8082795a438f6b5a5152d35819d57f8c12d13929b3abf8471805a2fd2a5db3506ee9fd24e4a2d6eba4478def1b27fb07de08d13b7ef8bc1d625c072a04c60e56977ec81ee2a7bff9cafe2c99e363414eb53b43c2faac05642ac3766f0b96e5cffcd597161c09627ddc33b2148f1e9aac677b6a3293139aa6a6f892794c598f4cc1ab9f70f5a8c80a7bb2915e525c68a92282086a478c34da9dc131cb099de98e0b24aa48c8e5f7750ee46f7da51b56f44def2790002dfc6e5fc0019f9dd037eda0f95799f95142c1e6fad4d775a34c258fb21c2723b4f1be494f610c214b1c0e1b6f8fa7b31490fa5bb8eb225397111644853d7a93eb43c566823648444df43d67df1e89202bc4b1d28748cf406ecc1a672bdce53",
+        "cipherParams": {
+            "iv": "fbab632fdf6cf909cc46c4c7"
+        },
+        "kdf": "PBKDF2",
+        "kdfparams": {
+            "dklen": 256,
+            "hash": "SHA-512",
+            "salt": "ec756095c06f695c7cf261660f1cf597",
+            "iterations": 120000
+        }
+    }
+}

--- a/tests/fixtures/my_wallet_legacy.json
+++ b/tests/fixtures/my_wallet_legacy.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "displayName": "Main Wallet",
+    "displayName": "Wallet Legacy",
     "created": "2022-03-28T05-45-12.391Z",
     "type": "local-node",
     "netId": 221,

--- a/tests/walletFiles.spec.ts
+++ b/tests/walletFiles.spec.ts
@@ -16,14 +16,19 @@ import {
 import {
   Wallet,
   WalletSecrets,
-  WalletSecretsEncrypted,
+  WalletSecretsEncryptedGCM,
+  WalletSecretsEncryptedLegacy,
   WalletType,
 } from '../shared/types';
 
 const FIXTURES_DIRECTORY = path.resolve(__dirname, './fixtures');
-const VALID_WALLET_PATH = path.resolve(
+const LEGACY_WALLET_PATH = path.resolve(
   FIXTURES_DIRECTORY,
-  './my_wallet_valid.json'
+  './my_wallet_legacy.json'
+);
+const GCM_WALLET_PATH = path.resolve(
+  FIXTURES_DIRECTORY,
+  './my_wallet_gcm.json'
 );
 
 // For update wallet test
@@ -35,24 +40,60 @@ describe('Encryption/Decryption wallet file', () => {
     accounts: [],
     contacts: [],
   };
-  const cipher: WalletSecretsEncrypted = {
+  const cipher: WalletSecretsEncryptedLegacy = {
     cipher: 'AES-128-CTR',
     cipherText:
       '715066e1109e89e8d638e703fdc6038d7bb25a81df6b6d2aebeba26488f7b4b47bc805b61302c125c6998ebcbb15a40c5802e8386c4edbdca832db3d8e1d27c36e68357a840d0cc623a92c498cde40c6205d715013cb5ecd2d676212d6ed2b30061fc85b70890eb2',
   };
 
-  it('encrypts the wallet file', () =>
-    expect(encryptWallet(secrets, 'password')).toStrictEqual(cipher));
-  it('decrypts the wallet file', () =>
-    expect(decryptWallet(cipher, 'password')).toStrictEqual(secrets));
+  const cipher2: WalletSecretsEncryptedGCM = {
+    cipher: 'AES-GCM',
+    cipherText:
+      '5d1877a1e2c65ee3f894e7100c434770702fa29402b548438b8fbcdb37a76ca1dff4151a84984ba889a9efc564580b6278619e7bba17902405b05170a3407b63e640f1e68f97a02e60c917e806b3f761a1c8c29e66d856406f4eeacaedd50ba3f0f896011aa4d312c1636305b8175b1bb26ea827368af738',
+    cipherParams: {
+      iv: '49c842e8b787923f9b4e7dc5',
+    },
+    kdf: 'PBKDF2',
+    kdfparams: {
+      dklen: 256,
+      hash: 'SHA-512',
+      salt: '99d1b77e562446a65f0aa031d476df5b',
+      iterations: 120000,
+    },
+  };
+
+  const PASSWORD = 'password';
+
+  it('encrypts the wallet file (GCM)', async () => {
+    const encrypted = await encryptWallet(secrets, PASSWORD);
+    expect(encrypted).toHaveProperty('cipherText');
+    expect(encrypted).toHaveProperty('cipherParams');
+    expect(encrypted).toHaveProperty('kdf');
+    // Since every GCM encryption creates new random salt
+    // the only way to ensure that it is encrypted correctly
+    // is to decrypt it afterward and compare secrets
+    expect(await decryptWallet(encrypted, PASSWORD)).toEqual(secrets);
+  });
+  it('decrypts the wallet file (legacy CTR)', async () =>
+    expect(await decryptWallet(cipher, PASSWORD)).toStrictEqual(secrets));
+  it('decrypts the wallet file (GCM)', async () =>
+    expect(await decryptWallet(cipher2, PASSWORD)).toStrictEqual(secrets));
   it('decrypt throws an error in case of wrong password', async () => {
-    expect(() => decryptWallet(cipher, 'wrong')).toThrowError('Wrong password');
+    expect.assertions(2);
+    // Legacy CTR
+    await decryptWallet(cipher, 'wrong').catch((err) =>
+      expect(err.message).toMatch('Wrong password')
+    );
+    // GCM
+    await decryptWallet(cipher2, 'wrong').catch((err) =>
+      expect(err.message).toMatch('Wrong password')
+    );
   });
 });
 
 describe('Load wallet file', () => {
   it('loads valid wallet file', async () => {
-    const wallet = await loadWallet(VALID_WALLET_PATH, '1');
+    const wallet = await loadWallet(LEGACY_WALLET_PATH, '1');
 
     expect(wallet).toEqual(
       expect.objectContaining<Wallet>({
@@ -86,7 +127,7 @@ describe('Load wallet file', () => {
   });
 
   it('throws an error in case of wrong password', async () => {
-    const wallet = loadWallet(VALID_WALLET_PATH, 'wr0ng');
+    const wallet = loadWallet(LEGACY_WALLET_PATH, 'wr0ng');
     await expect(wallet).rejects.toThrow('Wrong password');
   });
 });
@@ -104,15 +145,15 @@ describe('Save/update wallet file', () => {
       );
   });
   it('saves wallet file', async () => {
-    const wallet = await loadWallet(VALID_WALLET_PATH, '1');
+    const wallet = await loadWallet(LEGACY_WALLET_PATH, '1');
     const { filepath } = await saveWallet(outDir, 'password', wallet);
     const result = await loadWallet(filepath, 'password');
 
     expect(result).toStrictEqual(wallet);
   });
   it('updates wallet meta', async () => {
-    const walletPath = path.resolve(outDir, path.basename(VALID_WALLET_PATH));
-    await fs.copyFile(VALID_WALLET_PATH, walletPath);
+    const walletPath = path.resolve(outDir, path.basename(LEGACY_WALLET_PATH));
+    await fs.copyFile(LEGACY_WALLET_PATH, walletPath);
     const result = await updateWalletMeta(walletPath, {
       displayName: 'It works!',
       netId: 5,
@@ -125,16 +166,16 @@ describe('Save/update wallet file', () => {
       },
     });
     // And secrets untouched
-    const original = await loadWallet(VALID_WALLET_PATH, '1');
+    const original = await loadWallet(LEGACY_WALLET_PATH, '1');
     const updatedWallet = await loadWallet(walletPath, '1');
     expect(original.crypto).toStrictEqual(updatedWallet.crypto);
   });
   it('updates encrypted part of wallet', async () => {
-    const walletPath = path.resolve(outDir, path.basename(VALID_WALLET_PATH));
-    await fs.copyFile(VALID_WALLET_PATH, walletPath);
+    const walletPath = path.resolve(outDir, path.basename(LEGACY_WALLET_PATH));
+    await fs.copyFile(LEGACY_WALLET_PATH, walletPath);
     await updateWalletSecrets(walletPath, '1', { mnemonic: 'It works!' });
 
-    const original = await loadWallet(VALID_WALLET_PATH, '1');
+    const original = await loadWallet(LEGACY_WALLET_PATH, '1');
     const updatedWallet = await loadWallet(walletPath, '1');
 
     // Secret part is updated
@@ -154,9 +195,15 @@ describe('List wallet files', () => {
     expect(wallets).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          path: VALID_WALLET_PATH,
+          path: LEGACY_WALLET_PATH,
           meta: expect.objectContaining({
-            displayName: 'Main Wallet',
+            displayName: 'Wallet Legacy',
+          }),
+        }),
+        expect.objectContaining({
+          path: GCM_WALLET_PATH,
+          meta: expect.objectContaining({
+            displayName: 'Wallet GCM',
           }),
         }),
       ])
@@ -165,18 +212,19 @@ describe('List wallet files', () => {
 
   it('by paths', async () => {
     const wallets = await listWalletsByPaths([
-      VALID_WALLET_PATH,
-      VALID_WALLET_PATH,
+      LEGACY_WALLET_PATH,
+      LEGACY_WALLET_PATH,
+      GCM_WALLET_PATH,
     ]);
-    expectWalletList(2, wallets);
+    expectWalletList(3, wallets);
   });
   it('within directory', async () => {
     const wallets = await listWalletsInDirectory(FIXTURES_DIRECTORY);
-    expectWalletList(1, wallets);
+    expectWalletList(2, wallets);
   });
   it('from both sources (returns only unique wallet files)', async () => {
-    const wallets = await listWallets(FIXTURES_DIRECTORY, [VALID_WALLET_PATH]);
-    expectWalletList(1, wallets);
+    const wallets = await listWallets(FIXTURES_DIRECTORY, [LEGACY_WALLET_PATH]);
+    expectWalletList(2, wallets);
   });
 });
 
@@ -194,12 +242,12 @@ describe('copyWalletFile', () => {
   });
 
   it('copies wallet file & increment name', async () => {
-    const copied = await copyWalletFile(VALID_WALLET_PATH, tmpDir);
+    const copied = await copyWalletFile(LEGACY_WALLET_PATH, tmpDir);
     expect(copied).toBeTruthy();
     // And couple times more to ensure that it will not overwrite the file
     // But append a counter to the filename
-    await copyWalletFile(VALID_WALLET_PATH, tmpDir);
-    await copyWalletFile(VALID_WALLET_PATH, tmpDir);
+    await copyWalletFile(LEGACY_WALLET_PATH, tmpDir);
+    await copyWalletFile(LEGACY_WALLET_PATH, tmpDir);
 
     const files = await fs.readdir(tmpDir);
     expect(files).toHaveLength(3);


### PR DESCRIPTION
It closes #988 

In this PR I left the previous vulnerable file encryption method to make it possible to easily migrate to the new wallet encryption schema. So the Users won't need to copy-paste mnemonics, they can just open their old wallet files.

On the first unlock of the legacy-encrypted wallet file, it will be automatically resaved with the new encryption method and the same password.

Besides this, I left some TODOs there to make it clear that these things should be removed in further releases.