### PR TITLE
A bunch of small fixes

### DIFF
--- a/app/basicComponents/NetworkIndicator.tsx
+++ b/app/basicComponents/NetworkIndicator.tsx
@@ -1,18 +1,15 @@
-import React from 'react';
 import styled from 'styled-components';
-
-const Round = styled.div`
-  width: 10px;
-  height: 10px;
-  margin-right: 5px;
-  border-radius: 50%;
-  background-color: ${({ color }) => color};
-`;
 
 type Props = {
   color: string;
 };
 
-const NetworkIndicator = ({ color }: Props) => <Round color={color} />;
+const NetworkIndicator = styled.div`
+  width: 10px;
+  height: 10px;
+  margin-right: 5px;
+  border-radius: 50%;
+  background-color: ${({ color }: Props) => color};
+`;
 
 export default NetworkIndicator;

--- a/app/components/transactions/LatestTransactions.tsx
+++ b/app/components/transactions/LatestTransactions.tsx
@@ -10,7 +10,6 @@ import {
 } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
-import { TxState } from '../../../shared/types';
 import {
   getLatestTransactions,
   RewardView,
@@ -18,6 +17,7 @@ import {
 } from '../../redux/wallet/selectors';
 import { isReward } from '../../../shared/types/guards';
 import { SingleSigMethods } from '../../../shared/templateConsts';
+import getStatusColor from '../../vars/getStatusColor';
 
 const Wrapper = styled.div`
   display: flex;
@@ -93,35 +93,13 @@ const LatestTransactions = ({ navigateToAllTransactions }: Props) => {
   );
   const latestTransactions = useSelector(getLatestTransactions(address));
 
-  const getColor = ({
-    status,
-    isSent,
-  }: {
-    status: number;
-    isSent: boolean;
-  }) => {
-    if (
-      status === TxState.TRANSACTION_STATE_MEMPOOL ||
-      status === TxState.TRANSACTION_STATE_MESH
-    ) {
-      return smColors.orange;
-    } else if (
-      status === TxState.TRANSACTION_STATE_REJECTED ||
-      status === TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS ||
-      status === TxState.TRANSACTION_STATE_CONFLICTING
-    ) {
-      return smColors.red;
-    }
-    return isSent ? smColors.blue : smColors.darkerGreen;
-  };
-
   const renderTransaction = (tx: TxView) => {
     const { id, status, timestamp, contacts, meta } = tx;
     // TODO: Temporary solution until we don't support other account types
     const isSent =
       tx.method === SingleSigMethods.Spend && tx.principal === address;
     const isSpawn = tx.method === SingleSigMethods.Spawn;
-    const color = getColor({ status, isSent });
+    const color = getStatusColor(status, isSent);
     return (
       <TxWrapper key={`tx_${id}`}>
         <Icon chevronRight={isSent} />

--- a/app/infra/utils.ts
+++ b/app/infra/utils.ts
@@ -89,7 +89,7 @@ const packValueAndUnit = (value: number, unit: string) => ({
 });
 
 export const toSMH = (smidge: number) => smidge / 10 ** 12;
-export const toSmidge = (smh: number) => Math.ceil(smh * 10 ** 12);
+export const toSmidge = (smh: number) => Math.round(smh * 10 ** 12);
 
 // Parses number into { value, unit } format.
 // Used to format smidge strings

--- a/app/redux/wallet/actions.ts
+++ b/app/redux/wallet/actions.ts
@@ -334,14 +334,12 @@ export const sendTransaction = ({
     fee,
     note,
   };
-  // @TODO (remove ts-ignore) and check why state is error of return type in sendTx
-  // @ts-ignore
-  const { error, tx, state } = await eventsService.sendTx({
+  const { error, tx } = await eventsService.sendTx({
     fullTx,
     accountIndex: currentAccountIndex,
   });
   if (tx) {
-    return { id: tx.id, state };
+    return { id: tx.id };
   } else {
     const errorToLog = error
       ? addErrorPrefix('Send transaction error\n', error as Error)

--- a/app/screens/transactions/Transactions.tsx
+++ b/app/screens/transactions/Transactions.tsx
@@ -74,9 +74,10 @@ const getNumOfCoinsFromTransactions = (
           ? parseInt(payload?.Arguments?.Amount || 0, 10)
           : 0;
       if (
-        status !== TxState.TRANSACTION_STATE_REJECTED &&
-        status !== TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS &&
-        status !== TxState.TRANSACTION_STATE_CONFLICTING
+        status !== TxState.REJECTED &&
+        status !== TxState.INSUFFICIENT_FUNDS &&
+        status !== TxState.CONFLICTING &&
+        status !== TxState.FAILURE
       ) {
         return sender === address
           ? { ...coins, sent: coins.sent + amount }

--- a/app/screens/transactions/Transactions.tsx
+++ b/app/screens/transactions/Transactions.tsx
@@ -21,9 +21,10 @@ import {
   RewardView,
   TxView,
 } from '../../redux/wallet/selectors';
-import { TxState, HexString } from '../../../shared/types';
+import { TxState, Bech32Address } from '../../../shared/types';
 import { isReward, isTx } from '../../../shared/types/guards';
 import { ExternalLinks } from '../../../shared/constants';
+import { SingleSigMethods } from '../../../shared/templateConsts';
 
 const Wrapper = styled.div`
   display: flex;
@@ -61,14 +62,17 @@ const DropDownWrapper = styled.div`
 `;
 
 const getNumOfCoinsFromTransactions = (
-  address: HexString,
+  address: Bech32Address,
   transactions: (TxView | RewardView)[]
 ) => {
   const coins = { mined: 0, sent: 0, received: 0 };
   return transactions.reduce((coins, txOrReward: TxView | RewardView) => {
     if (isTx(txOrReward)) {
-      const { status, principal: sender, amount: am } = txOrReward;
-      const amount = am || 0;
+      const { status, principal: sender, method, payload } = txOrReward;
+      const amount =
+        method === SingleSigMethods.Spend
+          ? parseInt(payload?.Arguments?.Amount || 0, 10)
+          : 0;
       if (
         status !== TxState.TRANSACTION_STATE_REJECTED &&
         status !== TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS &&

--- a/app/screens/wallet/Overview.tsx
+++ b/app/screens/wallet/Overview.tsx
@@ -86,6 +86,13 @@ const Overview = ({ history }: RouteComponentProps) => {
 
   const navigateToWalletGuide = () => window.open(ExternalLinks.WalletGuide);
 
+  const isAccountPendingSpawnTx = !!txs.find(
+    (tx) =>
+      tx.meta?.templateName === 'SingleSig' &&
+      tx.method === 0 &&
+      (tx.status === TransactionState.TRANSACTION_STATE_MEMPOOL ||
+        tx.status === TransactionState.TRANSACTION_STATE_MESH)
+  );
   const isAccountSpawned = !!txs.find(
     (tx) =>
       tx.meta?.templateName === 'SingleSig' &&
@@ -125,6 +132,7 @@ const Overview = ({ history }: RouteComponentProps) => {
             img={sendIcon}
             imgPosition="after"
             style={{ marginBottom: 20 }}
+            isDisabled={isAccountPendingSpawnTx}
           />
         ) : (
           <Button

--- a/app/screens/wallet/Overview.tsx
+++ b/app/screens/wallet/Overview.tsx
@@ -7,9 +7,8 @@ import { BoldText, Button, Link } from '../../basicComponents';
 import { sendIcon, requestIcon } from '../../assets/images';
 import { RootState } from '../../types';
 import { MainPath, WalletPath } from '../../routerPaths';
-import { PostSetupState } from '../../../shared/types';
+import { PostSetupState, TxState } from '../../../shared/types';
 import { ExternalLinks } from '../../../shared/constants';
-import { _spacemesh_v1_TransactionState_TransactionState as TransactionState } from '../../../proto/spacemesh/v1/TransactionState';
 
 const Wrapper = styled.div`
   display: flex;
@@ -90,14 +89,13 @@ const Overview = ({ history }: RouteComponentProps) => {
     (tx) =>
       tx.meta?.templateName === 'SingleSig' &&
       tx.method === 0 &&
-      (tx.status === TransactionState.TRANSACTION_STATE_MEMPOOL ||
-        tx.status === TransactionState.TRANSACTION_STATE_MESH)
+      (tx.status === TxState.MEMPOOL || tx.status === TxState.MESH)
   );
   const isAccountSpawned = !!txs.find(
     (tx) =>
       tx.meta?.templateName === 'SingleSig' &&
       tx.method === 0 &&
-      tx.status === TransactionState.TRANSACTION_STATE_PROCESSED
+      tx.status === TxState.SUCCESS
   );
 
   const renderMiddleSection = () =>

--- a/app/screens/wallet/SpawnAccount.tsx
+++ b/app/screens/wallet/SpawnAccount.tsx
@@ -19,6 +19,7 @@ import {
 import { smColors } from '../../vars';
 import { TxSentFieldType } from '../../components/wallet/TxSent';
 import { MAX_GAS } from '../../../shared/constants';
+import Address from '../../components/common/Address';
 
 interface Props extends RouteComponentProps {
   location: {
@@ -176,7 +177,9 @@ const SpawnAccount = ({ history }: Props) => {
       <DetailsRow>
         <DetailsText>Self-Spawn</DetailsText>
         <Dots>....................................</Dots>
-        <DetailsText>{currentAccount.address}</DetailsText>
+        <DetailsText>
+          <Address address={currentAccount.address} suffix="(Me)" />
+        </DetailsText>
       </DetailsRow>
       <DetailsRow>
         <DetailsText>Fee</DetailsText>

--- a/app/vars/getStatusColor.ts
+++ b/app/vars/getStatusColor.ts
@@ -1,0 +1,24 @@
+import { TxState } from '../../shared/types';
+import smColors from './colors';
+
+const getStatusColor = (status: TxState, isSent: boolean) => {
+  switch (status) {
+    case TxState.MEMPOOL:
+    case TxState.MESH:
+    case TxState.PROCESSED:
+      return smColors.orange;
+    case TxState.REJECTED:
+    case TxState.INSUFFICIENT_FUNDS:
+    case TxState.CONFLICTING:
+    case TxState.FAILURE:
+    case TxState.INVALID:
+      return smColors.red;
+    case TxState.SUCCESS:
+      return isSent ? smColors.blue : smColors.darkerGreen;
+    case TxState.UNSPECIFIED:
+    default:
+      return smColors.mediumGray;
+  }
+};
+
+export default getStatusColor;

--- a/desktop/AccountState.ts
+++ b/desktop/AccountState.ts
@@ -15,7 +15,7 @@ interface StateType {
 }
 
 // Types
-export type AccountState = Record<GenesisID, StateType | string>;
+export type AccountState = Record<GenesisID, StateType | HexString>;
 
 // Utils
 const getDefaultAccountState = (
@@ -109,7 +109,7 @@ export class AccountStateManager {
   private autosave = () => Promise.resolve();
 
   // Getters (pure)
-  getAddress = () => this.state.address;
+  getAddress = () => this.state.address as HexString;
 
   getState = () => (this.state[this.genesisID] as StateType).state;
 

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -232,8 +232,6 @@ class TransactionManager {
           ...tx,
           layer: txRes.layer,
         });
-        // TODO: https://github.com/spacemeshos/go-spacemesh/issues/3687
-        queryAccountData();
       })
     );
 

--- a/desktop/main/promptBeforeClose.ts
+++ b/desktop/main/promptBeforeClose.ts
@@ -46,6 +46,7 @@ const promptBeforeClose = (
 
   const quit = async () => {
     try {
+      mainWindow.hide();
       managers.wallet?.unsubscribeAllStreams();
       await managers.node?.stopNode();
     } finally {
@@ -60,7 +61,7 @@ const promptBeforeClose = (
     if (cachedPromptResult !== null) return;
     event.preventDefault();
     if (!mainWindow) {
-      quit();
+      await quit();
       return;
     }
     const promptResult =
@@ -76,11 +77,8 @@ const promptBeforeClose = (
       $showWindowOnLoad.next(false);
       mainWindow.reload();
     } else if (promptResult === CloseAppPromptResult.CLOSE) {
-      $isAppClosing.next(true);
       mainWindow.webContents.send(ipcConsts.CLOSING_APP);
-      managers.wallet?.unsubscribeAllStreams();
-      await managers?.node?.stopNode();
-      quit();
+      await quit();
     }
   };
 

--- a/desktop/main/reactions/handleSmesherIpc.ts
+++ b/desktop/main/reactions/handleSmesherIpc.ts
@@ -1,4 +1,4 @@
-import { from, Subject, switchMap, withLatestFrom } from 'rxjs';
+import { from, Observable, Subject, switchMap, withLatestFrom } from 'rxjs';
 import { ipcConsts } from '../../../app/vars';
 import { PostSetupOpts } from '../../../shared/types';
 import { SmeshingSetupState } from '../../NodeManager';
@@ -13,7 +13,7 @@ const startSmeshing = (managers: Managers, opts: PostSetupOpts) =>
 
 export default (
   $managers: Subject<Managers>,
-  $smeshingStarted: Subject<SmeshingSetupState>
+  $smeshingStarted: Observable<SmeshingSetupState>
 ) => {
   const startSmeshingRequest = fromIPC<PostSetupOpts>(
     ipcConsts.SMESHER_START_SMESHING

--- a/desktop/main/reactions/syncNodeConfig.ts
+++ b/desktop/main/reactions/syncNodeConfig.ts
@@ -17,12 +17,12 @@ import { makeSubscription } from '../rx.utils';
 export default (
   $currentNetwork: Observable<Network | null>,
   $nodeConfig: Subject<NodeConfig>,
-  $smeshingStarted: Subject<SmeshingSetupState>
+  $smeshingSetupState: Subject<SmeshingSetupState>
 ) =>
   makeSubscription(
     merge(
       $currentNetwork.pipe(filter(Boolean), distinctUntilChanged()),
-      $smeshingStarted.pipe(
+      $smeshingSetupState.pipe(
         filter((value) => value !== SmeshingSetupState.ViaAPI),
         switchMap(() => $currentNetwork),
         filter(Boolean)

--- a/desktop/main/sources/smesherInfo.ts
+++ b/desktop/main/sources/smesherInfo.ts
@@ -27,6 +27,7 @@ import {
 import { hasRequiredRewardFields } from '../../../shared/types/guards';
 import { longToNumber } from '../../../shared/utils';
 import Logger from '../../logger';
+import { SmeshingSetupState } from '../../NodeManager';
 import { Managers } from '../app.types';
 import { MINUTE } from '../constants';
 
@@ -63,7 +64,10 @@ const syncSmesherInfo = (
   $isWalletActivated: Subject<void>,
   $wallet: BehaviorSubject<Wallet | null>
 ) => {
-  const $smeshingStarted = new Subject<void>();
+  const $smeshingSetupState = new Subject<SmeshingSetupState>();
+  const $smeshingStarted = $smeshingSetupState.pipe(
+    filter((s) => s !== SmeshingSetupState.Failed)
+  );
 
   const $isLocalNode = $wallet.pipe(
     filter(Boolean),
@@ -167,6 +171,7 @@ const syncSmesherInfo = (
     $rewards,
     $coinbase,
     $smeshingStarted,
+    $smeshingSetupState,
   };
 };
 

--- a/desktop/main/sources/wallet.ipc.ts
+++ b/desktop/main/sources/wallet.ipc.ts
@@ -7,6 +7,7 @@ import {
   from,
   map,
   merge,
+  Observable,
   of,
   OperatorFunction,
   pipe,
@@ -38,6 +39,7 @@ import {
   stringifySocketAddress,
 } from '../../../shared/utils';
 import Logger from '../../logger';
+import { SmeshingSetupState } from '../../NodeManager';
 import { hasNetwork } from '../Networks';
 import {
   explodeResult,
@@ -142,7 +144,7 @@ const handleWalletIpcRequests = (
   $wallet: Subject<Wallet | null>,
   $walletPath: Subject<string>,
   $networks: Subject<Network[]>,
-  $smeshingStarted: Subject<void>
+  $smeshingStarted: Observable<SmeshingSetupState>
 ) => {
   // Handle IPC requests and produces WalletUpdate
   const $nextWallet = merge(

--- a/desktop/main/startApp.ts
+++ b/desktop/main/startApp.ts
@@ -115,6 +115,7 @@ const startApp = (): AppStore => {
     $activations,
     $rewards,
     $smeshingStarted,
+    $smeshingSetupState,
   } = getSmesherInfo($managers, $isWalletActivated, $wallet);
 
   const { $nodeRestartRequest } = nodeIPCStreams();
@@ -131,7 +132,7 @@ const startApp = (): AppStore => {
     // Spawn managers (and handle unsubscribing)
     spawnManagers($nodeConfig, $managers, $mainWindow),
     // On changing network -> update node config
-    syncNodeConfig($currentNetwork, $nodeConfig, $smeshingStarted),
+    syncNodeConfig($currentNetwork, $nodeConfig, $smeshingSetupState),
     // Activate wallet and accounts
     activateWallet(
       $wallet,

--- a/desktop/transformers.ts
+++ b/desktop/transformers.ts
@@ -2,7 +2,6 @@ import Bech32 from '@spacemesh/address-wasm';
 import { TemplateRegistry } from '@spacemesh/sm-codec';
 import { Transaction__Output } from '../proto/spacemesh/v1/Transaction';
 import { TransactionReceipt__Output } from '../proto/spacemesh/v1/TransactionReceipt';
-import { TransactionState__Output } from '../proto/spacemesh/v1/TransactionState';
 import { getMethodName, getTemplateName } from '../shared/templateMeta';
 import { hasRequiredTxFields } from '../shared/types/guards';
 import { Tx, TxState } from '../shared/types/tx';
@@ -26,10 +25,7 @@ const prettifyPayload = (payload: Record<string, any>) =>
     })
   );
 
-export const toTx = (
-  tx: Transaction__Output,
-  txState: TransactionState__Output | null
-) => {
+export const toTx = (tx: Transaction__Output, txState: TxState | null) => {
   if (!hasRequiredTxFields(tx)) return null;
   // const hrp = deriveHRP(tx.template.address);
   // if (!hrp) {
@@ -50,7 +46,7 @@ export const toTx = (
     principal: tx.principal.address,
     template: tx.template.address,
     method,
-    status: txState?.state || TxState.TRANSACTION_STATE_UNSPECIFIED,
+    status: txState || TxState.UNSPECIFIED,
     payload: prettifyPayload(decoded.Payload),
     gas: {
       gasPrice,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -7,13 +7,16 @@ export const LOCAL_NODE_API_URL: SocketAddress = {
 };
 
 export const TX_STATE_LABELS: Record<TxState, string> = {
-  [TxState.TRANSACTION_STATE_UNSPECIFIED]: 'Unknown state',
-  [TxState.TRANSACTION_STATE_REJECTED]: 'Rejected',
-  [TxState.TRANSACTION_STATE_CONFLICTING]: 'Conflicting',
-  [TxState.TRANSACTION_STATE_INSUFFICIENT_FUNDS]: 'Insufficient funds',
-  [TxState.TRANSACTION_STATE_MEMPOOL]: 'Pending',
-  [TxState.TRANSACTION_STATE_MESH]: 'Accepted',
-  [TxState.TRANSACTION_STATE_PROCESSED]: 'Confirmed',
+  [TxState.UNSPECIFIED]: 'Unknown state',
+  [TxState.REJECTED]: 'Rejected',
+  [TxState.CONFLICTING]: 'Conflicting',
+  [TxState.INSUFFICIENT_FUNDS]: 'Insufficient funds',
+  [TxState.MEMPOOL]: 'Pending',
+  [TxState.MESH]: 'Accepted',
+  [TxState.PROCESSED]: 'Confirmed',
+  [TxState.SUCCESS]: 'Applied',
+  [TxState.FAILURE]: 'Failed to apply',
+  [TxState.INVALID]: 'Invalid transaction',
 };
 
 export enum ExternalLinks {

--- a/shared/types/guards.ts
+++ b/shared/types/guards.ts
@@ -38,7 +38,7 @@ export const hasRequiredRewardFields = (
 
 // Own Type guards
 export const isTx = (a: any): a is Tx =>
-  a && a.id && a.sender && a.receiver && a.amount;
+  a && a.id && a.principal && a.template && a.method && a.payload;
 
 export const isReward = (a: any): a is Reward =>
   a && a.layer && a.coinbase && a.amount;

--- a/shared/types/tx.ts
+++ b/shared/types/tx.ts
@@ -1,14 +1,32 @@
-import { _spacemesh_v1_TransactionState_TransactionState as TxState } from '../../proto/spacemesh/v1/TransactionState';
-import { _spacemesh_v1_TransactionReceipt_TransactionResult as TxResult } from '../../proto/spacemesh/v1/TransactionReceipt';
+import { _spacemesh_v1_TransactionState_TransactionState as TState } from '../../proto/spacemesh/v1/TransactionState';
+import { _spacemesh_v1_TransactionReceipt_TransactionResult as TReceipt } from '../../proto/spacemesh/v1/TransactionReceipt';
+import { _spacemesh_v1_TransactionResult_Status as TResult } from '../../proto/spacemesh/v1/TransactionResult';
 import { Bech32Address, HexString } from './misc';
 
-export { _spacemesh_v1_TransactionState_TransactionState as TxState } from '../../proto/spacemesh/v1/TransactionState';
+export enum TxState {
+  UNSPECIFIED = 0,
+  REJECTED = 1,
+  INSUFFICIENT_FUNDS = 2,
+  CONFLICTING = 3,
+  MEMPOOL = 4,
+  MESH = 5,
+  PROCESSED = 6,
+  SUCCESS = 7,
+  FAILURE = 8,
+  INVALID = 9,
+}
+
+export const toTxState = (state: TState | TxState, res?: TResult): TxState => {
+  if (!state) return TxState.UNSPECIFIED;
+  if (typeof res === 'number') return TxState.PROCESSED + 1 + res;
+  return state as TxState;
+};
 
 // Transactions
 
 interface TxReceipt {
   fee: number;
-  result?: TxResult;
+  result?: TReceipt;
   gasUsed?: number;
   svmData?: HexString;
 }

--- a/shared/types/tx.ts
+++ b/shared/types/tx.ts
@@ -33,7 +33,6 @@ export interface Tx<T = any> {
   note?: string;
   // Old one, TODO: Remove
   receipt?: TxReceipt;
-  amount?: number;
 }
 
 export const asTx = <T>(tx: Tx<T>): Tx<T> => tx;


### PR DESCRIPTION
Based on top of genesis-id feature.
Will be merged in the `develop` branch after #999.

**Fixes:**
- Tx statistics, part of #1018
- Show the proper status of the processed transactions. For example, if the User sent a few spawn transactions he will see that all of them except one is not applied, and only one is applied to the state.
- Conversion of SMH (floats) to Smidge (int) worked imperfectly on some amounts
- Exit Smapp quickly
   Previously, when User turns Smapp off he may see some error messages appearing in the shaded GUI in the last moments. Now Smapp hides right after User confirms closing Smapp and turns down GRPC and Node in the background.
- Get rid of stale prop and ts-ignore
   The thingy that I've found in #999. I think we can easily get rid of it. Right, @maparr? :)