### PR TITLE
Fix hanging closing app and weird on close prompt behaviour

### DIFF
--- a/desktop/main/reactions/handleCloseApp.ts
+++ b/desktop/main/reactions/handleCloseApp.ts
@@ -15,14 +15,14 @@ export default (
   $showWindowOnLoad: Subject<boolean>
 ) =>
   makeSubscription(
-    $quit.pipe(withLatestFrom($mainWindow), withLatestFrom($managers)),
-    ([[event, mw], managers]) => {
+    $quit.pipe(withLatestFrom($mainWindow, $managers, $isAppClosing)),
+    ([event, mw, managers, isAppClosing]) =>
       mw &&
-        promptBeforeClose(
-          mw,
-          managers || {},
-          $isAppClosing,
-          $showWindowOnLoad
-        )(event).catch((err) => logger.error('promptBeforeClose', err));
-    }
+      promptBeforeClose(
+        mw,
+        managers || {},
+        isAppClosing,
+        $isAppClosing,
+        $showWindowOnLoad
+      )(event).catch((err) => logger.error('promptBeforeClose', err))
   );


### PR DESCRIPTION
No issue.

Found in `develop` and other latest branches, also https://github.com/spacemeshos/smapp/pull/1071#issuecomment-1435399603.
On MacOS, but may work for other platforms as well.

Steps to reproduce:
1. Unlock wallet (Local Node mode)
2. Close Smapp (choose CLOSE in prompt)
3. Click on the Spacemesh icon in Dock (on Icon in Tray)
4. You'll see "Shutting down..." modal there
5. On closing this window you'll be prompted to Close or Keep the app again...

It also makes auto-updater behaves weirdly (asking 2-4 times do you want to close or keep).

--
What is fixed:
- On closing Smapp now we're unsubscribing from all GRPC service streams before calling `app.quit()`. It makes the app close faster and more "graceful". No excessive retries and etc.
- For the described scenario in step 5 now User won't be prompted again and the renderer window will just disappear.