### PR TITLE
remaining tooltip on wallet only

### DIFF
--- a/app/basicComponents/AutocompleteDropdown.tsx
+++ b/app/basicComponents/AutocompleteDropdown.tsx
@@ -176,14 +176,14 @@ const AutocompleteList = styled.div<{
   overflow: auto;
   height: ${({ isOpened }) => (isOpened ? 'unset' : '0')};
   max-height: 214px;
-  z-index: 9;
+  z-index: 11;
   -webkit-box-shadow: 0 2px 3px ${smColors.black30Alpha};
   box-shadow: 0 2px 3px ${smColors.black30Alpha};
   > div {
     padding: 10px;
     font-size: 13px;
     background: ${smColors.white};
-    color: ${smColors.black30Alpha};
+    color: ${smColors.dark75Alpha};
     border-bottom: 1px solid ${smColors.disabledGray};
     cursor: pointer;
     outline: none;

--- a/app/basicComponents/DropDown.tsx
+++ b/app/basicComponents/DropDown.tsx
@@ -52,7 +52,7 @@ const HeaderWrapper = styled.div<{
   isOpened: boolean;
   isDarkMode: boolean;
 }>`
-  z-index: 11;
+  z-index: 10;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -282,12 +282,15 @@ const Network = ({ history }) => {
         {genesisID.length ? renderNetworkDetails() : renderNoNetwork()}
         <FooterWrap>
           {!isWalletMode && (
-            <Link onClick={openLogFile} text="BROWSE LOG FILE" />
+            <>
+              <Link onClick={openLogFile} text="BROWSE LOG FILE" />
+              <Tooltip
+                width={250}
+                text="Locate the go-spacemesh and app log files on your computer"
+              />
+            </>
           )}
-          <Tooltip
-            width={250}
-            text="Locate the go-spacemesh and app log files on your computer"
-          />
+
           {renderActionButton()}
         </FooterWrap>
       </Container>


### PR DESCRIPTION
no issue to link
removed the tooltip regarding browsing for the log file from the Network screen if Smapp in Wallet-Only mode. 

Before:

<img width="1392" alt="Screenshot 2023-03-10 at 23 51 45" src="https://user-images.githubusercontent.com/89876259/224445069-9b16ddb7-1a42-44ae-b459-b787eebe10ff.png">
<img width="1392" alt="Screenshot 2023-03-11 at 00 12 45" src="https://user-images.githubusercontent.com/89876259/224445153-f49de0fb-505e-4ef6-a36e-cd047a1c2a4e.png">

After: 

<img width="1392" alt="Screenshot 2023-03-11 at 00 13 56" src="https://user-images.githubusercontent.com/89876259/224445261-4d663aa2-d4be-436b-9197-54ac2d47f149.png">
<img width="1392" alt="Screenshot 2023-03-11 at 00 12 45" src="https://user-images.githubusercontent.com/89876259/224445153-f49de0fb-505e-4ef6-a36e-cd047a1c2a4e.png">
