### PR TITLE
Fix transaction-related issues

### DIFF
--- a/app/components/transactions/LatestTransactions.tsx
+++ b/app/components/transactions/LatestTransactions.tsx
@@ -119,8 +119,8 @@ const LatestTransactions = ({ navigateToAllTransactions }: Props) => {
     const { id, status, timestamp, contacts, meta } = tx;
     // TODO: Temporary solution until we don't support other account types
     const isSent =
-      tx.method === SingleSigMethods.Spend &&
-      !!tx.payload?.Arguments?.Destination;
+      tx.method === SingleSigMethods.Spend && tx.principal === address;
+    const isSpawn = tx.method === SingleSigMethods.Spawn;
     const color = getColor({ status, isSent });
     return (
       <TxWrapper key={`tx_${id}`}>
@@ -139,11 +139,13 @@ const LatestTransactions = ({ navigateToAllTransactions }: Props) => {
           </Section>
           <Section>
             <Text>{getFormattedTimestamp(timestamp, status)}</Text>
-            <Amount color={color}>
-              {`${isSent ? '-' : '+'}${formatSmidge(
-                parseInt(tx.payload.Arguments.Amount, 10)
-              )}`}
-            </Amount>
+            {!isSpawn && (
+              <Amount color={color}>
+                {`${isSent ? '-' : '+'}${formatSmidge(
+                  parseInt(tx.payload.Arguments.Amount, 10)
+                )}`}
+              </Amount>
+            )}
           </Section>
         </MainWrapper>
       </TxWrapper>

--- a/app/components/transactions/TxRow.tsx
+++ b/app/components/transactions/TxRow.tsx
@@ -352,8 +352,9 @@ const TxRow = ({ tx, address, addAddressToContacts }: Props) => {
     if (!isSpendTransaction) return null;
     return (
       <HeaderSection>
-        <Amount color={smColors.blue}>
-          -{formatSmidge(parseInt(tx.payload.Arguments.Amount, 10))}
+        <Amount color={color}>
+          {isSent ? '-' : '+'}
+          {formatSmidge(parseInt(tx.payload.Arguments.Amount, 10))}
         </Amount>
         <DarkGrayText>{getFormattedTimestamp(tx.timestamp)}</DarkGrayText>
       </HeaderSection>

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -228,7 +228,10 @@ class TransactionManager {
             : TransactionState.TRANSACTION_STATE_REJECTED;
         const tx = toTx(txRes.tx, { id: { id: txRes.tx.id }, state });
         if (!tx) return;
-        this.upsertTransaction(address)(tx);
+        this.upsertTransaction(address)({
+          ...tx,
+          layer: txRes.layer,
+        });
         // TODO: https://github.com/spacemeshos/go-spacemesh/issues/3687
         queryAccountData();
       })

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -517,6 +517,18 @@ class TransactionManager {
             })
           : null;
       tx && this.upsertTransaction(address)(tx);
+
+      // TODO: Get rid of this call when we migrate to go-spacemesh
+      //       with this fix of the issue https://github.com/spacemeshos/go-spacemesh/issues/3687
+      this.retrieveAccountData({
+        filter: {
+          accountId: { address },
+          accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_ACCOUNT,
+        },
+        handler: this.updateAccountData(address),
+        retries: 0,
+      });
+
       return { error, tx };
     } catch (err) {
       this.logger.error('publishSelfSpawn', err);
@@ -600,6 +612,18 @@ class TransactionManager {
           : null;
 
       tx && this.upsertTransaction(address)(tx);
+
+      // TODO: Get rid of this call when we migrate to go-spacemesh
+      //       with this fix of the issue https://github.com/spacemeshos/go-spacemesh/issues/3687
+      this.retrieveAccountData({
+        filter: {
+          accountId: { address },
+          accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_ACCOUNT,
+        },
+        handler: this.updateAccountData(address),
+        retries: 0,
+      });
+
       return { error, tx };
     } catch (err) {
       this.logger.error('publishSpendTx', err);


### PR DESCRIPTION
There are no issues, but it includes fixes (within separate commits) to some bugs reported by our community members:

1. Fixes an issue when Users got "calculating time" instead of the actual layer time of the incoming transactions.
2. A temporary fix until we migrate to the newer go-spacemesh version (actual bug: https://github.com/spacemeshos/go-spacemesh/issues/3687): it forces an update of the account balance (and nonce) right after publishing the transaction. Otherwise, there is no guarantee that the account balance get updated, and then the next transaction may fail due to a "bad nonce" error.
3. Do not show `+0 SMH` for Spawn transaction and show proper signs before the amount for spend transactions (plus for incoming txs, minus for outgoing ones)