### PR TITLE
chore: upgrade sentry

### DIFF
--- a/app/sentry.ts
+++ b/app/sentry.ts
@@ -9,9 +9,10 @@ export const init = (history) =>
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
+    enabled: true,
     debug: process.env.SENTRY_LOG_LEVEL === 'debug',
-    maxValueLength: 20000,
     attachStacktrace: true,
+    maxValueLength: 25000,
     tracesSampleRate: parseInt(process.env.TRACES_SAMPLE_RATE || '0.3'),
     integrations: [
       new BrowserTracing({

--- a/desktop/sentry.ts
+++ b/desktop/sentry.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/electron/main';
-import { captureException, setTags, addBreadcrumb } from '@sentry/electron';
 import { Event, EventHint } from '@sentry/types/types/event';
 import logger from 'electron-log';
 import { generateGenesisIDFromConfig } from './main/Networks';
@@ -42,7 +41,8 @@ export const init = () =>
     environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
     tracesSampleRate: parseInt(process.env.TRACES_SAMPLE_RATE || '0.3'),
     debug: process.env.SENTRY_LOG_LEVEL === 'debug',
-    maxValueLength: 20000,
+    enabled: true,
+    maxValueLength: 25000,
     attachStacktrace: true,
     attachScreenshot: true,
     async beforeSend(event: Event, hint: EventHint) {
@@ -67,13 +67,13 @@ export const init = () =>
   });
 
 export const captureMainException = (e: Error) => {
-  return captureException(e);
+  return Sentry.captureException(e);
 };
 
 export const captureMainBreadcrumb = (o: any) => {
-  return addBreadcrumb(o);
+  return Sentry.addBreadcrumb(o);
 };
 
 export const setMainTags = (tags: any) => {
-  return setTags(tags);
+  return Sentry.setTags(tags);
 };

--- a/desktop/wasm_exec.js
+++ b/desktop/wasm_exec.js
@@ -70,7 +70,7 @@
 		const nodeCrypto = require("crypto");
 		global.crypto = {
 			getRandomValues(b) {
-				nodeCrypto.randomFillSync(b);
+				return nodeCrypto.randomFillSync(b);
 			},
 		};
 	}

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@babel/register": "7.13.8",
     "@jest-runner/electron": "^3.0.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
-    "@sentry/cli": "^2.10.0",
+    "@sentry/cli": "^2.12.0",
     "@sentry/webpack-plugin": "^1.20.0",
     "@storybook/addon-actions": "^6.5.6",
     "@storybook/addon-essentials": "^6.5.6",
@@ -179,9 +179,9 @@
     "@grpc/proto-loader": "0.6.2",
     "@iarna/toml": "^2.2.5",
     "@reduxjs/toolkit": "^1.7.2",
-    "@sentry/electron": "4.0.0-beta.1",
-    "@sentry/react": "^7.24.2",
-    "@sentry/tracing": "^7.24.2",
+    "@sentry/electron": "^4.2.0",
+    "@sentry/react": "^7.36.0",
+    "@sentry/tracing": "^7.36.0",
     "@spacemesh/address-wasm": "^0.2.0",
     "@spacemesh/sm-codec": "0.3.4",
     "auto-launch": "^5.0.5",
@@ -222,5 +222,8 @@
     "throttle-debounce": "^4.0.1",
     "ts-toolbelt": "^9.6.0",
     "uuid": "^8.3.2"
+  },
+  "resolutions": {
+    "@sentry/types": "^7.36.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,14 +2286,15 @@
     redux-thunk "^2.4.1"
     reselect "^4.1.5"
 
-"@sentry/browser@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.3.1.tgz#4f1181a93f987aebf0a8a317c8a5e1c61832ed90"
-  integrity sha512-x0LhK8hnrGEBBCZVsW9h3USW93agX+axXvUPu72SJMyMnwF+92XjpgOET48OdPNzej/bU8Qv+eXTC/VDh/HXvw==
+"@sentry/browser@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.30.0.tgz#9b4387da933290546b7a4ef521713c38723a0213"
+  integrity sha512-9hpaNAqIBDLdnrZ51iWkqenRotqqweE1f2AlHO56nyT/UE+u+GdmAiBrgRNqdFQQM13JtTG/gu4HGOyLWb9HEA==
   dependencies:
-    "@sentry/core" "7.3.1"
-    "@sentry/types" "7.3.1"
-    "@sentry/utils" "7.3.1"
+    "@sentry/core" "7.30.0"
+    "@sentry/replay" "7.30.0"
+    "@sentry/types" "7.30.0"
+    "@sentry/utils" "7.30.0"
     tslib "^1.9.3"
 
 "@sentry/browser@7.36.0":
@@ -2320,7 +2321,7 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/cli@^2.10.0":
+"@sentry/cli@^2.12.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.12.0.tgz#425c044b71648786f8e0a2db38603e510d002a1f"
   integrity sha512-EHDZVaje1Vkm0sygVyKuUtQgTw7OFzgysBXjwEad6BgZVPTtF46v0eizCrBK9jwA1P30logf76D1u+eULaSDDw==
@@ -2331,14 +2332,13 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/core@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.3.1.tgz#69a0cbb8678e44516f8faae0b13aaaa086183c96"
-  integrity sha512-UYPNDluFtj5w6alh+SjSm9p6kxReKVcKEE+EPE4o44pdowjZ1BFTUY6ipMJhtIiDPr/51eeP8TuYdOAbo0Z9Pg==
+"@sentry/core@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.30.0.tgz#02d2e8747484ba64b6d712e8afe6736250efdc26"
+  integrity sha512-NeLigkBlpcK63ymM63GoIHurml6V3BUe1Vi+trwm4/qqOTzT7PQhvdJCX+o3+atzRBH+zdb6kd4VWx44Oye3KA==
   dependencies:
-    "@sentry/hub" "7.3.1"
-    "@sentry/types" "7.3.1"
-    "@sentry/utils" "7.3.1"
+    "@sentry/types" "7.30.0"
+    "@sentry/utils" "7.30.0"
     tslib "^1.9.3"
 
 "@sentry/core@7.36.0":
@@ -2350,44 +2350,33 @@
     "@sentry/utils" "7.36.0"
     tslib "^1.9.3"
 
-"@sentry/electron@4.0.0-beta.1":
-  version "4.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@sentry/electron/-/electron-4.0.0-beta.1.tgz#332195a7e423f220ce8e634d3729e65913eaa1ca"
-  integrity sha512-ib4f8kjsywx86cQmAFkAISWYBNgnvhOAAlSECntSl4lZPcpkv0gYjucZrbfoHG5DSyw7SNGhKnHHiCD9HGxHoA==
+"@sentry/electron@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry/electron/-/electron-4.2.0.tgz#73bad35d3fd82ddb9f835da469b2e9642fcf5bf5"
+  integrity sha512-9r7Kb4BOPXNClsYvzWJ1Nppf5cL8sck9Li4KIAgCq/ofogPiE54fbUdJtx5Fkagon5sBSjy0gu74xuhnPexhoA==
   dependencies:
-    "@sentry/browser" "7.3.1"
-    "@sentry/core" "7.3.1"
-    "@sentry/hub" "7.3.1"
-    "@sentry/node" "7.3.1"
-    "@sentry/types" "7.3.1"
-    "@sentry/utils" "7.3.1"
-    deepmerge "^4.2.2"
+    "@sentry/browser" "7.30.0"
+    "@sentry/core" "7.30.0"
+    "@sentry/node" "7.30.0"
+    "@sentry/types" "7.30.0"
+    "@sentry/utils" "7.30.0"
+    deepmerge "4.2.2"
     tslib "^2.3.1"
 
-"@sentry/hub@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.3.1.tgz#9a0e0570631997b58484a97b6a1d3aa7368121ec"
-  integrity sha512-TFewt7zDvVLLrCfKkmvJEO4GPw3oPvR2t+606Z4S2gKiekGXKFGX4YC5u0ytoPfi+NMadXz4HivfrPuxrMy1JQ==
+"@sentry/node@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.30.0.tgz#42ef5b29d065f6de6ac5556a56aca20d3b9073e1"
+  integrity sha512-YYasu6C3I0HBP4N1oc/ed2nunxhGJgtAWaKwq3lo8uk3uF6cB1A8+2e0CpjzU5ejhbaFPUBxHyj4th39Bvku/w==
   dependencies:
-    "@sentry/types" "7.3.1"
-    "@sentry/utils" "7.3.1"
-    tslib "^1.9.3"
-
-"@sentry/node@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.3.1.tgz#4c6a9ed35a7113530fe2a53dfb1ed97aaf67729a"
-  integrity sha512-nuv/TZToJgRAIR4o/cpxhd3zYN5cSbXgctygDlaPSZmAdJeuuivy8Qy2ZJn37COA60yoAKRhGFBr38YBw8GQ6Q==
-  dependencies:
-    "@sentry/core" "7.3.1"
-    "@sentry/hub" "7.3.1"
-    "@sentry/types" "7.3.1"
-    "@sentry/utils" "7.3.1"
+    "@sentry/core" "7.30.0"
+    "@sentry/types" "7.30.0"
+    "@sentry/utils" "7.30.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/react@^7.24.2":
+"@sentry/react@^7.36.0":
   version "7.36.0"
   resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.36.0.tgz#8916d7a3d4f988161dd88ecc17a884e006fd5d01"
   integrity sha512-ttrRqbgeqvkV3DwkDRZC/V8OEnBKGpQf4dKpG8oMlfdVbMTINzrxYUgkhi9xAkxkH9O+vj3Md8L3Rdqw/SDwKQ==
@@ -2398,6 +2387,15 @@
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
+"@sentry/replay@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.30.0.tgz#44db86956166fc8909459eef8ce94f750c072519"
+  integrity sha512-qJgz1tG0uStqMF5V7gN7KqxZuZY0MMQQY7siwPcSQVYj7X3AQswHjmvD4npEKbIa+jP6aQ6fFjoBjl3c0t3Mmg==
+  dependencies:
+    "@sentry/core" "7.30.0"
+    "@sentry/types" "7.30.0"
+    "@sentry/utils" "7.30.0"
+
 "@sentry/replay@7.36.0":
   version "7.36.0"
   resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.36.0.tgz#87b24d44e8136e8c3fccd1d80097097c0c67affa"
@@ -2407,7 +2405,7 @@
     "@sentry/types" "7.36.0"
     "@sentry/utils" "7.36.0"
 
-"@sentry/tracing@^7.24.2":
+"@sentry/tracing@^7.36.0":
   version "7.36.0"
   resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.36.0.tgz#aa38319ed07f3b642134cf47da81f43df7835629"
   integrity sha512-5R5mfWMDncOcTMmmyYMjgus1vZJzIFw4LHaSbrX7e1IRNT/6vFyNeVxATa2ePXb9mI3XHo5f2p7YrnreAtaSXw==
@@ -2417,22 +2415,17 @@
     "@sentry/utils" "7.36.0"
     tslib "^1.9.3"
 
-"@sentry/types@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.3.1.tgz#c6eaabf0ab2cc778474ba68d3d8331ec839cda6f"
-  integrity sha512-EZaRLJ8G2aSb7Vlpe1TR9LRZKY5gNpufuu8OXVrnTHiEMLHNUv1NrLQevy2m1SQUkg43oLdTyMKdM+nTESIC+A==
-
-"@sentry/types@7.36.0":
+"@sentry/types@7.30.0", "@sentry/types@7.36.0", "@sentry/types@^7.36.0":
   version "7.36.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.36.0.tgz#205baaf7332ff55d1fb35413cbde16dea4168520"
   integrity sha512-uvfwUn3okAWSZ948D/xqBrkc3Sn6TeHUgi3+p/dTTNGAXXskzavgfgQ4rSW7f3YD4LL+boZojpoIARVLodMGuA==
 
-"@sentry/utils@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.3.1.tgz#f0d3644e9040d8654c452b01c3ba76df448d27f2"
-  integrity sha512-lrwbyajioWeG/CTFCzRh0Pu+zd/P+A+ASToEy2WIQsRbUORZrOmHSVzP0KR+TSZE0TMNrwxUwjSYZoyWCfZ1wQ==
+"@sentry/utils@7.30.0":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.30.0.tgz#1d83145399c65e31f725c1b6ae02f451a990f326"
+  integrity sha512-tSlBhr5u/LdE2emxIDTDmjmyRr99GnZGIAh5GwRxUgeDQ3VEfNUFlyFodBCbZ6yeYTYd6PWNih5xoHn1+Rf3Sw==
   dependencies:
-    "@sentry/types" "7.3.1"
+    "@sentry/types" "7.30.0"
     tslib "^1.9.3"
 
 "@sentry/utils@7.36.0":
@@ -7182,7 +7175,7 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.2.2:
+deepmerge@4.2.2, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -12689,9 +12682,9 @@ node-fetch@^1.0.1:
     is-stream "^1.0.1"
 
 node-fetch@^2.6.1, node-fetch@^2.6.7:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
-  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
It closes #1101 

as result, we have a more useful interface and can start to use tags etc. Will be in the next tasks

<img width="529" alt="Screenshot 2023-01-30 at 21 57 10" src="https://user-images.githubusercontent.com/54288612/215651470-c30f7eec-fe30-4c4b-aa50-6f79ed0610d6.png">
