### PR TITLE
deleted doubled option

### DIFF
--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -346,18 +346,6 @@ class Settings extends Component<Props, State> {
                 rowName="Backup wallet"
               />
               <SettingRow
-                upperPartLeft="Restore wallet from backup file or 12 words"
-                isUpperPartLeftText
-                upperPartRight={
-                  <Button
-                    onClick={this.navigateToWalletRestore}
-                    text="RESTORE"
-                    width={180}
-                  />
-                }
-                rowName="Restore wallet"
-              />
-              <SettingRow
                 upperPartLeft="Use at your own risk!"
                 isUpperPartLeftText
                 upperPartRight={


### PR DESCRIPTION
As discussed on Jan 15th on Slack, one of the options should be removed. 
The _Open_  option is more user-friendly so I removed the row with _Restore_ option. 

There was no issue created for that.
