### PR TITLE
Optimise rendering Transactions Log

### DIFF
--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled, { keyframes, useTheme } from 'styled-components';
 
-import { HexString } from '../../../shared/types';
+import { Bech32Address, HexString } from '../../../shared/types';
 import {
   ensure0x,
   getAbbreviatedAddress,
@@ -91,7 +91,7 @@ type Props = {
   full?: boolean; // Full length address or abbreviated. Default: false (abbreviated).
   hideCopy?: boolean; // Hide copy icon. Default: false
   hideExplorer?: boolean; // Hide explorer icon. Default: false
-  addToContacts?: ({ address }: { address: string }) => void; // If function exists — it shows up add contact icon. Default: undefined
+  addToContacts?: (address: Bech32Address) => void; // If function exists — it shows up add contact icon. Default: undefined
 };
 
 const Address = (props: Props) => {
@@ -138,7 +138,7 @@ const Address = (props: Props) => {
 
   const handleAddToContacts = (e: React.MouseEvent) => {
     e.stopPropagation();
-    addToContacts && addToContacts({ address: addr });
+    addToContacts && addToContacts(addr);
   };
 
   const textToShow =

--- a/app/components/transactions/LatestTransactions.tsx
+++ b/app/components/transactions/LatestTransactions.tsx
@@ -11,6 +11,7 @@ import {
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
 import {
+  getContacts,
   getLatestTransactions,
   RewardView,
   TxView,
@@ -92,9 +93,10 @@ const LatestTransactions = ({ navigateToAllTransactions }: Props) => {
       state.wallet.accounts[state.wallet.currentAccountIndex]?.address
   );
   const latestTransactions = useSelector(getLatestTransactions(address));
+  const contacts = useSelector(getContacts);
 
   const renderTransaction = (tx: TxView) => {
-    const { id, status, timestamp, contacts, meta } = tx;
+    const { id, status, timestamp, meta } = tx;
     // TODO: Temporary solution until we don't support other account types
     const isSent =
       tx.method === SingleSigMethods.Spend && tx.principal === address;

--- a/app/components/transactions/RewardRow.tsx
+++ b/app/components/transactions/RewardRow.tsx
@@ -134,8 +134,7 @@ type Props = {
 
 const RewardRow = ({ tx, address, isHidden = false }: Props) => {
   const [isDetailed, setIsDetailed] = useState(false);
-
-  const { layer, layerReward, amount, timestamp } = tx;
+  const { layer, layerReward, amount } = tx;
 
   const toggleTxDetails = () => {
     setIsDetailed(!isDetailed);
@@ -179,7 +178,7 @@ const RewardRow = ({ tx, address, isHidden = false }: Props) => {
             <Amount color={smColors.darkerGreen}>
               +{formatSmidge(amount)}
             </Amount>
-            <DarkGrayText>{getFormattedTimestamp(timestamp)}</DarkGrayText>
+            <DarkGrayText>{getFormattedTimestamp(tx.timestamp)}</DarkGrayText>
           </HeaderSection>
         </HeaderInner>
       </Header>

--- a/desktop/cryptoService.ts
+++ b/desktop/cryptoService.ts
@@ -1,5 +1,5 @@
 import * as bip39 from 'bip39';
-import { fromHexString, toHexString } from '../shared/utils';
+import { toHexString } from '../shared/utils';
 import Bip32KeyDerivation from './main/bip32-key-derivation';
 
 class CryptoService {
@@ -56,29 +56,6 @@ class CryptoService {
     index: number;
   }) => {
     return CryptoService.createWallet(mnemonic, index);
-  };
-
-  /**
-   * Signs message to be sent to node.
-   * @param secretKey - string
-   * @param message - utf8 string representation of message
-   * @return {Promise} when resolved returns signature as Uint8Array(64)
-   */
-  static signMessage = ({
-    message,
-    secretKey,
-  }: {
-    message: string;
-    secretKey: string;
-  }): Promise<string> => {
-    const sk = fromHexString(secretKey);
-    return new Promise((resolve) => {
-      const messageAsUint8Array = new TextEncoder().encode(message);
-      // @ts-ignore
-      global.__signTransaction(sk, messageAsUint8Array, (sig) => {
-        resolve(toHexString(sig));
-      });
-    });
   };
 
   /**

--- a/desktop/ed25519.ts
+++ b/desktop/ed25519.ts
@@ -16,7 +16,7 @@ export const sign = (dataBytes: Uint8Array, privateKey: HexString) => {
 
 export const verify = (
   dataBytes: Uint8Array,
-  signatureBytes: Uint8Array,
+  signatureBytes: HexString | Uint8Array,
   publicKey: HexString
 ) => {
   const key = Buffer.concat([
@@ -28,6 +28,10 @@ export const verify = (
     type: 'spki',
     key,
   });
+  const sig =
+    typeof signatureBytes === 'string'
+      ? Buffer.from(signatureBytes, 'hex')
+      : signatureBytes;
 
-  return crypto.verify(null, dataBytes, vk, signatureBytes);
+  return crypto.verify(null, dataBytes, vk, sig);
 };

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "ramda": "^0.28.0",
     "react": "17.0.2",
     "react-beautiful-dnd": "^13.1.1",
+    "react-cool-virtual": "^0.7.0",
     "react-dom": "17.0.2",
     "react-redux": "7.2.3",
     "react-router": "5.2.0",

--- a/shared/filterAddresses.ts
+++ b/shared/filterAddresses.ts
@@ -1,3 +1,4 @@
+import { isHRP } from './hrp';
 import { Bech32Address } from './types';
 
 type Filterable<T> = T[] | Record<string, T>;
@@ -8,10 +9,12 @@ const isFilterable = <T>(input: any): input is Filterable<T> =>
 const deepValues = (o: Filterable<any>): any[] =>
   Object.values(o).reduce((acc, next) => {
     if (isFilterable(next)) {
-      return [...acc, deepValues(next)];
+      return [...acc, ...deepValues(next)];
     }
     return [...acc, next];
   }, []);
 
 export default <I extends Filterable<any>>(input: I): Bech32Address[] =>
-  deepValues(input).filter((x) => x instanceof Uint8Array && x.length === 24);
+  deepValues(input).filter(
+    (x) => typeof x === 'string' && isHRP(x.split('1')[0])
+  );

--- a/shared/hrp.ts
+++ b/shared/hrp.ts
@@ -3,4 +3,7 @@ enum HRP {
   TestNet = 'stest',
 }
 
+export const isHRP = (a: any): a is HRP =>
+  typeof a === 'string' && (a === HRP.MainNet || a === HRP.TestNet);
+
 export default HRP;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,12 +1417,12 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.8", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
-  integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.7", "@babel/runtime@^7.17.8", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
+  integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
   dependencies:
-    regenerator-runtime "^0.13.4"
+    regenerator-runtime "^0.13.11"
 
 "@babel/runtime@~7.5.4":
   version "7.5.5"
@@ -14010,6 +14010,13 @@ react-beautiful-dnd@^13.1.1:
     redux "^4.0.4"
     use-memo-one "^1.1.1"
 
+react-cool-virtual@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-cool-virtual/-/react-cool-virtual-0.7.0.tgz#8fa5d8b622b1c73406f4542eba8cd75de3bc3558"
+  integrity sha512-oWRsF0Pf9dRWncpFvsCNWm0W/d/UEbUqxNIuhGEcLzdW16leokcl9gSYG9Ha5raaF/qq029W1cj65zAwgJyR7A==
+  dependencies:
+    "@babel/runtime" "^7.16.7"
+
 react-docgen-typescript@^2.1.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
@@ -14358,10 +14365,10 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
-  version "0.13.9"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
-  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-transform@^0.15.0:
   version "0.15.0"


### PR DESCRIPTION
It fixes #1086

What was optimized in comparison to `develop`:
- Opening Transaction Log takes ~50ms instead of ~3s + no more freezes
- Use the very insignificant amount of RAM instead of ~300MB (due to the huge DOM tree & some calculations)

The comparison was done on the account with 7089 rewards.

Also, get rid of stale code and started using a newer `ed25519.sign` function for signing plaintext messages.