### PR TITLE
Show popup if not enough permissions to setup auto launch

### DIFF
--- a/app/infra/eventsService/eventsService.ts
+++ b/app/infra/eventsService/eventsService.ts
@@ -196,7 +196,8 @@ class EventsService {
   static isAutoStartEnabled = () =>
     ipcRenderer.invoke(ipcConsts.IS_AUTO_START_ENABLED_REQUEST);
 
-  static toggleAutoStart = () => ipcRenderer.send(ipcConsts.TOGGLE_AUTO_START);
+  static toggleAutoStart = (): Promise<{ status: boolean; error?: string }> =>
+    ipcRenderer.invoke(ipcConsts.TOGGLE_AUTO_START);
 
   /** **************************************   MISC   ***************************************** */
 

--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -716,10 +716,14 @@ class Settings extends Component<Props, State> {
     this.setState({ accountDisplayNames: updatedAccountDisplayNames });
   };
 
-  toggleAutoStart = () => {
-    const { isAutoStartEnabled } = this.state;
-    eventsService.toggleAutoStart();
-    this.setState({ isAutoStartEnabled: !isAutoStartEnabled });
+  toggleAutoStart = async () => {
+    const res = await eventsService.toggleAutoStart();
+    this.setState({ isAutoStartEnabled: res.status });
+    if (res.error) {
+      const { setUiError } = this.props;
+      // @ts-ignore
+      setUiError(new Error(res.error));
+    }
   };
 
   externalNavigation = (to: ExternalLinks) => window.open(to);


### PR DESCRIPTION
It fixes #1023

Besides the instructions for macOS (how to grant permissions if the User doesn't allow it the first time), it will show up a popup with an error message for other platforms.
