### PR TITLE
Fix bugs with switching between wallet modes

### DIFF
--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -41,8 +41,27 @@ const NetworkStatus = ({
     return 0;
   };
 
-  const renderSyncingStatus = () => {
+  const getSyncProgress = () => {
+    if (!status || status.topLayer === 0) {
+      return <ProgressLabel>Connecting...</ProgressLabel>;
+    }
+
     const progress = getSyncLabelPercentage();
+    return (
+      <>
+        <ProgressLabel>syncing</ProgressLabel>
+        <ProgressLabel>{progress}%</ProgressLabel>
+        <ProgressLabel>
+          {`${status.syncedLayer || 0} / ${status.topLayer || 0}`}
+        </ProgressLabel>
+        <Progress>
+          <ProgressBar progress={progress} />
+        </Progress>
+      </>
+    );
+  }
+
+  const renderSyncingStatus = () => {
     return (
       <>
         {status?.isSynced ? (
@@ -55,14 +74,7 @@ const NetworkStatus = ({
             <NetworkIndicator
               color={status?.isSynced ? smColors.green : smColors.orange}
             />
-            <ProgressLabel>syncing</ProgressLabel>
-            <ProgressLabel>{progress}%</ProgressLabel>
-            <ProgressLabel>
-              {`${status?.syncedLayer || 0} / ${status?.topLayer || 0}`}
-            </ProgressLabel>
-            <Progress>
-              <ProgressBar progress={progress} />
-            </Progress>
+            {getSyncProgress()}
           </>
         )}
       </>

--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -59,7 +59,7 @@ const NetworkStatus = ({
         </Progress>
       </>
     );
-  }
+  };
 
   const renderSyncingStatus = () => {
     return (

--- a/app/components/node/SmesherLog.tsx
+++ b/app/components/node/SmesherLog.tsx
@@ -5,7 +5,7 @@ import { formatSmidge } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { SmallHorizontalPanel } from '../../basicComponents';
 import { horizontalPanelBlack } from '../../assets/images';
-import { RewardsInfo, SmesherReward } from '../../../shared/types';
+import { RewardsInfo, Reward } from '../../../shared/types';
 import { CorneredContainer } from '../common';
 
 const Wrapper = styled.div`
@@ -157,7 +157,7 @@ const Total = styled.div<{ epoch?: boolean }>`
 type Props = {
   initTimestamp: string | null;
   smeshingTimestamp: string | null;
-  rewards: SmesherReward[];
+  rewards: Reward[];
   rewardsInfo: RewardsInfo;
   epochByLayer: (number) => number;
   timestampByLayer: (number) => number;
@@ -214,7 +214,7 @@ const SmesherLog = ({
                         <DateText>
                           <ReactTimeago date={timestampByLayer(reward.layer)} />
                         </DateText>
-                        <AwardText>+{formatSmidge(reward.total)}</AwardText>
+                        <AwardText>+{formatSmidge(reward.amount)}</AwardText>
                       </LayerReward>
                     </LogEntry>
                   </div>

--- a/app/components/transactions/RewardRow.tsx
+++ b/app/components/transactions/RewardRow.tsx
@@ -6,12 +6,13 @@ import { RewardView } from '../../redux/wallet/selectors';
 import { Bech32Address } from '../../../shared/types';
 import Address from '../common/Address';
 
-const Wrapper = styled.div<{ isDetailed: boolean }>`
+const Wrapper = styled.div<{ isDetailed: boolean; isHidden: boolean }>`
   display: flex;
   flex-direction: column;
   ${({ isDetailed }) =>
     isDetailed && `background-color: ${smColors.lighterGray};`}
   cursor: pointer;
+  ${({ isHidden }) => isHidden && 'display: none'}
 `;
 
 const Header = styled.div`
@@ -128,9 +129,10 @@ const TextRow = styled.div<{ isLast?: boolean }>`
 type Props = {
   address: Bech32Address;
   tx: RewardView;
+  isHidden?: boolean;
 };
 
-const RewardRow = ({ tx, address }: Props) => {
+const RewardRow = ({ tx, address, isHidden = false }: Props) => {
   const [isDetailed, setIsDetailed] = useState(false);
 
   const { layer, layerReward, amount, timestamp } = tx;
@@ -166,7 +168,7 @@ const RewardRow = ({ tx, address }: Props) => {
   );
 
   return (
-    <Wrapper isDetailed={isDetailed}>
+    <Wrapper isDetailed={isDetailed} isHidden={isHidden}>
       <Header onClick={toggleTxDetails}>
         <Icon />
         <HeaderInner>

--- a/app/components/transactions/TxRow.tsx
+++ b/app/components/transactions/TxRow.tsx
@@ -14,12 +14,13 @@ import {
 import getStatusColor from '../../vars/getStatusColor';
 import { TxView } from '../../redux/wallet/selectors';
 
-const Wrapper = styled.div<{ isDetailed: boolean }>`
+const Wrapper = styled.div<{ isDetailed: boolean; isHidden: boolean; }>`
   display: flex;
   flex-direction: column;
   ${({ isDetailed }) =>
     isDetailed && `background-color: ${smColors.lighterGray};`}
   cursor: pointer;
+  ${({ isHidden }) => isHidden && 'display: none;'}
 `;
 
 const Header = styled.div`
@@ -181,6 +182,7 @@ type Props = {
   tx: TxView;
   address: string;
   addAddressToContacts: ({ address }: { address: string }) => void;
+  isHidden?: boolean;
 };
 
 type RowProps = React.PropsWithChildren<{
@@ -249,7 +251,12 @@ const TxStatusBulb = styled(NetworkIndicator)`
   margin-left: auto;
 `;
 
-const TxRow = ({ tx, address, addAddressToContacts }: Props) => {
+const TxRow = ({
+  tx,
+  address,
+  addAddressToContacts,
+  isHidden = false,
+}: Props) => {
   const note = tx.note || '';
 
   const [isDetailed, setIsDetailed] = useState(false);
@@ -350,7 +357,7 @@ const TxRow = ({ tx, address, addAddressToContacts }: Props) => {
   };
 
   return (
-    <Wrapper isDetailed={isDetailed}>
+    <Wrapper isDetailed={isDetailed} isHidden={isHidden}>
       <Header onClick={toggleTxDetails}>
         <Icon chevronRight={isSent} />
         <HeaderInner>

--- a/app/components/transactions/TxRow.tsx
+++ b/app/components/transactions/TxRow.tsx
@@ -14,7 +14,7 @@ import {
 import getStatusColor from '../../vars/getStatusColor';
 import { TxView } from '../../redux/wallet/selectors';
 
-const Wrapper = styled.div<{ isDetailed: boolean; isHidden: boolean; }>`
+const Wrapper = styled.div<{ isDetailed: boolean; isHidden: boolean }>`
   display: flex;
   flex-direction: column;
   ${({ isDetailed }) =>

--- a/app/redux/auth/actions.ts
+++ b/app/redux/auth/actions.ts
@@ -1,7 +1,9 @@
+import { eventsService } from '../../infra/eventsService';
 import { CustomAction } from '../../types';
 
 export const LOGOUT = 'LOGOUT';
 
 export const logout = (): CustomAction => {
+  eventsService.closeWallet();
   return { type: LOGOUT };
 };

--- a/app/redux/wallet/actions.ts
+++ b/app/redux/wallet/actions.ts
@@ -18,6 +18,7 @@ import {
 import { eventsService } from '../../infra/eventsService';
 import { addErrorPrefix } from '../../infra/utils';
 import { AppThDispatch, GetState } from '../../types';
+import { logout } from '../auth/actions';
 import { getGenesisID } from '../network/selectors';
 import { setUiError } from '../ui/actions';
 
@@ -190,6 +191,7 @@ export const switchApiProvider = (
           : WalletType.RemoteApi,
     },
   });
+  dispatch(logout());
   return true;
 };
 

--- a/app/redux/wallet/reducer.ts
+++ b/app/redux/wallet/reducer.ts
@@ -92,7 +92,7 @@ const reducer = (state: WalletState = initialState, action: CustomAction) => {
     }
     case SET_ACCOUNT_REWARDS: {
       const { rewards, publicKey } = action.payload;
-      return { ...state, rewards: { [publicKey]: rewards } };
+      return { ...state, rewards: { ...state.rewards, [publicKey]: rewards } };
     }
     case SET_BACKUP_TIME: {
       const { backupTime } = action.payload;

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -115,7 +115,7 @@ const Network = ({ history }) => {
     return isWalletMode ? (
       <Button
         text="SWITCH API PROVIDER"
-        width={150}
+        width={200}
         isPrimary
         onClick={requestSwitchApiProvider}
         style={{ marginLeft: 'auto' }}

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -19,6 +19,7 @@ import SubHeader from '../../basicComponents/SubHeader';
 import { goToSwitchNetwork } from '../../routeUtils';
 import { AuthPath } from '../../routerPaths';
 import { delay } from '../../../shared/utils';
+import Address from '../../components/common/Address';
 
 const Container = styled.div`
   display: flex;
@@ -141,6 +142,18 @@ const Network = ({ history }) => {
         </DetailsTextWrap>
         <GrayText>
           <CustomTimeAgo time={genesisTime} />
+        </GrayText>
+      </DetailsRow>
+      <DetailsRow>
+        <DetailsTextWrap>
+          <DetailsText>Genesis ID</DetailsText>
+          <Tooltip
+            width={250}
+            text="Unique hash per network, generated from genesis time and unique identifier."
+          />
+        </DetailsTextWrap>
+        <GrayText>
+          <Address isHex address={genesisID} />
         </GrayText>
       </DetailsRow>
       <DetailsRow>

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -27,7 +27,7 @@ import {
   NodeStatus,
   PostSetupState,
   RewardsInfo,
-  SmesherReward,
+  Reward,
 } from '../../../shared/types';
 import { isWalletOnly } from '../../redux/wallet/selectors';
 import * as SmesherSelectors from '../../redux/smesher/selectors';
@@ -214,7 +214,7 @@ const POS_DATA_NOT_READY_TO_START_NODE_ERROR_CASE = `The Node is not syncing. Pl
 const getStatus = (
   state: PostSetupState,
   isPaused: boolean,
-  rewards: SmesherReward[],
+  rewards: Reward[],
   epoch: number,
   isNodeSynced: boolean
 ) => {

--- a/app/screens/transactions/Transactions.tsx
+++ b/app/screens/transactions/Transactions.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../basicComponents';
 import { RootState } from '../../types';
 import {
+  getRewards,
+  getTransactions,
   getTxAndRewards,
   RewardView,
   TxView,
@@ -57,8 +59,12 @@ const RightPaneWrapper = styled(CorneredWrapper)`
 const DropDownWrapper = styled.div`
   position: absolute;
   width: 150px;
-  right: 0;
+  right: 6px;
   top: 7px;
+`;
+
+const FilterDropDownWrapper = styled(DropDownWrapper)`
+  right: 30px;
 `;
 
 const getNumOfCoinsFromTransactions = (
@@ -97,9 +103,22 @@ const TIME_SPANS = [
   { label: 'yearly', days: 365 },
 ];
 
+enum TxFilter {
+  All = 0,
+  Transactions = 1,
+  Rewards = 2,
+}
+
+const TX_FILTERS = [
+  { label: 'all', filter: TxFilter.All },
+  { label: 'transactions', filter: TxFilter.Transactions },
+  { label: 'rewards', filter: TxFilter.Rewards },
+];
+
 const Transactions = ({ history }: RouteComponentProps) => {
   const [selectedTimeSpan, setSelectedTimeSpan] = useState(0);
   const [addressToAdd, setAddressToAdd] = useState('');
+  const [txFilter, setTxFilter] = useState(TxFilter.All);
 
   const address = useSelector(
     (state: RootState) =>
@@ -154,6 +173,7 @@ const Transactions = ({ history }: RouteComponentProps) => {
     totalSent,
     totalReceived,
   } = coinStats;
+
   return (
     <Wrapper>
       <BackButton action={history.goBack} width={7} height={10} />
@@ -162,6 +182,16 @@ const Transactions = ({ history }: RouteComponentProps) => {
         header="TRANSACTION LOG"
         style={{ marginRight: 10 }}
       >
+        <FilterDropDownWrapper>
+          <DropDown
+            data={TX_FILTERS}
+            onClick={({ index }) => setTxFilter(index)}
+            selectedItemIndex={txFilter}
+            rowHeight={40}
+            bold
+            dark
+          />
+        </FilterDropDownWrapper>
         <TransactionsListWrapper>
           {transactions && transactions.length ? (
             transactions.map((tx: TxView | RewardView) =>
@@ -170,6 +200,7 @@ const Transactions = ({ history }: RouteComponentProps) => {
                   key={`${address}_reward_${tx.layer}`}
                   address={address}
                   tx={tx}
+                  isHidden={txFilter === TxFilter.Transactions}
                 />
               ) : (
                 <TxRow
@@ -177,6 +208,7 @@ const Transactions = ({ history }: RouteComponentProps) => {
                   tx={tx}
                   address={address}
                   addAddressToContacts={({ address }) => address}
+                  isHidden={txFilter === TxFilter.Rewards}
                 />
               )
             )

--- a/app/screens/transactions/Transactions.tsx
+++ b/app/screens/transactions/Transactions.tsx
@@ -17,8 +17,6 @@ import {
 } from '../../basicComponents';
 import { RootState } from '../../types';
 import {
-  getRewards,
-  getTransactions,
   getTxAndRewards,
   RewardView,
   TxView,

--- a/app/types/redux.ts
+++ b/app/types/redux.ts
@@ -12,7 +12,7 @@ import {
   Reward,
   Network,
   NetworkState,
-  SmesherReward,
+  Reward,
   Activation,
   AccountBalance,
   KeyPair,
@@ -60,7 +60,7 @@ export interface SmesherState {
   commitmentSize: number;
   numLabelsWritten: any;
   postSetupState: PostSetupState;
-  rewards: SmesherReward[];
+  rewards: Reward[];
   rewardsInfo?: RewardsInfo;
   activations: Activation[];
   config: SmesherConfig;

--- a/desktop/AccountState.ts
+++ b/desktop/AccountState.ts
@@ -141,4 +141,20 @@ export class AccountStateManager {
     (this.state[this.genesisID] as StateType).rewards[reward.layer] = reward;
     return this.autosave();
   };
+
+  lastSyncedTxLayer = () =>
+    Math.max.apply(null, [
+      ...Object.values((this.state[this.genesisID] as StateType).txs)
+        .slice(-10)
+        .map((tx) => tx.layer || 0),
+      0,
+    ]);
+
+  lastSyncedRewardsLayer = () =>
+    Math.max.apply(null, [
+      ...Object.keys((this.state[this.genesisID] as StateType).rewards).map(
+        (k) => parseInt(k, 10) || 0
+      ),
+      0,
+    ]);
 }

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -100,6 +100,8 @@ class NetServiceFactory<
       `${serviceName} started`,
       `${this.apiUrl.host}:${this.apiUrl.port}`
     );
+
+    this.restartStreams();
   };
 
   restartNetService = async () => {

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -80,7 +80,7 @@ class NetServiceFactory<
     this.logger?.debug(`createNetService(${serviceName})`, apiUrl);
     if (this.service) {
       this.cancelStreams();
-      this.service.close();
+      this.dropNetService();
     }
 
     this.protoPath = protoPath;

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -70,7 +70,7 @@ class NetServiceFactory<
     serviceName: string
   ) => {
     this.logger?.debug(`createNetService(${serviceName})`, apiUrl);
-    if (this.apiUrl && isNodeApiEq(this.apiUrl, apiUrl)) {
+    if (this.service && this.apiUrl && isNodeApiEq(this.apiUrl, apiUrl)) {
       this.logger?.debug(
         `createNetService(${serviceName}) cancelled: no change in apiUrl. Keep old one`
       );
@@ -105,6 +105,11 @@ class NetServiceFactory<
       `${serviceName} started`,
       `${this.apiUrl.host}:${this.apiUrl.port}`
     );
+  };
+
+  dropNetService = () => {
+    this.service && this.service.close();
+    this.service = null;
   };
 
   restartNetService = async () => {

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -3,7 +3,7 @@ import * as grpc from '@grpc/grpc-js';
 import { loadSync } from '@grpc/proto-loader';
 import { PublicService, SocketAddress } from '../shared/types';
 import { LOCAL_NODE_API_URL } from '../shared/constants';
-import { delay } from '../shared/utils';
+import { delay, isNodeApiEq } from '../shared/utils';
 import Logger from './logger';
 
 // Types
@@ -70,7 +70,7 @@ class NetServiceFactory<
     serviceName: string
   ) => {
     this.logger?.debug(`createNetService(${serviceName})`, apiUrl);
-    if (this.apiUrl == apiUrl) {
+    if (this.apiUrl && isNodeApiEq(this.apiUrl, apiUrl)) {
       this.logger?.debug(
         `createNetService(${serviceName}) cancelled: no change in apiUrl. Keep old one`
       );
@@ -105,8 +105,6 @@ class NetServiceFactory<
       `${serviceName} started`,
       `${this.apiUrl.host}:${this.apiUrl.port}`
     );
-
-    this.restartStreams();
   };
 
   restartNetService = async () => {

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -244,6 +244,7 @@ class NodeManager {
   connectToRemoteNode = async (apiUrl?: SocketAddress | PublicService) => {
     this.nodeService.cancelStatusStream();
     this.nodeService.cancelErrorStream();
+    this.smesherManager.unsubscribe();
     await this.stopNode();
 
     this.nodeService.createService(apiUrl);
@@ -481,6 +482,7 @@ class NodeManager {
   stopNode = async () => {
     if (!this.nodeProcess) return;
     try {
+      this.smesherManager.unsubscribe();
       // Request Node shutdown
       this.nodeProcess.kill('SIGTERM');
       logger.log('stop node', 'kill SIGTERM');

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -471,12 +471,12 @@ class NodeManager {
       `Wait process to finish isFinished: ${isFinished}, timeout: ${timeout}, interval: ${interval}`
     );
     if (timeout <= 0) return isFinished;
-    if (isFinished) return true;
-    return isFinished
-      ? true
-      : delay(interval).then(() =>
-          this.waitProcessFinish(timeout - interval, interval)
-        );
+    return (
+      isFinished ||
+      delay(interval).then(() =>
+        this.waitProcessFinish(timeout - interval, interval)
+      )
+    );
   };
 
   stopNode = async () => {
@@ -521,9 +521,14 @@ class NodeManager {
 
   getVersionAndBuild = async () => {
     try {
-      const version = await this.nodeService.getNodeVersion();
-      const build = await this.nodeService.getNodeBuild();
-      return { version, build };
+      const alive = await this.isNodeAlive(30);
+      if (alive) {
+        const version = await this.nodeService.getNodeVersion();
+        const build = await this.nodeService.getNodeBuild();
+        return { version, build };
+      } else {
+        return { version: '', build: 'node-not-started' };
+      }
     } catch (err) {
       logger.error('getVersionAndBuild', err);
       return { version: '', build: '' };

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -52,7 +52,9 @@ class SmesherManager {
   };
 
   unsubscribe = () => {
+    this.smesherService.deactivateProgressStream();
     this.smesherService.cancelStreams();
+    this.smesherService.dropNetService();
     this.unsub();
   };
 
@@ -90,6 +92,8 @@ class SmesherManager {
   serviceStartupFlow = async () => {
     const cfg = await this.sendSmesherConfig();
     if (cfg?.start) {
+      // Ensure that we started service
+      this.smesherService.createService();
       const { postSetupState } = await this.smesherService.getPostSetupStatus();
       // Unsubscribe first
       this.smesherService.deactivateProgressStream();

--- a/desktop/SmesherService.ts
+++ b/desktop/SmesherService.ts
@@ -142,13 +142,13 @@ class SmesherService extends NetServiceFactory<
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ smesherId: '' }));
 
-  getCoinbase = () =>
+  getCoinbase = (): Promise<{ error: Error | null; coinbase: string }> =>
     this.callService('Coinbase', {})
-      .then((response) => ({
+      .then((response): { coinbase: string } => ({
         coinbase: response.accountId ? response.accountId.address : '',
       }))
       .then(this.normalizeServiceResponse)
-      .catch(this.normalizeServiceError({ coinbase: '0x00' }));
+      .catch(this.normalizeServiceError({ coinbase: '' }));
 
   setCoinbase = ({ coinbase }: { coinbase: string }) =>
     this.callService('SetCoinbase', {

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -19,7 +19,6 @@ import { ipcConsts } from '../app/vars';
 import { AccountDataFlag } from '../proto/spacemesh/v1/AccountDataFlag';
 import { Transaction__Output } from '../proto/spacemesh/v1/Transaction';
 import { TransactionState__Output } from '../proto/spacemesh/v1/TransactionState';
-import { AccountData__Output } from '../proto/spacemesh/v1/AccountData';
 import { MeshTransaction__Output } from '../proto/spacemesh/v1/MeshTransaction';
 import { Reward__Output } from '../proto/spacemesh/v1/Reward';
 import { Account__Output } from '../proto/spacemesh/v1/Account';
@@ -32,7 +31,7 @@ import {
 } from '../shared/utils';
 import { MAX_GAS } from '../shared/constants';
 import { getMethodName, getTemplateName } from '../shared/templateMeta';
-import { addReceiptToTx, toTx } from './transformers';
+import { toTx } from './transformers';
 import TransactionService from './TransactionService';
 import MeshService from './MeshService';
 import GlobalStateService, {

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -1,4 +1,3 @@
-import * as R from 'ramda';
 import { BrowserWindow } from 'electron';
 import { debounce } from 'throttle-debounce';
 import { SingleSigTemplate, TemplateRegistry } from '@spacemesh/sm-codec';
@@ -45,8 +44,6 @@ import Logger from './logger';
 import { GRPC_QUERY_BATCH_SIZE } from './main/constants';
 import { sign } from './ed25519';
 
-const DATA_BATCH = 50;
-
 type TxHandlerArg = MeshTransaction__Output | null | undefined;
 type TxHandler = (tx: TxHandlerArg) => void;
 
@@ -92,10 +89,12 @@ class TransactionManager {
     this.genesisID = genesisID;
   }
 
-  unsubscribeAllStreams = () =>
+  unsubscribeAllStreams = () => {
     Object.values(this.unsubs).forEach((list) =>
       list.forEach((unsub) => unsub())
     );
+    this.unsubs = {};
+  };
 
   //
   appStateUpdater = (channel: ipcConsts, payload: any) => {
@@ -120,7 +119,7 @@ class TransactionManager {
   };
 
   updateAppStateRewards = (publicKey: string) => {
-    const rewards = this.accountStates[publicKey].getRewards() || {};
+    const rewards = this.accountStates[publicKey].getRewards() || [];
     this.appStateUpdater(ipcConsts.T_M_UPDATE_REWARDS, { rewards, publicKey });
   };
 
@@ -165,34 +164,18 @@ class TransactionManager {
       this.handleNewTx(publicKey),
       txIds
     );
-
-    // Do not request for query endpoint ?
-    // this.txService
-    //   .getTxsState(txIds)
-    //   .then((resp) =>
-    //     // two lists -> list of tuples
-    //     resp.transactions.map((tx, idx) => ({
-    //       transaction: tx,
-    //       transactionState: resp.transactionsState[idx],
-    //     }))
-    //   )
-    //   .then((txs) => txs.map(this.handleNewTx(publicKey)))
-    //   .catch((err) => {
-    //     this.logger.error('grpc TransactionState', err);
-    //   });
   });
 
   private subscribeAccount = (address: Bech32Address): void => {
     // Cancel account Txs subscription
     this.txStateStream[address]?.();
-    // Cancel account data, txs, rewards subscriptions to streams
-    this.unsubs[address] && this.unsubs[address].forEach((unsub) => unsub());
-    this.unsubs[address] = [];
 
+    const lastTxLayer = this.accountStates[address]?.lastSyncedTxLayer();
+    const lastRwLayer = this.accountStates[address]?.lastSyncedRewardsLayer();
     const addTransaction = this.upsertTransactionFromMesh(address);
     this.retrieveHistoricTxData({
       accountId: address,
-      offset: 0,
+      offset: lastTxLayer,
       handler: addTransaction,
       retries: 0,
     });
@@ -201,16 +184,14 @@ class TransactionManager {
     );
 
     const updateAccountData = this.updateAccountData(address);
-    const queryAccountData = () =>
-      this.retrieveAccountData({
-        filter: {
-          accountId: { address },
-          accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_ACCOUNT,
-        },
-        handler: updateAccountData,
-        retries: 0,
-      });
-    queryAccountData();
+    this.retrieveAccountData({
+      filter: {
+        accountId: { address },
+        accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_ACCOUNT,
+      },
+      handler: updateAccountData,
+      retries: 0,
+    });
 
     this.unsubs[address].push(
       this.glStateService.activateAccountDataStream(
@@ -244,7 +225,7 @@ class TransactionManager {
     // this.glStateService.activateAccountDataStream(binaryAccountId, AccountDataFlag.ACCOUNT_DATA_FLAG_TRANSACTION_RECEIPT, addReceiptToTx);
 
     const addReward = this.addReward(address);
-    this.retrieveRewards(address)
+    this.retrieveRewards(address, lastRwLayer)
       .then((value) => value.forEach(addReward))
       .catch((err) => {
         this.logger.error('Can not retrieve and store rewards', err);
@@ -253,9 +234,6 @@ class TransactionManager {
     this.unsubs[address].push(
       this.glStateService.listenRewardsByCoinbase(address, addReward)
     );
-
-    this.updateAppStateTxs(address);
-    this.updateAppStateRewards(address);
   };
 
   addAccount = (keypair: KeyPair) => {
@@ -278,6 +256,11 @@ class TransactionManager {
       address,
       this.genesisID
     );
+    // Send stored Tx & Rewards
+    this.updateAppStateTxs(address);
+    this.updateAppStateRewards(address);
+
+    this.unsubs[address] = [];
     // Resubscribe
     this.subscribeAccount(address);
   };
@@ -285,13 +268,15 @@ class TransactionManager {
   setAccounts = (accounts: KeyPair[]) => {
     this.unsubscribeAllStreams();
     this.keychain = [];
-    this.accountStates = {};
     accounts.forEach(this.addAccount);
   };
 
   private upsertTransaction = (accountAddress: Bech32Address) => async <T>(
     tx: Tx<T>
   ) => {
+    if (!this.accountStates[accountAddress]) {
+      return;
+    }
     const originalTx = this.accountStates[accountAddress].getTxById(tx.id);
     const receipt = tx.receipt
       ? { ...originalTx?.receipt, ...tx.receipt }
@@ -346,10 +331,10 @@ class TransactionManager {
       });
     } else {
       data && data.length && data.forEach((tx) => handler(tx.meshTransaction));
-      if (offset + DATA_BATCH < totalResults) {
+      if (offset + GRPC_QUERY_BATCH_SIZE < totalResults) {
         await this.retrieveHistoricTxData({
           accountId,
-          offset: offset + DATA_BATCH,
+          offset: offset + GRPC_QUERY_BATCH_SIZE,
           handler,
           retries: 0,
         });
@@ -366,10 +351,11 @@ class TransactionManager {
       counter: longToNumber(data.stateProjected?.counter || 0),
       balance: longToNumber(data.stateProjected?.balance?.value || 0),
     };
-    this.accountStates[address].storeState({
-      currentState,
-      projectedState,
-    });
+    this.accountStates[address] &&
+      this.accountStates[address].storeState({
+        currentState,
+        projectedState,
+      });
 
     this.updateAppStateAccount(address);
   };
@@ -427,13 +413,16 @@ class TransactionManager {
     this.storeReward(accountId, parsedReward);
   };
 
-  retrieveRewards = async (coinbase: string): Promise<Reward__Output[]> => {
+  retrieveRewards = async (
+    coinbase: string,
+    offset = 0
+  ): Promise<Reward__Output[]> => {
     const composeArg = (batchNumber: number) => ({
       filter: {
         accountId: { address: coinbase },
         accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD as AccountDataValidFlags,
       },
-      offset: batchNumber * GRPC_QUERY_BATCH_SIZE,
+      offset: offset + batchNumber * GRPC_QUERY_BATCH_SIZE,
     });
     const getAccountDataQuery = async (batch: number, retries = 5) => {
       const res = await this.glStateService.sendAccountDataQuery(
@@ -457,18 +446,32 @@ class TransactionManager {
           !!item && hasRequiredRewardFields(item)
       ) as Reward__Output[];
     } else {
-      const nextRewards = await Promise.all(
-        R.compose(
-          R.map((idx) =>
-            this.glStateService
-              .sendAccountDataQuery(composeArg(idx))
-              .then((resp) => resp.data)
-          ),
-          R.range(1)
-        )(Math.ceil(totalResults / GRPC_QUERY_BATCH_SIZE))
-      ).then(R.unnest);
+      const nextRewards = await this.retrieveRewards(
+        coinbase,
+        offset + GRPC_QUERY_BATCH_SIZE
+      );
       return data ? [...data, ...nextRewards] : nextRewards;
     }
+  };
+
+  retrieveNewRewards = async (coinbase: string) => {
+    const oldRewards = this.accountStates[coinbase]?.getRewards() || [];
+    const newRewards = (
+      await this.retrieveRewards(
+        coinbase,
+        this.accountStates[coinbase]?.lastSyncedRewardsLayer() || 0
+      )
+    ).reduce((acc, reward) => {
+      if (!reward || !hasRequiredRewardFields(reward)) return acc;
+      const parsedReward: Reward = {
+        layer: reward.layer.number,
+        amount: longToNumber(reward.total.value),
+        layerReward: longToNumber(reward.layerReward.value),
+        coinbase: reward.coinbase.address,
+      };
+      return [...acc, parsedReward];
+    }, <Reward[]>[]);
+    return [...oldRewards, ...newRewards];
   };
 
   // TODO: Replace with generic `publishTx`

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -283,6 +283,9 @@ class TransactionManager {
   };
 
   setAccounts = (accounts: KeyPair[]) => {
+    this.unsubscribeAllStreams();
+    this.keychain = [];
+    this.accountStates = {};
     accounts.forEach(this.addAccount);
   };
 

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -42,7 +42,7 @@ import GlobalStateService, {
 } from './GlobalStateService';
 import { AccountStateManager } from './AccountState';
 import Logger from './logger';
-import { GRPC_QUERY_BATCH_SIZE as BATCH_SIZE } from './main/constants';
+import { GRPC_QUERY_BATCH_SIZE } from './main/constants';
 import { sign } from './ed25519';
 
 const DATA_BATCH = 50;
@@ -433,7 +433,7 @@ class TransactionManager {
         accountId: { address: coinbase },
         accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD as AccountDataValidFlags,
       },
-      offset: batchNumber * BATCH_SIZE,
+      offset: batchNumber * GRPC_QUERY_BATCH_SIZE,
     });
     const getAccountDataQuery = async (batch: number, retries = 5) => {
       const res = await this.glStateService.sendAccountDataQuery(
@@ -451,7 +451,7 @@ class TransactionManager {
       return res;
     };
     const { totalResults, data } = await getAccountDataQuery(0);
-    if (totalResults <= BATCH_SIZE) {
+    if (totalResults <= GRPC_QUERY_BATCH_SIZE) {
       return data.filter(
         (item): item is Reward__Output =>
           !!item && hasRequiredRewardFields(item)
@@ -465,7 +465,7 @@ class TransactionManager {
               .then((resp) => resp.data)
           ),
           R.range(1)
-        )(Math.ceil(totalResults / BATCH_SIZE))
+        )(Math.ceil(totalResults / GRPC_QUERY_BATCH_SIZE))
       ).then(R.unnest);
       return data ? [...data, ...nextRewards] : nextRewards;
     }

--- a/desktop/WalletManager.ts
+++ b/desktop/WalletManager.ts
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 import { BrowserWindow, ipcMain } from 'electron';
 import { ipcConsts } from '../app/vars';
-import { Activation, KeyPair, Wallet } from '../shared/types';
+import { Activation, KeyPair, Reward, Wallet } from '../shared/types';
 import {
   delay,
   isLocalNodeType,
@@ -179,9 +179,8 @@ class WalletManager {
     }
   };
 
-  requestRewardsByCoinbase = async (
-    coinbase: string
-  ): Promise<Reward__Output[]> => this.txManager.retrieveRewards(coinbase);
+  requestRewardsByCoinbase = async (coinbase: string): Promise<Reward[]> =>
+    this.txManager.retrieveNewRewards(coinbase);
 
   listenRewardsByCoinbase = (
     coinbase: string,

--- a/desktop/main/constants.ts
+++ b/desktop/main/constants.ts
@@ -15,4 +15,4 @@ export const NODE_CONFIG_FILE = path.resolve(USERDATA_DIR, 'node-config.json');
 
 export const DEFAULT_WALLETS_DIRECTORY = USERDATA_DIR;
 
-export const GRPC_QUERY_BATCH_SIZE = 50;
+export const GRPC_QUERY_BATCH_SIZE = 100;

--- a/desktop/main/reactions/spawnManagers.ts
+++ b/desktop/main/reactions/spawnManagers.ts
@@ -3,6 +3,7 @@ import {
   delay,
   distinctUntilChanged,
   ReplaySubject,
+  share,
   skip,
   Subject,
   withLatestFrom,
@@ -41,7 +42,8 @@ const spawnManagers$ = (
   const $uniqNodeCondig = $nodeConfig.pipe(
     distinctUntilChanged(
       (prev, next) => JSON.stringify(prev) === JSON.stringify(next)
-    )
+    ),
+    share()
   );
   const subs = [
     // If node config changed, then unsubscribe managers

--- a/desktop/main/reactions/syncToRenderer.ts
+++ b/desktop/main/reactions/syncToRenderer.ts
@@ -22,7 +22,7 @@ import {
   NodeConfig,
   NodeVersionAndBuild,
   RewardsInfo,
-  SmesherReward,
+  Reward,
   Wallet,
 } from '../../../shared/types';
 import { ConfigStore } from '../../storeService';
@@ -112,7 +112,7 @@ const sync = (
 const getRewardsInfo = (
   cfg: NodeConfig,
   curLayer: number,
-  rewards: SmesherReward[]
+  rewards: Reward[]
 ): RewardsInfo => {
   const getLayerTime = timestampByLayer(
     cfg.genesis['genesis-time'],
@@ -123,7 +123,7 @@ const getRewardsInfo = (
 
   const sums = rewards.reduce(
     (acc, next) => ({
-      total: acc.total + next.total,
+      total: acc.total + next.amount,
       layers: new Set(acc.layers).add(next.layer),
       epochs: new Set(acc.epochs).add(getEpoch(next.layer)),
     }),
@@ -135,8 +135,8 @@ const getRewardsInfo = (
   );
 
   const lastEpoch = R.compose(
-    R.reduce((acc, next: SmesherReward) => acc + next.total, 0),
-    R.filter((reward: SmesherReward) => getEpoch(reward.layer) === curEpoch)
+    R.reduce((acc, next: Reward) => acc + next.amount, 0),
+    R.filter((reward: Reward) => getEpoch(reward.layer) === curEpoch)
   )(rewards);
 
   const dailyAverage =
@@ -169,7 +169,7 @@ export default (
   $nodeVersion: Observable<NodeVersionAndBuild>,
   $smesherId: Observable<string>,
   $activations: Observable<Activation[]>,
-  $rewards: Observable<SmesherReward[]>
+  $rewards: Observable<Reward[]>
 ) =>
   sync(
     // Sync to

--- a/desktop/main/sources/smesherInfo.ts
+++ b/desktop/main/sources/smesherInfo.ts
@@ -20,6 +20,7 @@ import {
 import { Reward__Output } from '../../../proto/spacemesh/v1/Reward';
 import {
   Activation,
+  Reward,
   SmesherReward,
   Wallet,
   WalletType,
@@ -36,10 +37,10 @@ const logger = Logger({ className: 'smesherInfo' });
 const getRewards$ = (
   managers: Managers,
   coinbase: string
-): Observable<Reward__Output[]> =>
+): Observable<Reward[]> =>
   from(managers.wallet.requestRewardsByCoinbase(coinbase));
 
-const toSmesherReward = (input: Reward__Output): SmesherReward => {
+const toSmesherReward = (input: Reward__Output | Reward): SmesherReward => {
   if (!hasRequiredRewardFields(input)) {
     throw new Error(
       `Can not convert input ${JSON.stringify(input)} to SmesherReward`

--- a/desktop/storeService.ts
+++ b/desktop/storeService.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import Store from 'electron-store';
-import { Function, Object, String } from 'ts-toolbelt';
+import { Object } from 'ts-toolbelt';
+import { AutoPath } from 'ts-toolbelt/out/Function/AutoPath';
+import { Split } from 'ts-toolbelt/out/String/Split';
 import { AccountBalance } from '../shared/types';
 import { Transaction } from '../proto/spacemesh/v1/Transaction';
 import { _spacemesh_v1_TransactionState_TransactionState } from '../proto/spacemesh/v1/TransactionState';
@@ -50,20 +52,20 @@ class StoreService {
   }
 
   static set = <O extends ConfigStore, P extends string>(
-    key: Function.AutoPath<O, P>,
-    property: Object.Path<O, String.Split<P, '.'>>
+    key: AutoPath<O, P>,
+    property: Object.Path<O, Split<P, '.'>>
   ) => {
     StoreService.store.set(key, property);
   };
 
   static get = <O extends ConfigStore, P extends string>(
-    key: Function.AutoPath<O, P>
-  ): Object.Path<O, String.Split<P, '.'>> => {
+    key: AutoPath<O, P>
+  ): Object.Path<O, Split<P, '.'>> => {
     return StoreService.store.get(key);
   };
 
   static remove = <O extends ConfigStore, P extends string>(
-    key: Function.AutoPath<O, P>
+    key: AutoPath<O, P>
   ) => {
     StoreService.store.delete(key as keyof ConfigStore); // kludge to workaround StoreService types
   };
@@ -77,9 +79,9 @@ class StoreService {
   static onChange = <
     O extends ConfigStore,
     P extends string,
-    V extends Object.Path<O, String.Split<P, '.'>>
+    V extends Object.Path<O, Split<P, '.'>>
   >(
-    key: Function.AutoPath<O, P>,
+    key: AutoPath<O, P>,
     cb: (newValue?: V, prevValue?: V) => void
   ) => {
     // @ts-ignore

--- a/shared/types/guards.ts
+++ b/shared/types/guards.ts
@@ -42,9 +42,6 @@ export const isTx = (a: any): a is Tx =>
 
 export const isReward = (a: any): a is Reward =>
   a &&
-  a.layer &&
-  a.coinbase &&
-  a.amount &&
   typeof a.coinbase === 'string' &&
   typeof a.layer === 'number' &&
   typeof a.amount === 'number';

--- a/shared/types/guards.ts
+++ b/shared/types/guards.ts
@@ -41,7 +41,13 @@ export const isTx = (a: any): a is Tx =>
   a && a.id && a.principal && a.template && a.method && a.payload;
 
 export const isReward = (a: any): a is Reward =>
-  a && a.layer && a.coinbase && a.amount;
+  a &&
+  a.layer &&
+  a.coinbase &&
+  a.amount &&
+  typeof a.coinbase === 'string' &&
+  typeof a.layer === 'number' &&
+  typeof a.amount === 'number';
 
 export const isActivation = (a: any): a is Activation =>
   a && a.id && a.layer && a.smesherId && a.coinbase && a.numUnits;

--- a/shared/types/tx.ts
+++ b/shared/types/tx.ts
@@ -73,13 +73,6 @@ export interface Reward {
   layerComputed?: number; // TODO ?
 }
 
-export interface SmesherReward {
-  coinbase: string;
-  total: number;
-  layer: number;
-  layerReward: number;
-}
-
 export interface Activation {
   id: Uint8Array;
   smesherId: Uint8Array;

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -122,6 +122,9 @@ export const stringifySocketAddress = (sa: SocketAddress): string =>
 export const isLocalNodeApi = (sa: SocketAddress) =>
   shallowEq(sa, LOCAL_NODE_API_URL);
 
+export const isNodeApiEq = (a: SocketAddress, b: SocketAddress) =>
+  shallowEq(a, b);
+
 export const isRemoteNodeApi = (sa: SocketAddress) => !isLocalNodeApi(sa);
 
 export const isWalletOnlyType = (walletType: WalletType) =>


### PR DESCRIPTION
It fixes #1052
Details:
- opening wallets of different types works smoothly now
- optimized querying of txs and rewards
- fixed managing the smesher service (turn off / on, etc)
- fixed <UnlockWallet> component
- enlarged grpc query batch size to 100 results
- some tiny fixes
- feat: added filter dropdown on Transaction Log screen. Now User is able to choose what to see: all / txs / rewards.

It also may fix some of these issues (pls, check it out):
- #1066 
- #1049