### PR TITLE
Show correct order and timestamp in reward logs on Smesher screen

### DIFF
--- a/app/components/node/SmesherLog.tsx
+++ b/app/components/node/SmesherLog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import ReactTimeago from 'react-timeago';
-import { formatSmidge } from '../../infra/utils';
+import { formatSmidge, getFormattedTimestamp } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { SmallHorizontalPanel } from '../../basicComponents';
 import { horizontalPanelBlack } from '../../assets/images';
@@ -212,7 +212,11 @@ const SmesherLog = ({
                       <LayerReward>
                         <LayerNumber>{reward.layer}</LayerNumber>
                         <DateText>
-                          <ReactTimeago date={timestampByLayer(reward.layer)} />
+                          <ReactTimeago
+                            date={getFormattedTimestamp(
+                              timestampByLayer(reward.layer)
+                            )}
+                          />
                         </DateText>
                         <AwardText>+{formatSmidge(reward.amount)}</AwardText>
                       </LayerReward>

--- a/desktop/main/sources/smesherInfo.ts
+++ b/desktop/main/sources/smesherInfo.ts
@@ -162,7 +162,8 @@ const syncSmesherInfo = (
       );
     }),
     shareReplay(1),
-    distinctUntilChanged((prev, next) => prev.length === next.length)
+    distinctUntilChanged((prev, next) => prev.length === next.length),
+    map((rewards) => rewards.sort((a, b) => a.layer - b.layer))
   );
 
   const $activationsStream = combineLatest([$coinbase, $managers]).pipe(


### PR DESCRIPTION
It closes #1098 

Also, it fixes the ordering issue shown in this screenshot:
![image](https://user-images.githubusercontent.com/1897530/215840367-5cbdaf86-dc01-4b2d-8360-119f0a2ca659.png)