### PR TITLE
Tweak sign text & wallet screen

### DIFF
--- a/app/basicComponents/DropDown.tsx
+++ b/app/basicComponents/DropDown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styled, { css, useTheme } from 'styled-components';
 import { smColors } from '../vars';
 
@@ -338,9 +338,11 @@ const DropDownItem: React.FC<DropDownItemProps> = ({
 
 type Props<T extends ADataItem> = {
   onClick: ({ index }: { index: number }) => void | Promise<number>;
+  onClose?: () => void;
   data: Partial<T>[];
   selectedItemIndex: number;
   rowHeight?: number | string;
+  isOpened?: boolean;
   isDisabled?: boolean;
   bold?: boolean;
   hideSelectedItem?: boolean;
@@ -354,8 +356,10 @@ const ddItemKey = (index: number, key?: string) =>
 const DropDown = <T extends ADataItem>({
   data,
   onClick,
+  onClose = () => {},
   selectedItemIndex,
   rowHeight = 44,
+  isOpened: _isOpened = false,
   isDisabled = false,
   bold = false,
   hideSelectedItem = false,
@@ -363,12 +367,17 @@ const DropDown = <T extends ADataItem>({
   maxHeight = undefined,
 }: Props<T>) => {
   const theme = useTheme();
-  const [isOpened, setIsOpened] = useState(false);
-  const closeDropdown = () => setIsOpened(false);
+  const [isOpened, setIsOpened] = useState(_isOpened);
+  const closeDropdown = useCallback(() => {
+    setIsOpened(false);
+    onClose();
+  }, [onClose]);
+
   useEffect(() => {
     window.addEventListener('click', closeDropdown);
     return () => window.removeEventListener('click', closeDropdown);
-  }, []);
+  }, [closeDropdown]);
+
   const isDisabledComputed = isDisabled || !data || !data.length;
   const isLightTheme = dark === undefined ? !theme.isDarkMode : dark;
 
@@ -392,7 +401,7 @@ const DropDown = <T extends ADataItem>({
               e.preventDefault();
               e.stopPropagation();
               onClick({ index });
-              setIsOpened(false);
+              closeDropdown();
             }
       }
       height={rowHeight}
@@ -410,7 +419,11 @@ const DropDown = <T extends ADataItem>({
   );
 
   const handleToggle = () => {
-    setIsOpened(!isOpened);
+    if (isOpened) {
+      closeDropdown();
+    } else {
+      setIsOpened(true);
+    }
   };
 
   return (

--- a/app/basicComponents/SubHeader.tsx
+++ b/app/basicComponents/SubHeader.tsx
@@ -5,4 +5,5 @@ export default styled.div`
   line-height: 20px;
   color: ${({ theme: { color } }) => color.primary};
   flex: 0.2;
+  margin-bottom: 1em;
 `;

--- a/app/components/settings/SignMessage.tsx
+++ b/app/components/settings/SignMessage.tsx
@@ -42,6 +42,7 @@ const SignMessage = ({ index, close }: Props) => {
   });
 
   const accounts = useSelector((state: RootState) => state.wallet.accounts);
+  const keychain = useSelector((state: RootState) => state.wallet.keychain);
 
   const signText = async () => {
     const signedMessage = await eventsService.signMessage({
@@ -50,7 +51,15 @@ const SignMessage = ({ index, close }: Props) => {
     });
     copiedTimeout && clearTimeout(copiedTimeout);
     await navigator.clipboard.writeText(
-      `{ "text": "${message}", "signature": "0x${signedMessage}", "address": "${accounts[index].address}" }`
+      JSON.stringify(
+        {
+          text: message,
+          signature: `0x${signedMessage}`,
+          publicKey: `0x${keychain[index].publicKey}`,
+        },
+        null,
+        2
+      )
     );
     copiedTimeout = setTimeout(() => setIsCopied(false), 10000);
     setIsCopied(true);
@@ -80,7 +89,7 @@ const SignMessage = ({ index, close }: Props) => {
         />
         <Button onClick={close} isPrimary={false} text="Cancel" />
       </ButtonsWrapper>
-      <CopiedText>{isCopied ? 'Address copied' : ' '}</CopiedText>
+      <CopiedText>{isCopied ? 'Signed message copied' : ' '}</CopiedText>
     </Modal>
   );
 };

--- a/app/components/settings/SignMessage.tsx
+++ b/app/components/settings/SignMessage.tsx
@@ -7,12 +7,13 @@ import { Input, Button } from '../../basicComponents';
 import { getAbbreviatedAddress } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
+import SubHeader from '../../basicComponents/SubHeader';
 
 const ButtonsWrapper = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin: 30px 0 15px 0;
+  margin: auto 0 15px 0;
 `;
 
 const CopiedText = styled.div`
@@ -22,6 +23,22 @@ const CopiedText = styled.div`
   line-height: 16px;
   height: 20px;
   color: ${smColors.green};
+`;
+
+const ResultWrapper = styled.textarea`
+  width: 100%;
+  height: 95px;
+  color: ${smColors.mediumGray};
+  white-space: pre;
+  overflow: auto;
+  font-size: 12px;
+  line-height: 1.2;
+  padding: 10px 15px 20px 15px;
+  box-sizing: border-box;
+  background: ${smColors.black20Alpha};
+  border: none;
+  outline: none;
+  resize: none;
 `;
 
 const inputStyle = { marginBottom: 20 };
@@ -35,6 +52,7 @@ const SignMessage = ({ index, close }: Props) => {
   let copiedTimeout: any = null;
   const [message, setMessage] = useState('');
   const [isCopied, setIsCopied] = useState(false);
+  const [lastResult, setLastResult] = useState('');
   useEffect(() => {
     return () => {
       clearTimeout(copiedTimeout);
@@ -50,46 +68,52 @@ const SignMessage = ({ index, close }: Props) => {
       accountIndex: index,
     });
     copiedTimeout && clearTimeout(copiedTimeout);
-    await navigator.clipboard.writeText(
-      JSON.stringify(
-        {
-          text: message,
-          signature: `0x${signedMessage}`,
-          publicKey: `0x${keychain[index].publicKey}`,
-        },
-        null,
-        2
-      )
+    const result = JSON.stringify(
+      {
+        text: message,
+        signature: `0x${signedMessage}`,
+        publicKey: `0x${keychain[index].publicKey}`,
+      },
+      null,
+      2
     );
+    setLastResult(result);
+    await navigator.clipboard.writeText(result);
     copiedTimeout = setTimeout(() => setIsCopied(false), 10000);
     setIsCopied(true);
   };
 
   return (
-    <Modal
-      header="SIGN TEXT"
-      subHeader={`sign text with account ${getAbbreviatedAddress(
-        accounts[index].address
-      )}`}
-    >
+    <Modal header="SIGN TEXT" height={400}>
+      <SubHeader>
+        -- <br />
+        sign text with account {getAbbreviatedAddress(accounts[index].address)}
+      </SubHeader>
       <Input
         value={message}
         placeholder="ENTER TEXT TO SIGN"
         onChange={({ value }) => setMessage(value)}
-        maxLength="64"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            signText();
+          } else if (e.key === 'Escape') {
+            close();
+          }
+        }}
         style={inputStyle}
         autofocus
       />
+      {lastResult.length > 0 && <ResultWrapper readOnly value={lastResult} />}
+      <CopiedText>{isCopied ? 'Copied' : ' '}</CopiedText>
       <ButtonsWrapper>
         <Button
           onClick={signText}
-          text="SIGN"
+          text="SIGN & COPY"
           width={150}
           isDisabled={!message}
         />
         <Button onClick={close} isPrimary={false} text="Cancel" />
       </ButtonsWrapper>
-      <CopiedText>{isCopied ? 'Signed message copied' : ' '}</CopiedText>
     </Modal>
   );
 };

--- a/app/components/wallet/AccountsOverview.tsx
+++ b/app/components/wallet/AccountsOverview.tsx
@@ -21,6 +21,7 @@ const AccountDetails = styled.div`
 
 const AccountWrapper = styled.div`
   display: flex;
+  font-size: 14px;
   flex-direction: column;
   align-items: flex-start;
   margin: 5px 0;
@@ -58,8 +59,7 @@ const SwitchAccountButton = styled(AccountActionButton)`
 
 const AccountName = styled(BoldText)`
   font-size: 16px;
-  line-height: 22px;
-  cursor: inherit;
+  line-height: 18px;
 `;
 
 const Footer = styled.div`
@@ -191,7 +191,12 @@ const AccountsOverview = () => {
         <BalanceHeader>BALANCE</BalanceHeader>
         <BalanceWrapper
           isSynced={isSynced}
-          title={isSynced ? 'Your current balance' : 'Last synced balance'}
+          title={[
+            isSynced ? 'Your current balance' : 'Last synced balance',
+            ': ',
+            balance?.currentState?.balance || 0,
+            ' Smidge',
+          ].join('')}
         >
           <BalanceAmount>{value}</BalanceAmount>
           &nbsp;

--- a/app/components/wallet/AccountsOverview.tsx
+++ b/app/components/wallet/AccountsOverview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { setCurrentAccount } from '../../redux/wallet/actions';
@@ -14,7 +14,7 @@ import Address from '../common/Address';
 
 const AccountDetails = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   margin-bottom: 15px;
 `;
 
@@ -22,9 +22,37 @@ const AccountWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  margin: 5px;
+  margin: 5px 0;
   cursor: inherit;
   color: ${({ theme }) => theme.color.contrast};
+`;
+
+const AccountActionButton = styled.button`
+  color: ${smColors.blue};
+
+  cursor: pointer;
+
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  line-height: 22px;
+  background: none;
+  border: none;
+  outline: none;
+  text-decoration: underline;
+  text-align: left;
+
+  padding: 0;
+  margin: 3px 0;
+
+  &:hover {
+    text-decoration: none;
+  }
+`;
+
+const SwitchAccountButton = styled(AccountActionButton)`
+  color: ${smColors.orange};
 `;
 
 const AccountName = styled(BoldText)`
@@ -85,6 +113,7 @@ const AccountsOverview = () => {
     (state: RootState) => state.wallet.currentAccountIndex
   );
   const dispatch = useDispatch();
+  const [isSwitching, setIsSwitching] = useState(false);
 
   const handleSetCurrentAccount = ({ index }: { index: number }) => {
     dispatch(setCurrentAccount(index));
@@ -117,18 +146,36 @@ const AccountsOverview = () => {
       header={meta.displayName}
     >
       <AccountDetails>
-        {accounts.length > 1 ? (
-          <DropDown
-            data={accounts.map((item) => ({
-              label: item.displayName,
-              description: getAbbreviatedAddress(item.address),
-            }))}
-            onClick={handleSetCurrentAccount}
-            selectedItemIndex={currentAccountIndex}
-            rowHeight={55}
+        {isSwitching && (
+          <>
+            <DropDown
+              data={accounts.map((item) => ({
+                label: item.displayName,
+                description: getAbbreviatedAddress(item.address),
+              }))}
+              onClick={handleSetCurrentAccount}
+              onClose={() => setIsSwitching(false)}
+              isOpened
+              selectedItemIndex={currentAccountIndex}
+              rowHeight={55}
+              maxHeight={400}
+            />
+            <div>
+              <SwitchAccountButton onClick={() => setIsSwitching(false)}>
+                cancel
+              </SwitchAccountButton>
+            </div>
+          </>
+        )}
+        {renderAccountRow({ displayName, address })}
+        {accounts.length > 1 && !isSwitching && (
+          <div>
+            <SwitchAccountButton onClick={() => setIsSwitching(true)}>
+              switch account
+            </SwitchAccountButton>
+          </div>
+        )}
           />
-        ) : (
-          renderAccountRow({ displayName, address })
         )}
       </AccountDetails>
       <Footer>

--- a/app/components/wallet/AccountsOverview.tsx
+++ b/app/components/wallet/AccountsOverview.tsx
@@ -158,6 +158,7 @@ const AccountsOverview = () => {
               onClick={handleSetCurrentAccount}
               onClose={() => setIsSwitching(false)}
               isOpened
+              hideHeader
               selectedItemIndex={currentAccountIndex}
               rowHeight={55}
               maxHeight={400}

--- a/app/components/wallet/AccountsOverview.tsx
+++ b/app/components/wallet/AccountsOverview.tsx
@@ -11,6 +11,7 @@ import { getAbbreviatedAddress, parseSmidge } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { RootState } from '../../types';
 import Address from '../common/Address';
+import { SignMessage } from '../settings';
 
 const AccountDetails = styled.div`
   display: flex;
@@ -114,6 +115,7 @@ const AccountsOverview = () => {
   );
   const dispatch = useDispatch();
   const [isSwitching, setIsSwitching] = useState(false);
+  const [isSigning, setIsSigning] = useState(false);
 
   const handleSetCurrentAccount = ({ index }: { index: number }) => {
     dispatch(setCurrentAccount(index));
@@ -175,6 +177,13 @@ const AccountsOverview = () => {
             </SwitchAccountButton>
           </div>
         )}
+        <AccountActionButton onClick={() => setIsSigning(true)}>
+          sign message
+        </AccountActionButton>
+        {isSigning && (
+          <SignMessage
+            index={currentAccountIndex}
+            close={() => setIsSigning(false)}
           />
         )}
       </AccountDetails>

--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -73,13 +73,13 @@ const GreenText = styled(Text)`
 const AccountCmdBtnWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  margin-top: 30px;
+  margin: 1em 0;
 `;
 
 const AccountCmdBtnSeparator = styled.div`
   width: 2px;
   height: 20px;
-  background-color: ${smColors.blue};
+  background-color: ${smColors.mediumGray};
   margin: auto 15px;
 `;
 
@@ -472,6 +472,7 @@ class Settings extends Component<Props, State> {
                           onClick={() =>
                             this.startEditingAccountDisplayName({ index })
                           }
+                          style={{ color: smColors.orange }}
                           text="RENAME"
                         />
                       )}
@@ -480,7 +481,6 @@ class Settings extends Component<Props, State> {
                         onClick={() => this.toggleSignMessageModal({ index })}
                         text="SIGN TEXT"
                       />
-                      <AccountCmdBtnSeparator />
                     </AccountCmdBtnWrapper>
                   }
                   key={account.address}


### PR DESCRIPTION
It closes #1137.

--
It also changes `SignedMessage` format, aka replacing `address` with `publicKey`. Due to:
1. `verify` should be fast as possible, and the extra step of searching for the public key in a spawn transaction does not seem working in the right direction.
2. The address can be generated from publicKey. We can also put both of them if needed.
3. Not sure that this repo is still actual, but now it corresponds to https://github.com/spacemeshos/ed25519-client/blob/master/signed_msg.json

Probably we used `address` instead of `publicKey` in Smapp by mistake.
If we did it specifically by some reason — let me know 🙏 