### PR TITLE
deleted _ from the screen name for consistency

### DIFF
--- a/app/screens/auth/Steps.tsx
+++ b/app/screens/auth/Steps.tsx
@@ -4,7 +4,7 @@ import { StepsContainer } from '../../basicComponents';
 export enum Step {
   NEW_WALLET_SETUP = 'NEW WALLET SETUP',
   NEW_WALLET_TYPE = 'NEW WALLET TYPE',
-  PROTECT_WALLET = 'PROTECT_WALLET',
+  PROTECT_WALLET = 'PROTECT WALLET',
   SELECT_NETWORK = 'SELECT NETWORK',
 }
 const STEPS_ORDERED = [


### PR DESCRIPTION
On the Wallet setup screens, there was `PROTECT_WALLET` with an underscore. I just removed it to keep the convention/pattern. 

<img width="325" alt="Screenshot 2023-03-03 at 20 52 30" src="https://user-images.githubusercontent.com/89876259/222813878-5fe59694-3097-4b93-9794-fe9156551817.png">
<img width="325" alt="Screenshot 2023-03-03 at 20 52 57" src="https://user-images.githubusercontent.com/89876259/222813874-ed1e5d8d-bef4-4db4-8b15-ef74987a17a8.png">

