### PR TITLE
Fix reconnecting GRPC clients

### DIFF
--- a/app/screens/auth/UnlockWallet.tsx
+++ b/app/screens/auth/UnlockWallet.tsx
@@ -163,6 +163,7 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
   const decryptWallet = async () => {
     const passwordMinimumLength = 1; // TODO: For testing purposes, set to 1 minimum length. Should be changed back to 8 when ready.
     if (!!password && password.trim().length >= passwordMinimumLength) {
+      setShowLoader(true);
       if (walletFiles.length === 0) {
         throw new Error('No wallets found to unlock');
       }
@@ -172,6 +173,7 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
 
       if (status.success) {
         if (status.forceNetworkSelection) {
+          setShowLoader(false);
           history.push(AuthPath.SwitchNetwork, {
             redirect: nextPage,
             isWalletOnly: status.isWalletOnly,

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -225,7 +225,12 @@ const Network = ({ history }) => {
   };
 
   return (
-    <WrapperWith2SideBars width={1000} header="NETWORK" headerIcon={network}>
+    <WrapperWith2SideBars
+      width={1000}
+      header="NETWORK"
+      headerIcon={network}
+      style={{ minHeight: 485 }}
+    >
       <SubHeader>
         {netName}
         {nodeError && (

--- a/desktop/AccountState.ts
+++ b/desktop/AccountState.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { equals } from 'ramda';
 import { app } from 'electron';
 import { AccountBalance, Tx, Reward, HexString } from '../shared/types';
-import { debounce, shallowEq } from '../shared/utils';
+import { debounceShared, shallowEq } from '../shared/utils';
 import Logger from './logger';
 
 const logger = Logger({ className: 'AccountState' });
@@ -99,7 +99,7 @@ export class AccountStateManager {
     this.baseDir = opts.accountStateDir;
     this.genesisID = genesisID;
     if (opts.autosave) {
-      this.autosave = debounce(opts.debounce, this.save);
+      this.autosave = debounceShared(opts.debounce, this.save);
     }
   }
 

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -5,6 +5,7 @@ import { PublicService, SocketAddress } from '../shared/types';
 import { LOCAL_NODE_API_URL } from '../shared/constants';
 import { delay, isNodeApiEq } from '../shared/utils';
 import Logger from './logger';
+import { MINUTE } from './main/constants';
 
 // Types
 type Proto = { spacemesh: { v1: any; [k: string]: any }; [k: string]: any };
@@ -31,12 +32,28 @@ export type ServiceCallbackResult<
   // TODO: It works fine, but TypeScript finds this errorish
   Parameters<ServiceCallback<P, ServiceName, K>>[1];
 
+export type ServiceStream<
+  P extends Proto,
+  ServiceName extends keyof P['spacemesh']['v1'],
+  K extends keyof Service<P, ServiceName>
+> = ReturnType<Service<P, ServiceName>[K]>;
+
+export type ServiceStreamResponse<
+  P extends Proto,
+  ServiceName extends keyof P['spacemesh']['v1'],
+  K extends keyof Service<P, ServiceName>
+> = ServiceStream<P, ServiceName, K> extends grpc.ClientReadableStream<infer T>
+  ? T
+  : never;
+
 const ERROR_CODE_TO_RESTART_STREAM = [
   2, // UNKNOWN
   13, // INTERNAL, including nginx TIMEOUT
   14, // UNAVAILABLE
   15, // DATA_LOSS
 ];
+
+const MAX_RETRIES = 5; // In a row
 
 // Abstract Class
 
@@ -185,8 +202,8 @@ class NetServiceFactory<
   runStream = <K extends keyof Service<T, ServiceName>>(
     method: K,
     opts: ServiceOpts<T, ServiceName, K>,
-    onData: (data: ServiceCallbackResult<T, ServiceName, K>) => void,
-    _retries = 5
+    onData: (data: ServiceStreamResponse<T, ServiceName, K>) => void,
+    onError: (error: grpc.ServiceError) => void = () => {}
   ) => {
     if (!this.service) {
       this.logger?.debug(
@@ -198,10 +215,11 @@ class NetServiceFactory<
       return () => {};
     }
     this.logger?.debug(
-      `Stream ${this.serviceName}.${String(method)} with`,
+      `running stream ${this.serviceName}.${String(method)} with`,
       opts
     );
 
+    let retries = MAX_RETRIES;
     let stream: ReturnType<typeof this.service[typeof method]>;
 
     const cancel = () =>
@@ -212,7 +230,7 @@ class NetServiceFactory<
         })
       );
 
-    const startStream = async (retries: number, afterRestart) => {
+    const startStream = async (afterRestart) => {
       if (!this.service) {
         this.logger?.debug(
           `startStream > Service ${this.serviceName} is not running`,
@@ -222,47 +240,58 @@ class NetServiceFactory<
       }
       this.logger?.debug(
         `${this.serviceName}.${String(method)} started. Attempt #${
-          _retries - retries
+          MAX_RETRIES - retries
         }`
       );
+
+      await cancel();
+
       stream = this.service[method](opts);
-      stream.on('data', onData);
-      stream.on('error', async (error: Error & { code: number }) => {
+      stream.on('data', (data) => {
+        retries = MAX_RETRIES;
+        onData(data);
+      });
+      stream.on('error', async (error: grpc.ServiceError) => {
         if (error.code === 1) return; // Cancelled on client
-        this.logger?.error(
+        this.logger?.debug(
           `grpc ${this.serviceName}.${String(method)}`,
           error,
           `Retries left: ${retries}`
         );
+        onError(error);
         if (retries > 0 && ERROR_CODE_TO_RESTART_STREAM.includes(error.code)) {
           await cancel();
           await delay(5000);
-          this.logger?.error(
+          this.logger?.debug(
             `grpc ${this.serviceName}.${String(method)} restarting...`,
             null
           );
-          await startStream(retries - 1, afterRestart);
+          retries -= 1;
+          await startStream(afterRestart);
         } else if (afterRestart) {
           this.logger?.error(
             `grpc ${this.serviceName}.${String(
               method
-            )} can not restart after restarting NetService`,
+            )} can not restart after restarting NetService. Will retry in a minute`,
             error
           );
+          await delay(MINUTE);
+          retries = MAX_RETRIES;
+          await startStream(false);
         } else {
           this.logger?.debug(
             `grpc ${this.serviceName}.${String(
               method
-            )} failed to restart. Restarting NetService...`
+            )} failed to connect. Restarting NetService...`
           );
           await this.restartNetService();
         }
       });
     };
-    startStream(_retries, false);
+    startStream(false);
 
     this.cancelStreamList[method] = () => cancel();
-    this.startStreamList[method] = () => startStream(_retries, true);
+    this.startStreamList[method] = () => startStream(true);
 
     return cancel;
   };

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -247,8 +247,7 @@ class NodeManager extends AbstractManager {
   };
 
   connectToRemoteNode = async (apiUrl?: SocketAddress | PublicService) => {
-    this.nodeService.cancelStatusStream();
-    this.nodeService.cancelErrorStream();
+    this.nodeService.cancelStreams();
     await this.stopNode();
     this.$_nodeStatus.reset();
 
@@ -279,9 +278,6 @@ class NodeManager extends AbstractManager {
     if (success) {
       // update node status once by query request
       await this.updateNodeStatus();
-      // ensure there are no active streams left
-      this.nodeService.cancelStatusStream();
-      this.nodeService.cancelErrorStream();
       // and activate streams
       this.activateNodeStatusStream();
       this.activateNodeErrorStream();
@@ -470,7 +466,7 @@ class NodeManager extends AbstractManager {
     interval: number
   ): Promise<boolean> => {
     if (!this.nodeProcess) return true;
-    const isFinished = this.nodeProcess.killed;
+    const isFinished = this.nodeProcess.exitCode !== null;
     logger.log(
       'Spawn process',
       `Wait process to finish isFinished: ${isFinished}, timeout: ${timeout}, interval: ${interval}`

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -23,7 +23,7 @@ import { Reward__Output } from '../proto/spacemesh/v1/Reward';
 import { Account__Output } from '../proto/spacemesh/v1/Account';
 import { hasRequiredRewardFields } from '../shared/types/guards';
 import {
-  debounceWithArgs,
+  debounceByArgs,
   delay,
   fromHexString,
   longToNumber,
@@ -104,7 +104,7 @@ class TransactionManager extends AbstractManager {
   };
 
   // Debounce update functions to avoid excessive IPC calls
-  updateAppStateAccount = debounceWithArgs(100, (address: string) => {
+  updateAppStateAccount = debounceByArgs(100, (address: string) => {
     const account = this.accountStates[address].getState();
     if (!account) {
       return;
@@ -115,12 +115,12 @@ class TransactionManager extends AbstractManager {
     });
   });
 
-  updateAppStateTxs = debounceWithArgs(100, (publicKey: string) => {
+  updateAppStateTxs = debounceByArgs(100, (publicKey: string) => {
     const txs = this.accountStates[publicKey].getTxs() || {};
     this.appStateUpdater(ipcConsts.T_M_UPDATE_TXS, { txs, publicKey });
   });
 
-  updateAppStateRewards = debounceWithArgs(100, (publicKey: string) => {
+  updateAppStateRewards = debounceByArgs(100, (publicKey: string) => {
     const rewards = this.accountStates[publicKey].getRewards() || [];
     this.appStateUpdater(ipcConsts.T_M_UPDATE_REWARDS, { rewards, publicKey });
   });
@@ -154,7 +154,7 @@ class TransactionManager extends AbstractManager {
     await this.upsertTransaction(publicKey)(newTx);
   };
 
-  private subscribeTransactions = debounceWithArgs(100, (publicKey: string) => {
+  private subscribeTransactions = debounceByArgs(100, (publicKey: string) => {
     const txs = this.accountStates[publicKey].getTxs();
     const txIds = Object.keys(txs).map(fromHexString);
 

--- a/shared/types/node.ts
+++ b/shared/types/node.ts
@@ -36,6 +36,15 @@ export interface NodeError {
   stackTrace: string;
 }
 
+export const asNodeError = (nodeError: NodeError): NodeError => nodeError;
+
+export const isNodeError = (e: any): e is NodeError =>
+  e &&
+  typeof e.level === 'number' &&
+  typeof e.module === 'string' &&
+  typeof e.msg === 'string' &&
+  typeof e.stackTrace === 'string';
+
 export interface NodeConfig {
   api: {
     grpc: string;

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -2,21 +2,68 @@ import TOML from '@iarna/toml';
 import { LOCAL_NODE_API_URL } from './constants';
 import { HexString, PublicService, SocketAddress, WalletType } from './types';
 
-// eslint-disable-next-line import/prefer-default-export
 export const delay = (ms: number) =>
   new Promise<void>((resolve) => {
     setTimeout(() => resolve(), ms);
   });
 
-// promisifed debounce function with multiple consumers
-// can not be cancelled
-export const debounce = <T extends unknown>(
+// Promisifed debounce function for multiple consumers
+//
+// It calls the callback function not more often than once
+// per specified delay time. The result of callback function
+// is spreaded (as resolved promise) to all callers.
+// Callback function will be called with the latest arguments.
+//
+// Check out the example:
+//   Let's say that we need to fetch some value from API
+//   however, we have a lot of async events that may trigger
+//   this function, to avoid making excessive fetch requests
+//   you can wrap your function in the `debounceShared`.
+//
+//   const myFetch = debounceShared(1000, () => fetch('0.0.0.0:8000/value.txt'));
+//   setInterval(() => myFetch().then(console.log), 800);
+//   setInterval(() => myFetch().then(console.log), 300);
+//   setInterval(() => myFetch().then(console.log), 400);
+//
+//   const myFetch = debounceShared(1000, async (x) => {
+//     console.log('fetch!', x);
+//     await delay(50);
+//     return { timestamp: Date.now(), x };
+//   }));
+//   setInterval(() => myFetch(800).then((x) => console.log(800, '>', x)), 800);
+//   setInterval(() => myFetch(300).then((x) => console.log(300, '>', x)), 300);
+//   setInterval(() => myFetch(400).then((x) => console.log(400, '>', x)), 400);
+//
+//   Output:
+//   fetch! 300
+//   300 > { timestamp: 1674162027724, x: 300 }
+//   400 > { timestamp: 1674162027724, x: 300 }
+//   300 > { timestamp: 1674162027724, x: 300 }
+//   800 > { timestamp: 1674162027724, x: 300 }
+//   400 > { timestamp: 1674162027724, x: 300 }
+//   300 > { timestamp: 1674162027724, x: 300 }
+//   400 > { timestamp: 1674162027724, x: 300 }
+//   300 > { timestamp: 1674162027724, x: 300 }
+//   fetch! 300
+//   300 > { timestamp: 1674162028933, x: 300 }
+//   ...
+//
+//   Will send one fetch request every 1000ms, the result will be spreaded to
+//   everyone who are awaiting for the result. So you will see bunches of results
+//   in console, however all of them will refer to the single result with the same
+//   `timestamp` and `x` properties.
+//
+//   In case if you want to have separate debounce "threads" for individual arguments
+//   use `debounceByArgs`
+//
+export const debounceShared = <T extends unknown>(
   delay: number,
   cb: (...args: any[]) => T | Promise<T>
 ) => {
   type PromiseHandler = (T) => any;
 
   let t: ReturnType<typeof setTimeout> | null = null;
+  let startedAt = 0;
   let thenResolvers: PromiseHandler[] = [];
   let thenRejecters: PromiseHandler[] = [];
   let catchResolvers: PromiseHandler[] = [];
@@ -34,27 +81,31 @@ export const debounce = <T extends unknown>(
   };
 
   return (...args: any[]) => {
-    t && clearTimeout(t);
-    t = setTimeout(() => {
-      try {
-        const r = cb(...args);
-        if (r && r instanceof Promise) {
-          // eslint-disable-next-line promise/catch-or-return
-          r.then(resolve)
-            .catch(reject)
-            .then((x) => {
-              clearHandlers();
-              return x;
-            });
-        } else {
-          resolve(r);
+    const now = Date.now();
+    if (now > startedAt + delay) {
+      t && clearTimeout(t);
+      startedAt = now;
+      t = setTimeout(() => {
+        try {
+          const r = cb(...args);
+          if (r && r instanceof Promise) {
+            // eslint-disable-next-line promise/catch-or-return
+            r.then(resolve)
+              .catch(reject)
+              .then((x) => {
+                clearHandlers();
+                return x;
+              });
+          } else {
+            resolve(r);
+            clearHandlers();
+          }
+        } catch (err) {
+          reject(err);
           clearHandlers();
         }
-      } catch (err) {
-        reject(err);
-        clearHandlers();
-      }
-    }, delay);
+      }, delay);
+    }
     return {
       then: (fn: PromiseHandler) =>
         new Promise((resolve, reject) => {
@@ -66,6 +117,40 @@ export const debounce = <T extends unknown>(
           catchResolvers.push((result: T) => resolve(fn(result)));
         }),
     } as Promise<T>;
+  };
+};
+
+// The extended version of `debounceShared`
+// This wrapper groups function calls by arguments in separate "threads".
+// Saying simpler, if you take the example of `debounceShared` function
+// and replace it with `debounceByArgs`, then there will be three
+// calls for each argument set individually:
+//   fetch! 300
+//   300 > { timestamp: 1674162440796, x: 300 }
+//   300 > { timestamp: 1674162440796, x: 300 }
+//   300 > { timestamp: 1674162440796, x: 300 }
+//   300 > { timestamp: 1674162440796, x: 300 }
+//   fetch! 400
+//   400 > { timestamp: 1674162440892, x: 400 }
+//   400 > { timestamp: 1674162440892, x: 400 }
+//   400 > { timestamp: 1674162440892, x: 400 }
+//   fetch! 800
+//   800 > { timestamp: 1674162441291, x: 800 }
+//   800 > { timestamp: 1674162441291, x: 800 }
+//   fetch! 300
+//   300 > { timestamp: 1674162442008, x: 300 }
+// ...
+export const debounceByArgs = <T extends (...args: any[]) => any>(
+  ms: number,
+  callback: T
+) => {
+  const t = {};
+  return (...args) => {
+    const k = JSON.stringify(args);
+    if (!t[k]) {
+      t[k] = debounceShared(ms, callback);
+    }
+    return t[k](...args);
   };
 };
 
@@ -178,21 +263,6 @@ export const deriveHRP = (addr: string) => addr.match(/^(\w+)1/)?.[1] || null;
 
 export const longToNumber = (val: Long | number) =>
   typeof val === 'number' ? val : val.toNumber();
-
-//
-export const debounceWithArgs = <T extends (...args: any[]) => any>(
-  ms: number,
-  callback: T
-) => {
-  const t = {};
-  return (...args) => {
-    const k = JSON.stringify(args);
-    if (!t[k]) {
-      t[k] = debounce(ms, callback);
-    }
-    return t[k](...args);
-  };
-};
 
 export const convertBytesToGB = (maxFileSize: number) =>
   maxFileSize / 1024 / 1024 / 1024;


### PR DESCRIPTION
This PR includes:
- Critical bug fix:
   Every 3 hours Node drops GRPC clients due to [`MaxConnectionAge`](https://github.com/spacemeshos/go-spacemesh/blob/develop/api/grpcserver/grpc.go#L84-L86). Previously we had a bug, that NodeService streams restarted only 5 times, and then the `retries` counter ended up. Reported by @lrettig 
   So I've refactored the code to handle NodeService streams in the same ways as others, and also improved the handling of streams for all GRPC services.
   **HOW TO TEST** 
   Instead of waiting for 18+ hours, you can build your own go-spacemesh binary with reduced `MaxConnectionAge` to 1-2 minutes. Afterward, you will be able to ensure that Smapp handles connection drop fine within ~10-15 minutes :)
   
- Fix of regression in #1083 (showing loader on unlocking the wallet)
- Add minimal height for the container on the Network screen to fit all contents well
- Optimised `isNodeAlive` calls