### PR TITLE
Fix smesher screen issues + small fixes

### DIFF
--- a/app/StyledApp.tsx
+++ b/app/StyledApp.tsx
@@ -5,7 +5,7 @@ import { Router, Route, Switch, Redirect } from 'react-router-dom';
 import { ipcRenderer } from 'electron';
 import { createBrowserHistory } from 'history';
 import routes from './routes';
-import GlobalStyle from './globalStyle';
+import GlobalStyle, { fontsCss } from './globalStyle';
 import { RootState } from './types';
 import { setOsTheme } from './redux/ui/actions';
 import ErrorBoundary from './ErrorBoundary';
@@ -51,6 +51,7 @@ const StyledApp = () => {
 
   return (
     <ThemeProvider theme={theme}>
+      <style>{fontsCss}</style>
       <GlobalStyle />
       <ErrorBoundary>
         {isClosingApp && <CloseAppModal />}

--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -46,14 +46,29 @@ const NetworkStatus = ({
       return <ProgressLabel>Connecting...</ProgressLabel>;
     }
 
+    const syncedLayer = status.syncedLayer || 0;
+    const topLayer = status.topLayer || 0;
+
+    if (topLayer < syncedLayer) {
+      const progress = Math.floor((topLayer / syncedLayer) * 100);
+      return (
+        <>
+          <ProgressLabel>Genesis</ProgressLabel>
+          <ProgressLabel>{progress}%</ProgressLabel>
+          <ProgressLabel>{`${topLayer} / ${syncedLayer}`}</ProgressLabel>
+          <Progress>
+            <ProgressBar progress={progress} />
+          </Progress>
+        </>
+      );
+    }
+
     const progress = getSyncLabelPercentage();
     return (
       <>
         <ProgressLabel>syncing</ProgressLabel>
         <ProgressLabel>{progress}%</ProgressLabel>
-        <ProgressLabel>
-          {`${status.syncedLayer || 0} / ${status.topLayer || 0}`}
-        </ProgressLabel>
+        <ProgressLabel>{`${syncedLayer} / ${topLayer}`}</ProgressLabel>
         <Progress>
           <ProgressBar progress={progress} />
         </Progress>

--- a/app/globalStyle.ts
+++ b/app/globalStyle.ts
@@ -3,20 +3,22 @@ import SourceCodeProRegular from './assets/fonts/SourceCodePro-Regular.ttf';
 import SourceCodeProBold from './assets/fonts/SourceCodePro-Bold.ttf';
 import { smColors } from './vars';
 
-const GlobalStyle = createGlobalStyle`
+export const fontsCss = `
     @font-face {
       font-family: SourceCodePro;
       src: url(${SourceCodeProRegular});
       font-style: normal;
       font-weight: 400;
     }
-    
+
     @font-face {
       font-family: SourceCodePro;
       src: url(${SourceCodeProBold});
       font-weight: 800;
     }
+`;
 
+const GlobalStyle = createGlobalStyle`
     html, body {
         width: 100%;
         height: 100%;

--- a/app/redux/smesher/reducer.ts
+++ b/app/redux/smesher/reducer.ts
@@ -31,7 +31,13 @@ const initialState = {
   postSetupState: PostSetupState.STATE_NOT_STARTED,
   postProgressError: '',
   rewards: [],
-  rewairdsInfo: {},
+  rewardsInfo: {
+    total: 0,
+    dailyAverage: 0,
+    epochs: 0,
+    lastEpoch: 0,
+    layers: 0,
+  },
   activations: [],
   config: {} as SmesherConfig,
 };

--- a/app/redux/smesher/reducer.ts
+++ b/app/redux/smesher/reducer.ts
@@ -20,6 +20,7 @@ import {
 
 const initialState = {
   smesherId: '',
+  isSmeshingStarted: false,
   postSetupComputeProviders: [] as PostSetupComputeProvider[],
   coinbase: '',
   dataDir: '',
@@ -49,6 +50,7 @@ const reducer = (state: SmesherState = initialState, action: CustomAction) => {
         payload: {
           config,
           smesherId,
+          isSmeshingStarted,
           postSetupState,
           numLabelsWritten,
           numUnits,
@@ -67,6 +69,7 @@ const reducer = (state: SmesherState = initialState, action: CustomAction) => {
         numLabelsWritten,
         postSetupState,
         commitmentSize,
+        isSmeshingStarted,
       };
     }
     case SET_SETUP_COMPUTE_PROVIDERS: {

--- a/app/redux/smesher/selectors.ts
+++ b/app/redux/smesher/selectors.ts
@@ -25,14 +25,19 @@ export const isValidSmeshingOpts = (
 };
 
 export const isSmeshingPaused = (state: RootState) => {
-  const isNotStarted = getPostSetupState(state) === PostSetupState.STATE_PAUSED;
+  const isPausedState =
+    getPostSetupState(state) === PostSetupState.STATE_PAUSED;
   const opts = getSmeshingOpts(state);
-  return isNotStarted && isValidSmeshingOpts(opts);
+  return (
+    (isPausedState || !state.smesher.isSmeshingStarted) &&
+    isValidSmeshingOpts(opts)
+  );
 };
 
 export const isSmeshing = (state: RootState) =>
-  getPostSetupState(state) === PostSetupState.STATE_COMPLETE ||
-  // Until Node will sync enough GRPC API returns NOT STARTED state
-  // even if we already started smeshing (so PoS will be created soon)
-  (getPostSetupState(state) === PostSetupState.STATE_NOT_STARTED &&
-    isValidSmeshingOpts(getSmeshingOpts(state)));
+  state.smesher.isSmeshingStarted &&
+  (getPostSetupState(state) === PostSetupState.STATE_COMPLETE ||
+    // Until Node will sync enough GRPC API returns NOT STARTED state
+    // even if we already started smeshing (so PoS will be created soon)
+    (getPostSetupState(state) === PostSetupState.STATE_NOT_STARTED &&
+      isValidSmeshingOpts(getSmeshingOpts(state))));

--- a/app/redux/smesher/selectors.ts
+++ b/app/redux/smesher/selectors.ts
@@ -4,8 +4,6 @@ import { RootState } from '../../types';
 export const getPostSetupState = (state: RootState) =>
   state.smesher.postSetupState;
 
-export const isSmeshing = (state: RootState) =>
-  getPostSetupState(state) === PostSetupState.STATE_COMPLETE;
 export const isCreatingPostData = (state: RootState) =>
   getPostSetupState(state) === PostSetupState.STATE_IN_PROGRESS;
 
@@ -31,3 +29,10 @@ export const isSmeshingPaused = (state: RootState) => {
   const opts = getSmeshingOpts(state);
   return isNotStarted && isValidSmeshingOpts(opts);
 };
+
+export const isSmeshing = (state: RootState) =>
+  getPostSetupState(state) === PostSetupState.STATE_COMPLETE ||
+  // Until Node will sync enough GRPC API returns NOT STARTED state
+  // even if we already started smeshing (so PoS will be created soon)
+  (getPostSetupState(state) === PostSetupState.STATE_NOT_STARTED &&
+    isValidSmeshingOpts(getSmeshingOpts(state)));

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -3,12 +3,7 @@ import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { SmesherIntro, SmesherLog } from '../../components/node';
-import {
-  WrapperWith2SideBars,
-  Button,
-  Link,
-  Tooltip,
-} from '../../basicComponents';
+import { WrapperWith2SideBars, Button, Link } from '../../basicComponents';
 import { hideSmesherLeftPanel, setUiError } from '../../redux/ui/actions';
 import { formatBytes, getFormattedTimestamp } from '../../infra/utils';
 import {
@@ -208,9 +203,10 @@ const BottomActionSection = styled.div`
   display: flex;
 `;
 
-const POS_DATA_NOT_READY_TO_START =
-  'Please wait for the node to finish syncing before setting up your proof of space. You can check these details on the Network screen.';
-const POS_DATA_NOT_READY_TO_START_NODE_ERROR_CASE = `The Node is not syncing. Please check the Network tab. ${POS_DATA_NOT_READY_TO_START}`;
+const ERR_MESSAGE_ERR_STATE =
+  'PoS initialization failed. Try to delete it and re-initialize.';
+const ERR_MESSAGE_NODE_ERROR =
+  'The Node is not syncing. Please check the Network tab';
 const getStatus = (
   state: PostSetupState,
   isPaused: boolean,
@@ -223,16 +219,18 @@ const getStatus = (
       return 'Creating PoS data';
     case PostSetupState.STATE_COMPLETE:
       // eslint-disable-next-line no-nested-ternary
-      return rewards.length > 0 && epoch
+      return rewards.length > 0 && epoch && isNodeSynced
         ? `Smeshing: epoch ${epoch}`
         : isNodeSynced
         ? 'Waiting for next epoch'
         : 'Syncing the Node';
     case PostSetupState.STATE_ERROR:
       return 'Error';
-    default:
     case PostSetupState.STATE_PAUSED:
       return isPaused ? 'Paused creation PoS Data' : 'Not started';
+    default:
+    case PostSetupState.STATE_NOT_STARTED:
+      return 'Waiting Node to sync';
   }
 };
 
@@ -299,9 +297,6 @@ const Node = ({ history, location }: Props) => {
   const isCreatingPostData = useSelector(SmesherSelectors.isCreatingPostData);
   const isPausedSmeshing = useSelector(SmesherSelectors.isSmeshingPaused);
   const isErrorState = useSelector(SmesherSelectors.isErrorState);
-  const nodeStatus = useSelector(
-    (state: RootState) => state.node.status?.isSynced || false
-  );
   const nodeStatusError = useSelector(
     (state: RootState) => state.node.error?.msg || null
   );
@@ -422,8 +417,12 @@ const Node = ({ history, location }: Props) => {
       <>
         {isErrorState && (
           <ErrorMessage oneLine={false} align="right">
-            PoS DATA CREATION IS PAUSED. CHECK NETWORK SCREEN, SEEMS NODE IS
-            DOWN.
+            {ERR_MESSAGE_ERR_STATE}
+          </ErrorMessage>
+        )}
+        {nodeStatusError && (
+          <ErrorMessage oneLine={false} align="right">
+            {ERR_MESSAGE_NODE_ERROR}
           </ErrorMessage>
         )}
         {renderTable(getTableData())}
@@ -438,7 +437,6 @@ const Node = ({ history, location }: Props) => {
               isPrimary={false}
               style={{ marginRight: 15 }}
               imgPosition="before"
-              isDisabled={!nodeStatus}
               width={180}
             />
             {postSetupState === PostSetupState.STATE_IN_PROGRESS && (
@@ -448,7 +446,6 @@ const Node = ({ history, location }: Props) => {
                 img={pauseIcon}
                 isPrimary={false}
                 width={280}
-                isDisabled={!nodeStatus}
                 imgPosition="before"
               />
             )}
@@ -459,20 +456,7 @@ const Node = ({ history, location }: Props) => {
                 img={playIcon}
                 isPrimary
                 width={280}
-                isDisabled={!nodeStatus}
                 imgPosition="before"
-              />
-            )}
-            {!nodeStatus && (
-              <Tooltip
-                width={200}
-                marginLeft={-10}
-                hide={false}
-                text={
-                  nodeStatusError
-                    ? POS_DATA_NOT_READY_TO_START_NODE_ERROR_CASE
-                    : POS_DATA_NOT_READY_TO_START
-                }
               />
             )}
           </FooterSection>
@@ -490,7 +474,6 @@ const Node = ({ history, location }: Props) => {
     if (showIntro) {
       return <SmesherIntro hideIntro={() => setShowIntro(false)} />;
     }
-
     if (!isSmesherActive && !isErrorState) {
       return (
         <>
@@ -510,19 +493,7 @@ const Node = ({ history, location }: Props) => {
               onClick={buttonHandler}
               text="SETUP PROOF OF SPACE"
               width={250}
-              isDisabled={!nodeStatus}
             />
-            {!nodeStatus && (
-              <Tooltip
-                width={200}
-                hide={false}
-                text={
-                  nodeStatusError
-                    ? POS_DATA_NOT_READY_TO_START_NODE_ERROR_CASE
-                    : POS_DATA_NOT_READY_TO_START
-                }
-              />
-            )}
           </BottomActionSection>
         </>
       );

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -468,7 +468,7 @@ const Node = ({ history, location }: Props) => {
             {isPausedSmeshing && (
               <Button
                 onClick={handleResumeSmeshing}
-                text="RESUME POST DATA GENERATION"
+                text="RESUME SMESHING"
                 img={playIcon}
                 isPrimary
                 width={280}

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -132,6 +132,16 @@ const PosSmesherIcon = styled.img`
   margin-right: 5px;
 `;
 
+const PosDirLink = styled.span`
+  display: flex;
+  cursor: pointer;
+
+  &:hover span,
+  &:focus span {
+    text-decoration: none;
+  }
+`;
+
 const PosFolderIcon = styled.img.attrs(
   ({
     theme: {
@@ -144,11 +154,13 @@ const PosFolderIcon = styled.img.attrs(
   width: 20px;
   height: 20px;
   margin-right: 5px;
+  cursor: pointer;
 `;
 
 const PathDir = styled.span`
   color: ${smColors.blue};
   text-decoration: underline;
+  cursor: pointer;
 `;
 
 interface Props extends RouteComponentProps {
@@ -390,10 +402,14 @@ const Node = ({ history, location }: Props) => {
       ...progressRow,
       [
         'Data Directory',
-        <React.Fragment key="pos-data-dir">
+        <PosDirLink
+          onClick={() =>
+            eventsService.showFileInFolder({ filePath: posDataPath })
+          }
+        >
           <PosFolderIcon />
           <PathDir>{posDataPath}</PathDir>
-        </React.Fragment>,
+        </PosDirLink>,
       ],
       ['Data Size', formatBytes(commitmentSize)],
       [

--- a/app/screens/wallet/Overview.tsx
+++ b/app/screens/wallet/Overview.tsx
@@ -44,6 +44,9 @@ const Overview = ({ history }: RouteComponentProps) => {
   const accountIndex = useSelector(
     (state: RootState) => state.wallet.currentAccountIndex || 0
   );
+  const currentLayer = useSelector(
+    (state: RootState) => state.node.status?.topLayer || 0
+  );
 
   const account = useSelector(
     (state: RootState) => state.wallet.accounts[accountIndex]
@@ -85,14 +88,18 @@ const Overview = ({ history }: RouteComponentProps) => {
 
   const navigateToWalletGuide = () => window.open(ExternalLinks.WalletGuide);
 
-  const isAccountPendingSpawnTx = !!txs.find(
+  const pendingSpawnTx = txs.find(
     (tx) =>
       tx.meta?.templateName === 'SingleSig' &&
       tx.method === 0 &&
       (tx.status === TxState.MEMPOOL ||
         tx.status === TxState.MESH ||
-        tx.status === TxState.PROCESSED)
+        tx.status === TxState.PROCESSED) &&
+      tx.layer &&
+      currentLayer > 0 &&
+      currentLayer - 5 < tx.layer
   );
+  const isAccountPendingSpawnTx = !!pendingSpawnTx;
   const isAccountSpawned = !!txs.find(
     (tx) =>
       tx.meta?.templateName === 'SingleSig' &&

--- a/app/types/redux.ts
+++ b/app/types/redux.ts
@@ -51,6 +51,7 @@ export interface WalletState {
 
 export interface SmesherState {
   smesherId: string;
+  isSmeshingStarted: boolean;
   postSetupComputeProviders: PostSetupComputeProvider[];
   coinbase: string;
   dataDir: string;

--- a/desktop/AbstractManager.ts
+++ b/desktop/AbstractManager.ts
@@ -1,0 +1,50 @@
+import { BrowserWindow } from 'electron';
+
+const UNSUB_NOOP_FN = () => {};
+
+abstract class AbstractManager {
+  protected mainWindow: BrowserWindow;
+
+  protected abstract subscribeIPCEvents?(): () => void;
+
+  private _unsubscribeIPC = UNSUB_NOOP_FN;
+
+  constructor(mainWindow: BrowserWindow) {
+    this.mainWindow = mainWindow;
+    this.setBrowserWindow(mainWindow, true);
+  }
+
+  public isIPCSubscribed() {
+    return this._unsubscribeIPC !== UNSUB_NOOP_FN;
+  }
+
+  public unsubscribeIPC() {
+    if (this.isIPCSubscribed()) {
+      this._unsubscribeIPC();
+      this._unsubscribeIPC = UNSUB_NOOP_FN;
+    }
+  }
+
+  public subscribeIPC() {
+    if (this.isIPCSubscribed()) {
+      this._unsubscribeIPC();
+    }
+    this._unsubscribeIPC =
+      typeof this.subscribeIPCEvents === 'function'
+        ? this.subscribeIPCEvents()
+        : UNSUB_NOOP_FN;
+  }
+
+  // Updates MainWindow reference and resubscribes to IPC Events
+  public setBrowserWindow(mainWindow: BrowserWindow, force = false) {
+    if (this.mainWindow === mainWindow && !force) return;
+    this.unsubscribeIPC();
+    this.mainWindow = mainWindow;
+    this._unsubscribeIPC =
+      typeof this.subscribeIPCEvents === 'function'
+        ? this.subscribeIPCEvents()
+        : UNSUB_NOOP_FN;
+  }
+}
+
+export default AbstractManager;

--- a/desktop/GlobalStateService.ts
+++ b/desktop/GlobalStateService.ts
@@ -6,7 +6,7 @@ import { AccountDataStreamResponse__Output } from '../proto/spacemesh/v1/Account
 import { Reward__Output } from '../proto/spacemesh/v1/Reward';
 import { TransactionReceipt__Output } from '../proto/spacemesh/v1/TransactionReceipt';
 import { PublicService, SocketAddress } from '../shared/types';
-import { toHexString } from '../shared/utils';
+import { delay, toHexString } from '../shared/utils';
 import { GlobalStateHash } from '../app/types/events';
 import Logger from './logger';
 import NetServiceFactory from './NetServiceFactory';
@@ -143,13 +143,14 @@ class GlobalStateService extends NetServiceFactory<
         },
         offset: counter,
       })
-        .then((res) => {
+        .then(async (res) => {
           res.data.forEach((reward) => {
             counter += 1;
             handler(reward);
           });
           if (res.totalResults > counter) {
-            doQuery();
+            await delay(100);
+            return doQuery();
           }
           return res;
         })

--- a/desktop/GlobalStateService.ts
+++ b/desktop/GlobalStateService.ts
@@ -10,7 +10,7 @@ import { toHexString } from '../shared/utils';
 import { GlobalStateHash } from '../app/types/events';
 import Logger from './logger';
 import NetServiceFactory from './NetServiceFactory';
-import { GRPC_QUERY_BATCH_SIZE } from './main/constants';
+import { GRPC_QUERY_BATCH_SIZE, MINUTE } from './main/constants';
 
 const PROTO_PATH = 'proto/global_state.proto';
 
@@ -125,12 +125,41 @@ class GlobalStateService extends NetServiceFactory<
   listenRewardsByCoinbase = (
     coinbase: string,
     handler: (data: Reward__Output) => void
-  ) =>
-    this.activateAccountDataStream(
-      coinbase,
-      AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD,
-      handler
-    );
+  ) => {
+    // TODO: https://github.com/spacemeshos/go-spacemesh/issues/3935
+    // this.activateAccountDataStream(
+    //   coinbase,
+    //   AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD,
+    //   handler
+    // );
+    // Temporary workaround:
+    let counter = 0;
+
+    const doQuery = () => {
+      return this.sendAccountDataQuery({
+        filter: {
+          accountId: { address: coinbase },
+          accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD,
+        },
+        offset: counter,
+      })
+        .then((res) => {
+          res.data.forEach((reward) => {
+            counter += 1;
+            handler(reward);
+          });
+          if (res.totalResults > counter) {
+            doQuery();
+          }
+          return res;
+        })
+        .catch(() => {});
+    };
+
+    doQuery();
+    const ival = setInterval(doQuery, 1 * MINUTE);
+    return () => clearInterval(ival);
+  };
 }
 
 export default GlobalStateService;

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -56,12 +56,12 @@ class NetServiceFactory<
 
   private startStreamList: Record<
     keyof Service<T, ServiceName>,
-    () => void
+    () => Promise<void>
   > = {} as typeof this.startStreamList;
 
   private cancelStreamList: Record<
     keyof Service<T, ServiceName>,
-    () => void
+    () => Promise<void>
   > = {} as typeof this.cancelStreamList;
 
   createNetService = (
@@ -242,16 +242,14 @@ class NetServiceFactory<
             null
           );
           await startStream(retries - 1, afterRestart);
+        } else if (afterRestart) {
+          this.logger?.error(
+            `grpc ${this.serviceName}.${String(
+              method
+            )} can not restart after restarting NetService`,
+            error
+          );
         } else {
-          if (afterRestart) {
-            this.logger?.error(
-              `grpc ${this.serviceName}.${String(
-                method
-              )} can not restart after restarting NetService`,
-              error
-            );
-            return;
-          }
           this.logger?.debug(
             `grpc ${this.serviceName}.${String(
               method

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -244,7 +244,6 @@ class NodeManager {
   connectToRemoteNode = async (apiUrl?: SocketAddress | PublicService) => {
     this.nodeService.cancelStatusStream();
     this.nodeService.cancelErrorStream();
-    this.smesherManager.unsubscribe();
     await this.stopNode();
 
     this.nodeService.createService(apiUrl);

--- a/desktop/NodeService.ts
+++ b/desktop/NodeService.ts
@@ -121,7 +121,7 @@ class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
     retries = 5
   ) => {
     if (!this.service) return;
-    if (this.statusStream) return;
+    this.cancelStatusStream();
 
     this.statusStream = this.service.StatusStream({});
     this.statusStream.on('data', (response: any) => {
@@ -177,7 +177,7 @@ class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
 
   activateErrorStream = (handler: ErrorStreamHandler, retries = 5) => {
     if (!this.service) return;
-    if (this.errorStream) return;
+    this.cancelErrorStream();
 
     this.errorStream = this.service.ErrorStream({});
     this.errorStream.on('data', (response: any) => {

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -122,9 +122,12 @@ class SmesherManager extends AbstractManager {
         nodeConfig.smeshing['smeshing-opts'] &&
         nodeConfig.smeshing['smeshing-opts']['smeshing-opts-numunits']) ||
       0;
+    const isSmeshingStarted = nodeConfig.smeshing?.['smeshing-start'] || false;
+
     const data: IPCSmesherStartupData = {
       config,
       smesherId: smesherId || '',
+      isSmeshingStarted,
       postSetupState,
       numLabelsWritten,
       numUnits,

--- a/desktop/SmesherService.ts
+++ b/desktop/SmesherService.ts
@@ -57,14 +57,6 @@ class SmesherService extends NetServiceFactory<
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({ config: {} }));
 
-  getSmesherId = () =>
-    this.callService('SmesherID', {})
-      .then(({ accountId }) => ({
-        smesherId: accountId || '',
-      }))
-      .then(this.normalizeServiceResponse)
-      .catch(this.normalizeServiceError({ smesherId: '' }));
-
   getSetupComputeProviders = () =>
     this.callService('PostSetupComputeProviders', { benchmark: true })
       .then((response) => ({

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -169,12 +169,10 @@ class TransactionManager {
     // Cancel account Txs subscription
     this.txStateStream[address]?.();
 
-    const lastTxLayer = this.accountStates[address]?.lastSyncedTxLayer();
-    const lastRwLayer = this.accountStates[address]?.lastSyncedRewardsLayer();
     const addTransaction = this.upsertTransactionFromMesh(address);
     this.retrieveHistoricTxData({
       accountId: address,
-      offset: lastTxLayer,
+      offset: 0,
       handler: addTransaction,
       retries: 0,
     });
@@ -219,7 +217,7 @@ class TransactionManager {
     }
 
     const addReward = this.addReward(address);
-    this.retrieveRewards(address, lastRwLayer)
+    this.retrieveRewards(address, 0)
       .then((value) => value.forEach(addReward))
       .catch((err) => {
         this.logger.error('Can not retrieve and store rewards', err);

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -434,8 +434,11 @@ class TransactionManager extends AbstractManager {
     }
   };
 
+  getOldRewards = (coinbase: HexString) =>
+    this.accountStates[coinbase]?.getRewards() || [];
+
   retrieveNewRewards = async (coinbase: string) => {
-    const oldRewards = this.accountStates[coinbase]?.getRewards() || [];
+    const oldRewards = this.getOldRewards(coinbase);
     const newRewards = (await this.retrieveRewards(coinbase, 0)).reduce(
       (acc, reward) => {
         if (!reward || !hasRequiredRewardFields(reward)) return acc;

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -128,7 +128,7 @@ class TransactionManager extends AbstractManager {
   private storeTx = (publicKey: string, tx: Tx): Promise<void> =>
     this.accountStates[publicKey]
       .storeTransaction(tx)
-      .then(() => this.updateAppStateTxs(publicKey))
+      .then((isNew) => isNew && this.updateAppStateTxs(publicKey))
       .catch((err) => {
         console.log('TransactionManager.storeTx', err); // eslint-disable-line no-console
         this.logger.error('TransactionManager.storeTx', err);
@@ -137,7 +137,7 @@ class TransactionManager extends AbstractManager {
   private storeReward = (publicKey: string, reward: Reward) =>
     this.accountStates[publicKey]
       .storeReward(reward)
-      .then(() => this.updateAppStateRewards(publicKey))
+      .then((isNew) => isNew && this.updateAppStateRewards(publicKey))
       .catch((err) => {
         console.log('TransactionManager.storeReward', err); // eslint-disable-line no-console
         this.logger.error('TransactionManager.storeReward', err);

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -42,13 +42,14 @@ import { AccountStateManager } from './AccountState';
 import Logger from './logger';
 import { GRPC_QUERY_BATCH_SIZE } from './main/constants';
 import { sign } from './ed25519';
+import AbstractManager from './AbstractManager';
 
 type TxHandlerArg = MeshTransaction__Output | null | undefined;
 type TxHandler = (tx: TxHandlerArg) => void;
 
 type RewardHandlerArg = Reward__Output | null | undefined;
 
-class TransactionManager {
+class TransactionManager extends AbstractManager {
   logger = Logger({ className: 'TransactionManager' });
 
   private readonly meshService: MeshService;
@@ -60,8 +61,6 @@ class TransactionManager {
   keychain: KeyPair[] = [];
 
   accounts: AccountWithBalance[] = [];
-
-  private readonly mainWindow: BrowserWindow;
 
   private txStateStream: Record<
     string,
@@ -81,11 +80,15 @@ class TransactionManager {
     mainWindow: BrowserWindow,
     genesisID: string
   ) {
+    super(mainWindow);
     this.meshService = meshService;
     this.glStateService = glStateService;
     this.txService = txService;
-    this.mainWindow = mainWindow;
     this.genesisID = genesisID;
+  }
+
+  setGenesisID(id: HexString) {
+    this.genesisID = id;
   }
 
   unsubscribeAllStreams = () => {

--- a/desktop/main/reactions/syncToRenderer.ts
+++ b/desktop/main/reactions/syncToRenderer.ts
@@ -172,9 +172,9 @@ export default (
     // Views
     walletView($wallet, $walletPath),
     storeView($storeService),
-    networkView($currentNetwork, $nodeConfig, $currentLayer, $rootHash),
+    networkView($currentNetwork, $nodeConfig),
     $networks.pipe(map(R.objOf('networks'))),
-    $nodeVersion.pipe(map(R.objOf('node'))), // here
+    $nodeVersion.pipe(map(R.objOf('node'))),
     $smesherId.pipe(map((smesherId) => ({ smesher: { smesherId } }))),
     $rewards.pipe(map((rewards) => ({ smesher: { rewards } }))),
     $activations.pipe(map((activations) => ({ smesher: { activations } }))),
@@ -189,5 +189,6 @@ export default (
         },
       }))
     ),
-    $currentLayer.pipe(map((currentLayer) => ({ node: { currentLayer } })))
+    $rootHash.pipe(map((rootHash) => ({ network: { rootHash } }))),
+    $currentLayer.pipe(map((currentLayer) => ({ network: { currentLayer } })))
   );

--- a/desktop/main/reactions/views/networkView.ts
+++ b/desktop/main/reactions/views/networkView.ts
@@ -5,13 +5,11 @@ import { generateGenesisIDFromConfig } from '../../Networks';
 
 export default (
   $currentNetwork: Observable<Network | null>,
-  $nodeConfig: Observable<NodeConfig>,
-  $currentLayer: Observable<number>,
-  $rootHash: Observable<string>
+  $nodeConfig: Observable<NodeConfig>
 ) =>
-  combineLatest([$currentNetwork, $nodeConfig, $currentLayer, $rootHash]).pipe(
+  combineLatest([$currentNetwork, $nodeConfig]).pipe(
     map(
-      ([curNet, nodeConfig, currentLayer, rootHash]) =>
+      ([curNet, nodeConfig]) =>
         <NetworkState>{
           genesisID: generateGenesisIDFromConfig(nodeConfig) || '',
           netName: curNet?.netName || 'Not connected',
@@ -19,8 +17,6 @@ export default (
           layerDurationSec: nodeConfig.main['layer-duration-sec'],
           layersPerEpoch: nodeConfig.main['layers-per-epoch'],
           explorerUrl: curNet?.explorer || '',
-          currentLayer,
-          rootHash,
         }
     ),
     map(objOf('network'))

--- a/desktop/main/sources/smesherInfo.ts
+++ b/desktop/main/sources/smesherInfo.ts
@@ -138,8 +138,7 @@ const syncSmesherInfo = (
             subscriber.next(x)
           )
         )
-    ),
-    share()
+    )
   );
 
   const $rewards = concat(
@@ -147,7 +146,7 @@ const syncSmesherInfo = (
     $rewardsStream.pipe(
       scan((acc, next) => {
         if (hasRequiredRewardFields(next)) {
-          acc.push(toReward(next));
+          return [...acc, toReward(next)];
         }
         return acc;
       }, <Reward[]>[])

--- a/desktop/main/sources/smesherInfo.ts
+++ b/desktop/main/sources/smesherInfo.ts
@@ -27,7 +27,7 @@ import {
   WalletType,
 } from '../../../shared/types';
 import { hasRequiredRewardFields } from '../../../shared/types/guards';
-import { longToNumber } from '../../../shared/utils';
+import { longToNumber, shallowEq } from '../../../shared/utils';
 import Logger from '../../logger';
 import { SmeshingSetupState } from '../../NodeManager';
 import { Managers } from '../app.types';
@@ -160,7 +160,7 @@ const syncSmesherInfo = (
     ),
     scan((acc, next) => {
       const key = `${next.layer}$${next.amount}`;
-      return acc.set(key, next);
+      return shallowEq(acc.get(key) || {}, next) ? acc : acc.set(key, next);
     }, new Map<string, Reward>()),
     map((uniqRewards) => Array.from(uniqRewards.values())),
     shareReplay(1)

--- a/desktop/main/utils.ts
+++ b/desktop/main/utils.ts
@@ -22,7 +22,10 @@ export const showNotification = (
 };
 
 export const getNodeLogsPath = (genesisID?: string) =>
-  path.resolve(USERDATA_DIR, `spacemesh-log-${genesisID || ''}.txt`);
+  path.resolve(
+    USERDATA_DIR,
+    `spacemesh-log-${(genesisID || 'unknown').substring(0, 8)}.txt`
+  );
 
 //
 

--- a/desktop/transformers.ts
+++ b/desktop/transformers.ts
@@ -10,14 +10,17 @@ import { isObject, longToNumber, toHexString } from '../shared/utils';
 const prettifyPayload = (payload: Record<string, any>) =>
   Object.fromEntries(
     Object.entries(payload).map(([key, val]) => {
-      if (val instanceof Uint8Array || val instanceof Buffer) {
+      if (
+        val instanceof Uint8Array ||
+        val instanceof Buffer ||
+        val instanceof Array
+      ) {
         switch (key) {
           case 'Destination':
-            return [key, Bech32.generateAddress(val)];
+            return [key, Bech32.generateAddress(Uint8Array.from(val))];
           case 'PublicKey':
-            return [key, `0x${toHexString(val)}`];
           default:
-            return [key, `0x${toHexString(val)}`];
+            return [key, `0x${toHexString(Uint8Array.from(val))}`];
         }
       }
       if (isObject(val)) return [key, prettifyPayload(val)];

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "detect-port": "1.3.0",
     "dotenv": "8.2.0",
     "electron": "^20.1.3",
-    "electron-builder": "22.14.13",
+    "electron-builder": "23.0.6",
     "electron-devtools-installer": "git+https://github.com/MarshallOfSound/electron-devtools-installer.git#31bf8632c32dd6a714b00289708c012a06741fd7",
     "electron-fetch": "1.7.3",
     "electron-notarize": "1.1.1",

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,4 +1,4 @@
-import { SocketAddress, TxState } from './types';
+import { NodeStatus, SocketAddress, TxState } from './types';
 
 export const LOCAL_NODE_API_URL: SocketAddress = {
   host: 'localhost',
@@ -17,6 +17,14 @@ export const TX_STATE_LABELS: Record<TxState, string> = {
   [TxState.SUCCESS]: 'Applied',
   [TxState.FAILURE]: 'Failed to apply',
   [TxState.INVALID]: 'Invalid transaction',
+};
+
+export const DEFAULT_NODE_STATUS: NodeStatus = {
+  connectedPeers: 0,
+  isSynced: false,
+  syncedLayer: 0,
+  topLayer: 0,
+  verifiedLayer: 0,
 };
 
 export enum ExternalLinks {

--- a/shared/memoDebounce.ts
+++ b/shared/memoDebounce.ts
@@ -1,0 +1,38 @@
+/**
+ * Function that wraps some handler over the incoming data.
+ * It calls the handler only for the brand-new data (immediately)
+ * or after the `ms` delay, if no newer data was received
+ * @param ms delay for calling handler with the same data
+ * @param handler function to be called
+ * @returns function, that can be used as a handler for events (on data/error/etc)
+ */
+const memoDebounce = <T>(ms: number, handler: (response: T) => void) => {
+  let lastResponse: T | null = null;
+  let lastUpdTime = 0;
+  let timeout: NodeJS.Timeout;
+  return (response: T) => {
+    const now = Date.now();
+    clearTimeout(timeout);
+    const upd = () => {
+      lastResponse = response;
+      lastUpdTime = now;
+      handler(response);
+    };
+    if (
+      JSON.stringify(lastResponse) !== JSON.stringify(response) ||
+      lastUpdTime + ms <= now
+    ) {
+      // If we got a brand-new response
+      // or the same but "ms" time already passed
+      // then calling handler
+      upd();
+    } else {
+      // Otherwise, we're waiting until "ms" time will pass
+      // and only then call handler, if newer data won't come
+      // to cancel the timeout
+      timeout = setTimeout(() => upd(), ms);
+    }
+  };
+};
+
+export default memoDebounce;

--- a/shared/types/smesher.ts
+++ b/shared/types/smesher.ts
@@ -54,6 +54,7 @@ export interface IPCSmesherStartupData {
   config: SmesherConfig | Record<string, never>;
   smesherId: string;
   postSetupState: PostSetupState;
+  isSmeshingStarted: boolean;
   numLabelsWritten: number;
   numUnits: number;
 }

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -179,3 +179,18 @@ export const deriveHRP = (addr: string) => addr.match(/^(\w+)1/)?.[1] || null;
 
 export const longToNumber = (val: Long | number) =>
   typeof val === 'number' ? val : val.toNumber();
+
+//
+export const debounceWithArgs = <T extends (...args: any[]) => any>(
+  ms: number,
+  callback: T
+) => {
+  const t = {};
+  return (...args) => {
+    const k = JSON.stringify(args);
+    if (!t[k]) {
+      t[k] = debounce(ms, callback);
+    }
+    return t[k](...args);
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,16 +1570,18 @@
     global-agent "^3.0.0"
     global-tunnel-ng "^2.7.1"
 
-"@electron/universal@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.0.5.tgz#b812340e4ef21da2b3ee77b2b4d35c9b86defe37"
-  integrity sha512-zX9O6+jr2NMyAdSkwEUlyltiI4/EBLu2Ls/VD3pUQdi3cAYeYfdQnT2AJJ38HE4QxLccbU13LSpccw1IWlkyag==
+"@electron/universal@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.2.1.tgz#3c2c4ff37063a4e9ab1e6ff57db0bc619bc82339"
+  integrity sha512-7323HyMh7KBAl/nPDppdLsC87G6RwRU02dy5FPeGB1eS7rUePh55+WNWiDPLhFQqqVPHzh77M69uhmoT8XnwMQ==
   dependencies:
     "@malept/cross-spawn-promise" "^1.1.0"
-    asar "^3.0.3"
+    asar "^3.1.0"
     debug "^4.3.1"
     dir-compare "^2.4.0"
     fs-extra "^9.0.1"
+    minimatch "^3.0.4"
+    plist "^3.0.4"
 
 "@emotion/is-prop-valid@^1.1.0":
   version "1.2.0"
@@ -4886,29 +4888,29 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-app-builder-bin@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-3.7.1.tgz#cb0825c5e12efc85b196ac3ed9c89f076c61040e"
-  integrity sha512-ql93vEUq6WsstGXD+SBLSIQw6SNnhbDEM0swzgugytMxLp3rT24Ag/jcC80ZHxiPRTdew1niuR7P3/FCrDqIjw==
+app-builder-bin@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-4.0.0.tgz#1df8e654bd1395e4a319d82545c98667d7eed2f0"
+  integrity sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==
 
-app-builder-lib@22.14.13:
-  version "22.14.13"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-22.14.13.tgz#c1f5b6afc86596357598bb90b69eef06c7c2eeb3"
-  integrity sha512-SufmrtxU+D0Tn948fjEwAOlCN9757UXLkzzTWXMwZKR/5hisvgqeeBepWfphMIE6OkDGz0fbzEhL1P2Pty4XMg==
+app-builder-lib@23.0.6:
+  version "23.0.6"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-23.0.6.tgz#98b7166a32bf927d70ee462e359f83f894f3dc45"
+  integrity sha512-CmDyNldqqt7hMNV3EaHCPeml4iCqBZPXBOEq0M1j9KkBHPMXnQzoYECq2IQ3xv4PxADEqMeVAt/W2iAXBy4v5Q==
   dependencies:
     "7zip-bin" "~5.1.1"
     "@develar/schema-utils" "~2.6.5"
-    "@electron/universal" "1.0.5"
+    "@electron/universal" "1.2.1"
     "@malept/flatpak-bundler" "^0.4.0"
     async-exit-hook "^2.0.1"
     bluebird-lst "^1.0.9"
-    builder-util "22.14.13"
-    builder-util-runtime "8.9.2"
+    builder-util "23.0.6"
+    builder-util-runtime "9.0.1"
     chromium-pickle-js "^0.2.0"
     debug "^4.3.2"
     ejs "^3.1.6"
-    electron-osx-sign "^0.5.0"
-    electron-publish "22.14.13"
+    electron-osx-sign "^0.6.0"
+    electron-publish "23.0.6"
     form-data "^4.0.0"
     fs-extra "^10.0.0"
     hosted-git-info "^4.0.2"
@@ -5113,7 +5115,7 @@ asap@~2.0.3:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
-asar@^3.0.3:
+asar@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/asar/-/asar-3.2.0.tgz#e6edb5edd6f627ebef04db62f771c61bea9c1221"
   integrity sha512-COdw2ZQvKdFGFxXwX3oYh2/sOsJWJegrdJCGxnN4MZ7IULgRBp9P6665aqj9z1v9VwP4oP1hRBojRDQ//IGgAg==
@@ -5963,25 +5965,25 @@ builder-util-runtime@8.7.5:
     debug "^4.3.2"
     sax "^1.2.4"
 
-builder-util-runtime@8.9.2:
-  version "8.9.2"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.9.2.tgz#a9669ae5b5dcabfe411ded26678e7ae997246c28"
-  integrity sha512-rhuKm5vh7E0aAmT6i8aoSfEjxzdYEFX7zDApK+eNgOhjofnWb74d9SRJv0H/8nsgOkos0TZ4zxW0P8J4N7xQ2A==
+builder-util-runtime@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-9.0.1.tgz#07891ec925f991215cac5457b2d80c41c35dd210"
+  integrity sha512-f9pjsGKjGaLWqYwIn11Lxc2YL0g8UnnxWECOS9GubCRNYWnqMz1ZjwwCedOUKk2UlD2J7zyVKJcCMt9v/pP/uQ==
   dependencies:
     debug "^4.3.2"
     sax "^1.2.4"
 
-builder-util@22.14.13:
-  version "22.14.13"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-22.14.13.tgz#41b5b7b4ee53aff4e09cc007fb144522598f3ce6"
-  integrity sha512-oePC/qrrUuerhmH5iaCJzPRAKlSBylrhzuAJmRQClTyWnZUv6jbaHh+VoHMbEiE661wrj2S2aV7/bQh12cj1OA==
+builder-util@23.0.6:
+  version "23.0.6"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-23.0.6.tgz#d131eae99194a272a2d9a354bae61d1f3c350398"
+  integrity sha512-xV6JmZmHvpeUtsJNKDoKTefFLo9LRPnm4ii3ckRQe39BNu0nDyfpRLhici7KqnRxBdMSpIVIfayJX9syN+7zDw==
   dependencies:
     "7zip-bin" "~5.1.1"
     "@types/debug" "^4.1.6"
     "@types/fs-extra" "^9.0.11"
-    app-builder-bin "3.7.1"
+    app-builder-bin "4.0.0"
     bluebird-lst "^1.0.9"
-    builder-util-runtime "8.9.2"
+    builder-util-runtime "9.0.1"
     chalk "^4.1.1"
     cross-spawn "^7.0.3"
     debug "^4.3.2"
@@ -7359,14 +7361,14 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dmg-builder@22.14.13:
-  version "22.14.13"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.14.13.tgz#cc613f3c18e889b8777d525991fd52f50a564f8c"
-  integrity sha512-xNOugB6AbIRETeU2uID15sUfjdZZcKdxK8xkFnwIggsM00PJ12JxpLNPTjcRoUnfwj3WrPjilrO64vRMwNItQg==
+dmg-builder@23.0.6:
+  version "23.0.6"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-23.0.6.tgz#0985904686b68e9a25e71474923c99e52ffe5f62"
+  integrity sha512-+2Wp3wDLAuj7qEBwqD9AssF68Uz3U0cwfvsz1qODKW1GBBEu/6X2LQUs4oDIdoIVpkai660+zyPok6f3DMfcSw==
   dependencies:
-    app-builder-lib "22.14.13"
-    builder-util "22.14.13"
-    builder-util-runtime "8.9.2"
+    app-builder-lib "23.0.6"
+    builder-util "23.0.6"
+    builder-util-runtime "9.0.1"
     fs-extra "^10.0.0"
     iconv-lite "^0.6.2"
     js-yaml "^4.1.0"
@@ -7589,17 +7591,17 @@ ejs@^3.1.6:
   dependencies:
     jake "^10.8.5"
 
-electron-builder@22.14.13:
-  version "22.14.13"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.14.13.tgz#fd40564685cf5422a8f8d667940af3d3776f4fb8"
-  integrity sha512-3fgLxqF2TXVKiUPeg74O4V3l0l3j7ERLazo8sUbRkApw0+4iVAf2BJkHsHMaXiigsgCoEzK/F4/rB5rne/VAnw==
+electron-builder@23.0.6:
+  version "23.0.6"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-23.0.6.tgz#07968bc402c1b5055ae2056b28967665141bf2a9"
+  integrity sha512-VA50mfjjsoEQ5DHwgT61CGua6F337phNYPumMXkcedfjpAS82H23H2hnu75E77m6zf0wRNGVj9o7Z3rYpwyXlg==
   dependencies:
     "@types/yargs" "^17.0.1"
-    app-builder-lib "22.14.13"
-    builder-util "22.14.13"
-    builder-util-runtime "8.9.2"
+    app-builder-lib "23.0.6"
+    builder-util "23.0.6"
+    builder-util-runtime "9.0.1"
     chalk "^4.1.1"
-    dmg-builder "22.14.13"
+    dmg-builder "23.0.6"
     fs-extra "^10.0.0"
     is-ci "^3.0.0"
     lazy-val "^1.0.5"
@@ -7664,10 +7666,10 @@ electron-notarize@1.1.1:
     debug "^4.1.1"
     fs-extra "^9.0.1"
 
-electron-osx-sign@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz#fc258c5e896859904bbe3d01da06902c04b51c3a"
-  integrity sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==
+electron-osx-sign@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz#9b69c191d471d9458ef5b1e4fdd52baa059f1bb8"
+  integrity sha512-+hiIEb2Xxk6eDKJ2FFlpofCnemCbjbT5jz+BKGpVBrRNT3kWTGs4DfNX6IzGwgi33hUcXF+kFs9JW+r6Wc1LRg==
   dependencies:
     bluebird "^3.5.0"
     compare-version "^0.1.2"
@@ -7676,14 +7678,14 @@ electron-osx-sign@^0.5.0:
     minimist "^1.2.0"
     plist "^3.0.1"
 
-electron-publish@22.14.13:
-  version "22.14.13"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-22.14.13.tgz#8b71e6975af8cc6ac5b21f293ade23f8704047c7"
-  integrity sha512-0oP3QiNj3e8ewOaEpEJV/o6Zrmy2VarVvZ/bH7kyO/S/aJf9x8vQsKVWpsdmSiZ5DJEHgarFIXrnO0ZQf0P9iQ==
+electron-publish@23.0.6:
+  version "23.0.6"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-23.0.6.tgz#6b7614d429759643cf7baa8b1caceb66b2fd968d"
+  integrity sha512-ikjgf93uHKyjfTIxVBs3jrDY3x2C06c7Vbq7QDMIQnvMWUqZd1mNTqWUBAr1IQfwX5xvapsWxAJ5TF/Ops5KLg==
   dependencies:
     "@types/fs-extra" "^9.0.11"
-    builder-util "22.14.13"
-    builder-util-runtime "8.9.2"
+    builder-util "23.0.6"
+    builder-util-runtime "9.0.1"
     chalk "^4.1.1"
     fs-extra "^10.0.0"
     lazy-val "^1.0.5"


### PR DESCRIPTION
It closes #1066 
And, I believe, the rest of the issues with Smesher screen :D
Also, I've returned the possibility to set up PoS without waiting to sync the node, and all works well.

Besides this, I:
- allowed to send one more (next to pending) spawn tx after some delay (3 layers). Just in case some transaction gets stuck, the User will be able to send another tx.
- fixed displaying of PublicKey in the transaction log
- fixed displaying of Rewards (now the sums are correct, @lrettig)
- fixed #1072 (switching the network)
- fixed retrieving of rewards for smesher (and made a temporary kludge due to https://github.com/spacemeshos/go-spacemesh/issues/3935)
- [commit](https://github.com/spacemeshos/smapp/pull/1076/commits/2257f6698cd9d3f25bf568958f85e79a0eb94731) should fix #1074 — the reason of it was that on closed streams `activateNodeStatusStream` and `activateNodeErrorStream` they runs this method again, but since it keeps the reference to the closed stream — it does nothing. So now I fixed it

A bunch of fundamental problems were solved within [refactoring commit](https://github.com/spacemeshos/smapp/pull/1076/commits/cd08c1d66b7f5d4a830eb352219a77637c90a05f), so I want to provide some details:
1. Instead of storing manager class instances in RxJs subject now we're storing the only reference to the single collection of Managers. Afterward, we're not re-creating new instances all the time, but updating dependencies (`mainWindow` and `genesisId`).
2. Some logic over updating `mainWindow` and sub/unsub was moved into the `AbstractManager` class
3. It fixes #1072, because previously `NodeManager` spawns a Node with the new node-config (points to a new network), but using the old node-data dir because it contains the same `genesisId` created in a constructor.
4. Probably it also fixes #1075. Since Smapp does not show this dialog it means, that Smapp thinks that the Node process is not running. It may happen in case we re-spawned NodeManager and the reference to the process has been lost. However, now we have a single instance of each manager per application session.