### PR TITLE
Fix checksum for windows binaries

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -167,6 +167,7 @@ jobs:
         name: Build windows app
         run: yarn package-win
         env:
+          DONT_SIGN_APP: true # Do not sign the development artifacts
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ENV: pr-builds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
       # Run tests and build
 
       - name: Test
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os == 'macos-latest'
         run: yarn test --forceExit
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,11 @@ jobs:
           APPLEIDPASS: ${{ secrets.APPLE_ID_PASS }}
           # TODO: Move notarizing MacOS application to another job, like `sign-win-app`
 
+      # Copy checksum util to release dir
+      - name: Copy checksum tool
+        shell: bash
+        run: cp ./scripts/checksum.js ./release/checksum.js
+
       # Store artifacts for further jobs
       - name: Store artifacts
         uses: actions/upload-artifact@v2
@@ -224,14 +229,15 @@ jobs:
       - name: Copy latest.yml
         run: cp "./release/latest.yml" "./signed/latest.yml"
 
-      - name: Install hex64
-        run: yarn global add hex64
+      - name: Install Node.js, NPM
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '16'
 
       - name: Get new sha512
         id: sha512
         run: |
-          sha=($(shasum -a512 "./signed/Spacemesh Setup ${{ needs.build.outputs.version }}.exe"))
-          echo "::set-output name=value::$($(yarn global bin)/hex64 $sha | cut -c6-)"
+          echo "::set-output name=value::$(node ./release/checksum.js "./signed/Spacemesh Setup ${{ needs.build.outputs.version }}.exe")"
 
       - name: Update latest.yml (sha512)
         uses: endaft/action-yamler@v1.0.9

--- a/scripts/checksum.js
+++ b/scripts/checksum.js
@@ -1,0 +1,65 @@
+#! /usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const  crypto = require('crypto');
+
+(async () => {
+  if (!process.argv[2]) {
+    logError(
+      'Specify path to the file.',
+      'Example:',
+      '  checksum ./my-file',
+      '  checksum /usr/local/my-file'
+    );
+    process.exit(1);
+  }
+
+  const filepath = path.resolve(
+    process.cwd(),
+    process.argv[2]
+  );
+  process.stderr.write(`Hashing ${filepath}\n`);
+  try {
+    const hash = await hashFile(filepath);
+    if (hash) {
+      process.stdout.write(hash);
+      process.stderr.write('\n');
+      process.exit(0);
+    }
+  } catch (err) {
+    logError(
+      `Error: Can not hash the file:`,
+      err?.message && err.message || 'Error: Unknown error'
+    );
+    process.exit(2);
+  }
+})();
+
+function hashFile(file, algorithm = 'sha512', encoding = 'base64', options) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash(algorithm);
+    hash.on('error', reject).setEncoding(encoding);
+    fs.createReadStream(
+      file,
+      Object.assign({}, options, {
+        highWaterMark: 1024 * 1024,
+        /* better to use more memory but hash faster */
+      })
+    )
+      .on('error', reject)
+      .on('end', () => {
+        hash.end();
+        resolve(hash.read());
+      })
+      .pipe(
+        hash,
+        {
+          end: false,
+        }
+      );
+  });
+}
+
+function logError(...args) {
+  process.stderr.write([...args, ''].join('\n'));
+}

--- a/scripts/packagerScript.js
+++ b/scripts/packagerScript.js
@@ -151,6 +151,9 @@ const getBuildOptions = ({ target }) => {
         title: 'Spacemesh'
       },
       win: {
+        ...(process.env.DONT_SIGN_APP ? {} : {
+          publisherName: 'Spacemesh (Unruly Technologies, Inc.)',
+        }),
         target: 'nsis',
       },
       nsis: {


### PR DESCRIPTION
No issue for the checksum bug.
Also, I've added one small commit that fixes #1123 

## Rationale
We're making Extended Validation (EV) Code Signing for Windows binaries, it is not the part of electron-builder pipeline, so we're signing binaries and then calculating new checksum for it and updating `latest.yml`.
I mistakenly used a bit different base64 format, which caused chars `+/` to be represented as `-_` chars.
Then it causes such error:
![image](https://user-images.githubusercontent.com/1897530/218627464-69ffd84f-e6a0-476d-b89e-3590c2a028f2.png)

## Solution
1. I made a simple NodeJS script (`./scripts/checksum.js`)
2. Use it in CI, instead of `shasum` and `hex64`.