### PR TITLE
Validate smeshing options before running the node

### DIFF
--- a/desktop/main/NodeConfig.ts
+++ b/desktop/main/NodeConfig.ts
@@ -4,6 +4,7 @@ import { NodeConfig } from '../../shared/types';
 import { configCodecByPath } from '../../shared/utils';
 import { fetchNodeConfig } from '../utils';
 import { NODE_CONFIG_FILE } from './constants';
+import { safeSmeshingOpts } from './smeshingOpts';
 
 export const loadNodeConfig = async () =>
   existsSync(NODE_CONFIG_FILE)
@@ -14,7 +15,10 @@ export const loadNodeConfig = async () =>
         )
     : {};
 
-const loadSmeshingOpts = async () => (await loadNodeConfig()).smeshing;
+const loadSmeshingOpts = async () => {
+  const opts = (await loadNodeConfig()).smeshing;
+  return safeSmeshingOpts(opts);
+};
 
 export const downloadNodeConfig = async (networkConfigUrl: string) => {
   const nodeConfig = await fetchNodeConfig(networkConfigUrl);

--- a/desktop/main/smeshingOpts.ts
+++ b/desktop/main/smeshingOpts.ts
@@ -1,0 +1,47 @@
+import Bech32 from '@spacemesh/address-wasm';
+import { fromHexString } from '../../shared/utils';
+
+export type SmeshingOpts = {
+  'smeshing-coinbase': string;
+  'smeshing-opts': {
+    'smeshing-opts-datadir': string;
+    'smeshing-opts-numfiles': number;
+    'smeshing-opts-numunits': number;
+    'smeshing-opts-provider': number;
+    'smeshing-opts-throttle': boolean;
+  };
+  'smeshing-start': boolean;
+};
+
+export const isSmeshingOpts = (a: any): a is SmeshingOpts =>
+  a &&
+  typeof a['smeshing-coinbase'] === 'string' &&
+  typeof a['smeshing-start'] === 'boolean' &&
+  typeof a['smeshing-opts'] === 'object' &&
+  typeof a['smeshing-opts']['smeshing-opts-datadir'] === 'string' &&
+  typeof a['smeshing-opts']['smeshing-opts-numfiles'] === 'number' &&
+  typeof a['smeshing-opts']['smeshing-opts-numunits'] === 'number' &&
+  typeof a['smeshing-opts']['smeshing-opts-provider'] === 'number' &&
+  typeof a['smeshing-opts']['smeshing-opts-throttle'] === 'boolean' &&
+  a['smeshing-coinbase'].length > 0 &&
+  a['smeshing-opts']['smeshing-opts-numfiles'] >= 1 &&
+  a['smeshing-opts']['smeshing-opts-numunits'] >= 1 &&
+  a['smeshing-opts']['smeshing-opts-provider'] >= 0;
+
+export const safeSmeshingOpts = (opts: SmeshingOpts) => {
+  if (!isSmeshingOpts(opts)) return {};
+
+  const oCoinbase = opts['smeshing-coinbase'];
+  const coinbase =
+    typeof oCoinbase === 'string' && oCoinbase.startsWith('0x')
+      ? Bech32.generateAddress(fromHexString(oCoinbase))
+      : oCoinbase;
+  if (Bech32.verify(coinbase)) {
+    return {
+      ...opts,
+      'smeshing-coinbase': coinbase,
+    };
+  } else {
+    return {};
+  }
+};


### PR DESCRIPTION
It fixes #1002 

So in case, the node config contains an old-fashioned address in the smeshing coinbase (aka `0x...`) it will be converted into a Bech32 address automatically.
Otherwise, it will drop off smeshing options, and the user will have to set up smeshing from scratch.

It also validates other fields (their types and minimum possible values, e.g. `-1` for `provider` will be invalid) and drop off entire smeshing options in case one of them is invalid.