### PR TITLE
Fix start Node correctly without `--pprof-server` flag

### DIFF
--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -400,8 +400,9 @@ class NodeManager extends AbstractManager {
       NODE_CONFIG_FILE,
       '-d',
       nodeDataFilesPath,
-      (process.env.PPROF_SERVER || app.commandLine.hasSwitch('pprof-server')) &&
-        '--pprof-server',
+      ...(process.env.PPROF_SERVER || app.commandLine.hasSwitch('pprof-server')
+        ? ['--pprof-server']
+        : []),
     ];
 
     logger.log('startNode', 'spawning node', [nodePath, ...args]);


### PR DESCRIPTION
Made a mistake in #1141 which breaks standard workflow 🙈 