### PR TITLE
Fix showing time when smeshing started

### DIFF
--- a/app/infra/eventsService/eventsService.ts
+++ b/app/infra/eventsService/eventsService.ts
@@ -326,11 +326,18 @@ ipcRenderer.on(
     const {
       status: { postSetupState, numLabelsWritten },
     } = request;
-    if (postSetupState === PostSetupState.STATE_COMPLETE) {
+    if (
+      store.getState().smesher.postSetupState !==
+        PostSetupState.STATE_COMPLETE &&
+      postSetupState === PostSetupState.STATE_COMPLETE
+    ) {
       localStorage.setItem(
         'smesherSmeshingTimestamp',
         `${new Date().getTime()}`
       );
+    }
+    if (postSetupState === PostSetupState.STATE_IN_PROGRESS) {
+      localStorage.removeItem('smesherSmeshingTimestamp');
     }
 
     store.dispatch({

--- a/app/redux/smesher/actions.ts
+++ b/app/redux/smesher/actions.ts
@@ -27,8 +27,12 @@ export const startSmeshing = ({
   provider,
   throttle,
   maxFileSize,
-}: SmeshingOpts) => async (dispatch: AppThDispatch): Promise<boolean> => {
+}: SmeshingOpts) => async (
+  dispatch: AppThDispatch,
+  getState: GetState
+): Promise<boolean> => {
   try {
+    const prevDataDir = getState().smesher.dataDir;
     await eventsService.startSmeshing({
       coinbase,
       dataDir,
@@ -38,8 +42,12 @@ export const startSmeshing = ({
       throttle,
     });
 
-    localStorage.setItem('smesherInitTimestamp', `${new Date().getTime()}`);
-    localStorage.removeItem('smesherSmeshingTimestamp');
+    if (prevDataDir !== dataDir) {
+      // Do not drop "start creating PoS data" & "start smeshing" timestamps
+      // in case User changes some settings but keeps the directory.
+      localStorage.setItem('smesherInitTimestamp', `${new Date().getTime()}`);
+      localStorage.removeItem('smesherSmeshingTimestamp');
+    }
 
     dispatch({
       type: STARTED_SMESHING,

--- a/desktop/SmesherService.ts
+++ b/desktop/SmesherService.ts
@@ -7,6 +7,7 @@ import {
   PostSetupState,
   PostSetupStatus,
 } from '../shared/types';
+import { longToNumber } from '../shared/utils';
 import memoDebounce from '../shared/memoDebounce';
 
 import Logger from './logger';
@@ -93,8 +94,9 @@ class SmesherService extends NetServiceFactory<
     handler,
   }: PostSetupOpts & {
     handler: (error: Error, status: Partial<PostSetupStatus>) => void;
-  }) =>
-    this.callService('StartSmeshing', {
+  }) => {
+    this.postDataCreationProgressStream(handler);
+    return this.callService('StartSmeshing', {
       coinbase: { address: coinbase },
       opts: {
         dataDir,
@@ -103,10 +105,8 @@ class SmesherService extends NetServiceFactory<
         computeProviderId,
         throttle,
       },
-    }).then((response) => {
-      this.postDataCreationProgressStream(handler);
-      return response.status;
-    });
+    }).then((response) => response.status);
+  };
 
   activateProgressStream = (
     handler: (error: Error, status: Partial<PostSetupStatus>) => void
@@ -218,9 +218,7 @@ class SmesherService extends NetServiceFactory<
           });
           handler(null, {
             postSetupState: state,
-            numLabelsWritten: numLabelsWritten
-              ? parseInt(numLabelsWritten.toString())
-              : 0,
+            numLabelsWritten: longToNumber(numLabelsWritten),
             opts: opts as PostSetupOpts | null,
           });
           streamError = null;


### PR DESCRIPTION
There is no issue.

But, there were a few small bugs:
1. When you set up smeshing there was a chance to miss some messages from `SmesherService.PostSetupStatusStream`
2. When you click "Modify" and choose the same directory — it clears the stored `smeshingStartedTimestamp`, but since PoS data is already initialized — it also does not update `smeshingStartedTimestamp`. As a consequence, this data was lost.
3. But when you're setting up Smeshing the first time — it will overwrite `smeshingStartedTimestamp` every 30 seconds or so (on each new `PosSetupStatusStream`).

This PR fixes all these three bugs.