### PR TITLE
Tweak network screen in genesis phase

### DIFF
--- a/app/basicComponents/CustomTimeAgo.tsx
+++ b/app/basicComponents/CustomTimeAgo.tsx
@@ -3,7 +3,26 @@ import TimeAgo from 'react-timeago';
 
 import buildFormatter from 'react-timeago/lib/formatters/buildFormatter';
 
-const enString = {
+export type FormatterKeys =
+  | 'prefixAgo'
+  | 'prefixFromNow'
+  | 'suffixAgo'
+  | 'suffixFromNow'
+  | 'seconds'
+  | 'minute'
+  | 'minutes'
+  | 'hour'
+  | 'hours'
+  | 'day'
+  | 'days'
+  | 'month'
+  | 'months'
+  | 'year'
+  | 'years'
+  | 'wordSeparator';
+export type FormatterDict = Record<FormatterKeys, string | null>;
+
+const enString: FormatterDict = {
   prefixAgo: null,
   prefixFromNow: null,
   suffixAgo: 'ago',
@@ -22,10 +41,15 @@ const enString = {
   wordSeparator: ' ',
 };
 
-const CustomTimeAgo = ({ time }: { time: string }) => {
-  const jsDate = new Date(time).getTime();
-
-  const formatter = buildFormatter(enString);
+const CustomTimeAgo = ({
+  time,
+  dict = {},
+}: {
+  time: number | string;
+  dict?: Partial<FormatterDict>;
+}) => {
+  const jsDate = typeof time === 'number' ? time : new Date(time).getTime();
+  const formatter = buildFormatter({ ...enString, ...dict });
   return <TimeAgo date={jsDate} formatter={formatter} />;
 };
 

--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -79,7 +79,7 @@ const NetworkStatus = ({
   const renderSyncingStatus = () => {
     return (
       <>
-        {status?.isSynced ? (
+        {status?.isSynced && status.topLayer === status.syncedLayer ? (
           <>
             <NetworkIndicator color={smColors.green} />
             <ProgressLabel>synced</ProgressLabel>

--- a/app/redux/network/selectors.ts
+++ b/app/redux/network/selectors.ts
@@ -1,3 +1,7 @@
+import {
+  firstLayerInEpoch,
+  timestampByLayer,
+} from '../../../shared/layerUtils';
 import { RootState } from '../../types';
 
 export const getNetworkInfo = (state: RootState) => state.network;
@@ -7,3 +11,9 @@ export const getNetworkName = (state: RootState) =>
 
 export const getGenesisID = (state: RootState) =>
   getNetworkInfo(state).genesisID;
+
+export const getTimestampByLayerFn = (state: RootState) =>
+  timestampByLayer(state.network.genesisTime, state.network.layerDurationSec);
+
+export const getFirstLayerInEpochFn = (state: RootState) =>
+  firstLayerInEpoch(state.network.layersPerEpoch);

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -20,6 +20,10 @@ import { goToSwitchNetwork } from '../../routeUtils';
 import { AuthPath } from '../../routerPaths';
 import { delay } from '../../../shared/utils';
 import Address from '../../components/common/Address';
+import {
+  getFirstLayerInEpochFn,
+  getTimestampByLayerFn,
+} from '../../redux/network/selectors';
 
 const Container = styled.div`
   display: flex;
@@ -90,6 +94,9 @@ const Network = ({ history }) => {
       state.network.netName ||
       (genesisID === '' ? 'NOT CONNECTED' : 'UNKNOWN NETWORK NAME')
   );
+
+  const getFirstLayerInEpoch = useSelector(getFirstLayerInEpochFn);
+  const getTimestampByLayer = useSelector(getTimestampByLayerFn);
 
   const genesisTime = useSelector(
     (state: RootState) => state.network.genesisTime
@@ -170,20 +177,39 @@ const Network = ({ history }) => {
           />
         </GrayText>
       </DetailsRow>
-      <DetailsRow>
-        <DetailsTextWrap>
-          <DetailsText>Current Layer</DetailsText>
-          <Tooltip width={250} text="tooltip Current Layer" />
-        </DetailsTextWrap>
-        <GrayText>{status?.topLayer || 0}</GrayText>
-      </DetailsRow>
-      <DetailsRow>
-        <DetailsTextWrap>
-          <DetailsText>Verified Layer</DetailsText>
-          <Tooltip width={250} text="tooltip Verified Layer" />
-        </DetailsTextWrap>
-        <GrayText>{status?.verifiedLayer || 0}</GrayText>
-      </DetailsRow>
+      {status && status.topLayer < status.syncedLayer ? (
+        <DetailsRow>
+          <DetailsTextWrap>
+            <DetailsText>Genesis will end in</DetailsText>
+            <Tooltip
+              width={250}
+              text="The genesis phase lasts for the first two epochs"
+            />
+          </DetailsTextWrap>
+          <GrayText>
+            <CustomTimeAgo
+              time={getTimestampByLayer(getFirstLayerInEpoch(2))}
+            />
+          </GrayText>
+        </DetailsRow>
+      ) : (
+        <>
+          <DetailsRow>
+            <DetailsTextWrap>
+              <DetailsText>Current Layer</DetailsText>
+              <Tooltip width={250} text="tooltip Current Layer" />
+            </DetailsTextWrap>
+            <GrayText>{status?.topLayer || 0}</GrayText>
+          </DetailsRow>
+          <DetailsRow>
+            <DetailsTextWrap>
+              <DetailsText>Verified Layer</DetailsText>
+              <Tooltip width={250} text="tooltip Verified Layer" />
+            </DetailsTextWrap>
+            <GrayText>{status?.verifiedLayer || 0}</GrayText>
+          </DetailsRow>
+        </>
+      )}
       <DetailsRow>
         <DetailsTextWrap>
           <DetailsText>Connection Type</DetailsText>


### PR DESCRIPTION
When the network is in the genesis phase, show "Genesis will end in 3h" instead of confusing layer numbers.

![image](https://user-images.githubusercontent.com/1897530/215008772-c06888a6-eea4-4378-ad75-326992234206.png)
