### PR TITLE
Fix: validate `discovery` arguments & allow to build unsigned macOS artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To build and pack application:
 ### Arguments
 Smapp can be started with additional arguments:
 - `--discovery` (string)
-  _e.g._ `./Spacemesh --discovery http://localhost:8000/networks.json`
+  _e.g._ `./Spacemesh --discovery=http://localhost:8000/networks.json`
   Specifies custom url to a custom networks list. It makes it possible for Smesher to connect to custom networks.
   Env variable alias: `DISCOVERY_URL`
 - `--pprof-server` (boolean)

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -60,6 +60,17 @@ Bech32.setHRPNetwork(HRP.TestNet);
 
 init();
 
+// Check arguments
+if (
+  app.commandLine.hasSwitch('discovery') &&
+  app.commandLine.getSwitchValue('discovery') === ''
+) {
+  process.stderr.write(
+    'Wrong discovery flag. Use: `spacemesh --discovery=http...`'
+  );
+  process.exit(1);
+}
+
 // Run
 app
   .whenReady()

--- a/scripts/packagerScript.ts
+++ b/scripts/packagerScript.ts
@@ -85,7 +85,8 @@ const getBuildOptions = ({ target }) => {
           path.join(__dirname, '../node/mac/libgpu-setup.dylib'),
           path.join(__dirname, '../node/mac/libMoltenVK.dylib'),
           path.join(__dirname, '../node/mac/libvulkan.1.dylib')
-        ]
+        ],
+        ...(process.env.DONT_SIGN_APP ? { identity: null } : {}),
       },
       dmg: {
         sign: false,


### PR DESCRIPTION
1. Thanks @piersy for discovering the problem with the wrong argument:
    - `spacemesh --discovery http://localhost:8080/networks.json` -- does not work
    - `spacemesh --discovery=http://localhost:8080/networks.json` -- works
    - Now, if the User set the `--discovery` flag it will validate for having some string there. If it is not presented, a most likely argument was specified wrongly, as a consequence there is an empty string in the flag and we're exiting with an error.
    - Also updated README.md

2. After some recent dependency updates it seems `electron-builder` tries to use `CSC_LINK` or Certificate from the keychain and then it fails (since I don't have it on my local machine). To make it possible to build unsigned binaries, I had to specify `identity: null` property to explicitly avoid signing. So now it works again with just `DONT_SIGN_APP=1` env variable ;)