### PR TITLE
Restart GRPC streams properly and restart GRPC client if needed

### DIFF
--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -3,6 +3,7 @@ import * as grpc from '@grpc/grpc-js';
 import { loadSync } from '@grpc/proto-loader';
 import { PublicService, SocketAddress } from '../shared/types';
 import { LOCAL_NODE_API_URL } from '../shared/constants';
+import { delay } from '../shared/utils';
 import Logger from './logger';
 
 // Types
@@ -53,10 +54,15 @@ class NetServiceFactory<
 
   private apiUrl: SocketAddress | null = null;
 
-  private restartStreamList: Record<
+  private startStreamList: Record<
     keyof Service<T, ServiceName>,
     () => void
-  > = <typeof this.restartStreamList>{};
+  > = {} as typeof this.startStreamList;
+
+  private cancelStreamList: Record<
+    keyof Service<T, ServiceName>,
+    () => void
+  > = {} as typeof this.cancelStreamList;
 
   createNetService = (
     protoPath: string,
@@ -94,15 +100,16 @@ class NetServiceFactory<
     );
   };
 
-  restartNetService = () => {
+  restartNetService = async () => {
     if (!this.protoPath || !this.apiUrl || !this.serviceName) return false;
     this.logger?.debug(
       `Restarting ${this.serviceName}`,
       this.protoPath,
       this.apiUrl
     );
+    await this.cancelStreams();
     this.createNetService(this.protoPath, this.apiUrl, this.serviceName);
-    this.restartStreams();
+    await this.restartStreams();
     return true;
   };
 
@@ -180,9 +187,16 @@ class NetServiceFactory<
     }
 
     let stream: ReturnType<typeof this.service[typeof method]>;
-    let timeout: NodeJS.Timeout;
 
-    const startStream = (retries: number) => {
+    const cancel = () =>
+      new Promise<void>((resolve) =>
+        setImmediate(() => {
+          stream && stream.cancel && stream.cancel();
+          resolve();
+        })
+      );
+
+    const startStream = async (retries: number, afterRestart) => {
       if (!this.service) {
         this.logger?.debug(
           `startStream > Service ${this.serviceName} is not running`,
@@ -192,46 +206,55 @@ class NetServiceFactory<
       }
       stream = this.service[method](opts);
       stream.on('data', onData);
-      stream.on('error', (error: Error & { code: number }) => {
+      stream.on('error', async (error: Error & { code: number }) => {
         if (error.code === 1) return; // Cancelled on client
-        this.logger?.error(`grpc ${this.serviceName}.${String(method)}`, error);
+        this.logger?.error(
+          `grpc ${this.serviceName}.${String(method)}`,
+          error,
+          `Retries left: ${retries}`
+        );
         if (retries > 0 && ERROR_CODE_TO_RESTART_STREAM.includes(error.code)) {
-          stream.cancel();
-          clearTimeout(timeout);
-          timeout = setTimeout(() => {
-            this.logger?.error(
-              `grpc ${this.serviceName}.${String(method)} restarting...`,
-              null
-            );
-            startStream(retries - 1);
-          }, 5000);
+          await cancel();
+          await delay(5000);
+          this.logger?.error(
+            `grpc ${this.serviceName}.${String(method)} restarting...`,
+            null
+          );
+          await startStream(retries - 1, afterRestart);
         } else {
-          this.restartNetService();
-          timeout = setTimeout(() => {
-            startStream(5);
-          }, 1000);
+          if (afterRestart) {
+            this.logger?.error(
+              `grpc ${this.serviceName}.${String(
+                method
+              )} can not restart after restarting NetService`,
+              error
+            );
+            return;
+          }
+          this.logger?.debug(
+            `grpc ${this.serviceName}.${String(
+              method
+            )} failed to restart. Restarting NetService...`
+          );
+          await this.restartNetService();
         }
       });
     };
-    startStream(_retries);
-    const cancel = () =>
-      new Promise<void>((resolve) =>
-        setImmediate(() => {
-          stream && stream.cancel && stream.cancel();
-          resolve();
-        })
-      );
+    startStream(_retries, false);
 
-    this.restartStreamList[method] = async () => {
-      await cancel();
-      startStream(_retries);
-    };
+    this.cancelStreamList[method] = () => cancel();
+    this.startStreamList[method] = () => startStream(_retries, true);
 
     return cancel;
   };
 
-  restartStreams = () =>
-    Object.values(this.restartStreamList).forEach((fn) => fn.call(this));
+  private callStreamList = (
+    list: typeof this.startStreamList | typeof this.cancelStreamList
+  ) => Promise.all(Object.values(list).map((fn) => fn.call(this)));
+
+  restartStreams = () => this.callStreamList(this.startStreamList);
+
+  cancelStreams = () => this.callStreamList(this.cancelStreamList);
 }
 
 export default NetServiceFactory;

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -214,19 +214,18 @@ class NodeManager {
     };
   };
 
-  waitForNodeServiceResponsiveness = async (resolve, attempts: number) => {
+  isNodeAlive = async (retries: number): Promise<boolean> => {
     if (!this.isNodeRunning()) {
-      resolve(false);
+      return false;
     }
     const isReady = await this.nodeService.echo();
     if (isReady) {
-      resolve(true);
-    } else if (attempts > 0) {
-      setTimeout(async () => {
-        await this.waitForNodeServiceResponsiveness(resolve, attempts - 1);
-      }, 500);
+      return true;
+    } else if (retries > 0) {
+      await delay(500);
+      return this.isNodeAlive(retries - 1);
     } else {
-      resolve(false);
+      return false;
     }
   };
 
@@ -243,9 +242,7 @@ class NodeManager {
     if (this.isNodeRunning()) return true;
     await this.spawnNode();
     this.nodeService.createService();
-    const success = await new Promise<boolean>((resolve) => {
-      this.waitForNodeServiceResponsiveness(resolve, 30); // 15 sec timeout
-    });
+    const success = await this.isNodeAlive(30); // 15 sec timeout
     if (success) {
       // update node status once by query request
       await this.updateNodeStatus();
@@ -552,14 +549,6 @@ class NodeManager {
       this.sendNodeStatus,
       this.pushNodeError
     );
-
-  isNodeAlive = async (attemptNumber = 0): Promise<boolean> => {
-    const res = await this.nodeService.echo();
-    if (!res && attemptNumber < 3) {
-      return delay(200).then(() => this.isNodeAlive(attemptNumber + 1));
-    }
-    return res;
-  };
 }
 
 export default NodeManager;


### PR DESCRIPTION
It fixes #992 and fixes #1003

Actually, I did not add incremental timeouts, it requires some more complicated constructions (or not robust shitty code), so I decided to keep the constant interval between retries.

So Smapp makes 5 retries (with 5 seconds delay) to establish Stream connections, then Smapp will restart the GRPC client and make another 5 retries. If nothing helps — it will stop retrying and send an error to the GUI.

So the User will be able to read an error and click on the RESTART button.

---
### How to test
1. To test that Smapp now restarts the GRPC client well the easiest way is to build your own go-spacemesh binary with changed lines of code: https://github.com/spacemeshos/go-spacemesh/blob/develop/api/grpcserver/grpc.go#L84-L86 (set lower values, otherwise you'll have to wait for 3+ hours)
2. To test that Smapp does not get stuck in an infinite loop of retries is just to kill the `go-spacemesh` process.