### PR TITLE
Bring explorer links back

### DIFF
--- a/app/components/common/Address.tsx
+++ b/app/components/common/Address.tsx
@@ -151,12 +151,7 @@ const Address = (props: Props) => {
         <span>{textToShow}</span>
       </PublicKey>
       {!hideCopy && <CopyIcon onClick={handleCopy} />}
-      {/* TODO:
-        Until we don't have an explorer that supports new tx&accounts structure
-        we have to hide the explorer button from the UI.
-        To avoid linter errors I've just added `false` into the condition.
-      */}
-      {!hideExplorer && false && (
+      {!hideExplorer && (
         <ExplorerIcon src={explorer} onClick={handleExplorer} />
       )}
       {addToContacts && isAccount && (


### PR DESCRIPTION
No issue.
Since @kacpersaw repaired explorer and now it's back again — we're returning explorer links (next to any address) ;)