### PR TITLE
bugfix: update Smeshing screen on sing in / sign out

### DIFF
--- a/desktop/main/reactions/handleAppWalletChange.ts
+++ b/desktop/main/reactions/handleAppWalletChange.ts
@@ -1,0 +1,29 @@
+import * as $ from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { makeSubscription } from '../rx.utils';
+import { isLocalNodeType } from '../../../shared/utils';
+import { Wallet } from '../../../shared/types';
+import { Managers } from '../app.types';
+
+export default (
+  $isWalletActivated: Subject<void>,
+  $wallet: Observable<Wallet | null>,
+  $managers: Subject<Managers>
+) =>
+  makeSubscription(
+    $isWalletActivated.pipe($.withLatestFrom($managers, $wallet)),
+    ([_, managers, wallet]) => {
+      const type = wallet?.meta?.type;
+
+      if (!type || !isLocalNodeType(type)) {
+        return;
+      }
+
+      (async () => {
+        await managers.node.startNode();
+        await managers.node.updateNodeStatus();
+        await managers.smesher.serviceStartupFlow();
+        await managers.smesher.updateSmesherState();
+      })();
+    }
+  );

--- a/desktop/main/reactions/handleNodeAutoStart.ts
+++ b/desktop/main/reactions/handleNodeAutoStart.ts
@@ -1,0 +1,25 @@
+import * as $ from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { makeSubscription } from '../rx.utils';
+import { isLocalNodeType } from '../../../shared/utils';
+import { Wallet } from '../../../shared/types';
+import { Managers } from '../app.types';
+
+export default (
+  $runNodeBeforeLogin: Subject<boolean>,
+  $wallet: Observable<Wallet | null>,
+  $managers: Subject<Managers>
+) =>
+  makeSubscription(
+    $.combineLatest($runNodeBeforeLogin, $managers, $wallet),
+    ([runNode, managers, wallet]) => {
+      if (!runNode) {
+        return;
+      }
+
+      const type = wallet?.meta?.type;
+      if (!type || isLocalNodeType(type)) {
+        managers.node.startNode();
+      }
+    }
+  );


### PR DESCRIPTION
### Issue
The Smeshing tab is not up to date on change wallet or sign out / sign in process

### Solution: 
subscribe on the smeshing information from RPC on sing in / sign out

### Steps to reproduce
1. create the wallet
2. sync node and set up a folder on the Smeshing screen 
3. log out
4. smeshing screen is not updating