### PR TITLE
Auto-switch PoS directory on switching network + PoS dropdown tweak

### DIFF
--- a/app/screens/node/NodeSetup.tsx
+++ b/app/screens/node/NodeSetup.tsx
@@ -26,6 +26,7 @@ import {
 import ErrorMessage from '../../basicComponents/ErrorMessage';
 import { MainPath } from '../../routerPaths';
 import { smColors } from '../../vars';
+import { distribute } from '../../../shared/utils';
 
 const Wrapper = styled.div`
   display: flex;
@@ -183,22 +184,24 @@ const NodeSetup = ({ history, location }: Props) => {
           />
         );
       case 2: {
-        const commitments: Commitment[] = [];
         const singleCommitmentSize =
           (smesherConfig.bitsPerLabel * smesherConfig.labelsPerUnit) / BITS;
-
-        for (
-          let i = smesherConfig.minNumUnits;
-          i <= smesherConfig.maxNumUnits;
-          i += 1
-        ) {
+        const commitments = distribute(
+          smesherConfig.minNumUnits,
+          smesherConfig.maxNumUnits,
+          10
+        ).reduce((acc, next) => {
+          const i = Math.ceil(next);
           const calculationResult = i * singleCommitmentSize;
-          commitments.push({
-            label: formatBytes(calculationResult),
-            size: calculationResult,
-            numUnits: i,
-          });
-        }
+          return [
+            ...acc,
+            {
+              label: formatBytes(calculationResult),
+              size: calculationResult,
+              numUnits: i,
+            },
+          ];
+        }, [] as Commitment[]);
         // TODO: Make a well default instead of logic inside view and rerendering comp:
         numUnits === 0 && setNumUnits(commitments[0].numUnits);
         return (

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -335,7 +335,7 @@ class NodeManager extends AbstractManager {
       // It can be moved back to SmesherManager when issue
       // https://github.com/spacemeshos/go-spacemesh/issues/2858
       // will be solved, and all these kludges can be removed.
-      await this.smesherManager.updateSmeshingConfig(opts);
+      await this.smesherManager.updateSmeshingConfig(opts, this.genesisID);
       await this.smesherManager.startSmeshing(opts);
       return SmeshingSetupState.ViaAPI;
     };
@@ -366,7 +366,10 @@ class NodeManager extends AbstractManager {
     }
     // In other cases — update config first and then restart the node
     // it will start Smeshing automatically based on the config
-    await this.smesherManager.updateSmeshingConfig(postSetupOpts);
+    await this.smesherManager.updateSmeshingConfig(
+      postSetupOpts,
+      this.genesisID
+    );
     await this.restartNode();
     return SmeshingSetupState.ViaRestart;
   };

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -4,6 +4,7 @@ import * as R from 'ramda';
 import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import { ipcConsts } from '../app/vars';
 import {
+  HexString,
   IPCSmesherStartupData,
   NodeConfig,
   PostSetupOpts,
@@ -15,6 +16,7 @@ import SmesherService from './SmesherService';
 import Logger from './logger';
 import { readFileAsync, writeFileAsync } from './utils';
 import AbstractManager from './AbstractManager';
+import StoreService from './storeService';
 
 const checkDiskSpace = require('check-disk-space');
 
@@ -250,7 +252,10 @@ class SmesherManager extends AbstractManager {
       handler: this.handlePostDataCreationStatusStream,
     });
 
-  updateSmeshingConfig = async (postSetupOpts: PostSetupOpts) => {
+  updateSmeshingConfig = async (
+    postSetupOpts: PostSetupOpts,
+    genesisID: HexString
+  ) => {
     const {
       coinbase,
       dataDir,
@@ -259,9 +264,7 @@ class SmesherManager extends AbstractManager {
       throttle,
       maxFileSize,
     } = postSetupOpts;
-
-    const config = await this.loadConfig();
-    config.smeshing = {
+    const opts = {
       'smeshing-coinbase': coinbase,
       'smeshing-opts': {
         'smeshing-opts-datadir': dataDir,
@@ -272,6 +275,10 @@ class SmesherManager extends AbstractManager {
       },
       'smeshing-start': true,
     };
+    StoreService.set(`smeshing.${genesisID}`, opts);
+
+    const config = await this.loadConfig();
+    config.smeshing = opts;
     return this.writeConfig(config);
   };
 

--- a/desktop/storeService.ts
+++ b/desktop/storeService.ts
@@ -3,24 +3,9 @@ import Store from 'electron-store';
 import { Object } from 'ts-toolbelt';
 import { AutoPath } from 'ts-toolbelt/out/Function/AutoPath';
 import { Split } from 'ts-toolbelt/out/String/Split';
-import { AccountBalance } from '../shared/types';
-import { Transaction } from '../proto/spacemesh/v1/Transaction';
-import { _spacemesh_v1_TransactionState_TransactionState } from '../proto/spacemesh/v1/TransactionState';
+import { HexString } from '../shared/types';
 import { USERDATA_DIR } from './main/constants';
-
-export type TxStored = Required<Transaction> & {
-  id: string;
-  state: _spacemesh_v1_TransactionState_TransactionState;
-};
-
-export interface AccountStore {
-  publicKey: string;
-  account: AccountBalance;
-  txs: { [txId: TxStored['id']]: TxStored };
-  rewards: { [rewardId: TxStored['id']]: TxStored }; // TODO: Implement within #766
-}
-
-// TODO: Rewards?
+import { SmeshingOpts } from './main/smeshingOpts';
 
 export interface ConfigStore {
   isAutoStartEnabled: boolean;
@@ -28,6 +13,7 @@ export interface ConfigStore {
     dataPath: string;
     port: string;
   };
+  smeshing: Record<HexString, SmeshingOpts>;
   walletFiles: string[];
 }
 
@@ -37,6 +23,7 @@ const CONFIG_STORE_DEFAULTS = {
     dataPath: path.resolve(USERDATA_DIR, 'node-data'),
     port: '9092',
   },
+  smeshing: {},
   walletFiles: [],
 };
 

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -4,6 +4,7 @@ import { F_OK } from 'constants';
 import cs from 'checksum';
 import fetch from 'electron-fetch';
 import { configCodecByFirstChar } from '../shared/utils';
+import { NodeConfig } from '../shared/types';
 
 // --------------------------------------------------------
 // ENV modes
@@ -25,7 +26,7 @@ export const isDevNet = (
 export const fetchJSON = async (url?: string) =>
   url ? fetch(`${url}?no-cache=${Date.now()}`).then((res) => res.json()) : null;
 
-export const fetchNodeConfig = async (url: string) =>
+export const fetchNodeConfig = async (url: string): Promise<NodeConfig> =>
   fetch(`${url}?no-cache=${Date.now()}`)
     .then((res) => res.text())
     .then((res) => configCodecByFirstChar(res).parse(res));

--- a/shared/types/node.ts
+++ b/shared/types/node.ts
@@ -53,10 +53,10 @@ export interface NodeConfig {
   p2p: {
     bootnodes: Array<string>;
   };
-  smeshing: {
-    'smeshing-coinbase': HexString;
-    'smeshing-start': boolean;
-    'smeshing-opts': {
+  smeshing?: {
+    'smeshing-coinbase'?: HexString;
+    'smeshing-start'?: boolean;
+    'smeshing-opts'?: {
       'smeshing-opts-datadir': string;
       'smeshing-opts-maxfilesize': number;
       'smeshing-opts-numunits': number;

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -268,3 +268,14 @@ export const convertBytesToGB = (maxFileSize: number) =>
   maxFileSize / 1024 / 1024 / 1024;
 export const convertGBToBytes = (maxFileSize: number) =>
   maxFileSize * 1024 * 1024 * 1024;
+
+export const distribute = (min: number, max: number, steps: number) => {
+  const delta = max - min;
+  const stepsSafe = delta > steps ? steps : delta + 1;
+  const step = delta / (stepsSafe - 1);
+  const res = <number[]>[];
+  for (let i = 0; i < stepsSafe; i += 1) {
+    res.push(min + i * step);
+  }
+  return res;
+};


### PR DESCRIPTION
1. Fixes #1087 with a little difference from the proposed solution.
   Instead of making a nested catalog, I made a more elegant solution:
   - When the User set up smeshing Smapp stores smeshing options in the persistent store in `Record<GenesisID, SmeshingOpts>`.
   - On loading a node config (Smapp does it each time on connection to the new network) instead of copying smeshing options we're looking for them in the persistent store.

2. Fix the PoS size dropdown, to make it possible to fit there a big range of possible values between `min/maxNumUnits`. It shows up to 10 uniformly distributed options.
   <img width="1026" alt="image" src="https://user-images.githubusercontent.com/1897530/213630867-8b6aab72-2c95-45e2-95ff-916f77b1c5ec.png">