### PR TITLE
tooltip on logs files unnecessary on wallet only mode

### DIFF
--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -282,12 +282,15 @@ const Network = ({ history }) => {
         {genesisID.length ? renderNetworkDetails() : renderNoNetwork()}
         <FooterWrap>
           {!isWalletMode && (
-            <Link onClick={openLogFile} text="BROWSE LOG FILE" />
+            <>
+              <Link onClick={openLogFile} text="BROWSE LOG FILE" />
+              <Tooltip
+                width={250}
+                text="Locate the go-spacemesh and app log files on your computer"
+              />
+            </>
           )}
-          <Tooltip
-            width={250}
-            text="Locate the go-spacemesh and app log files on your computer"
-          />
+
           {renderActionButton()}
         </FooterWrap>
       </Container>


### PR DESCRIPTION
no issue to link
removed the tooltip regarding browsing for the log file from the Network screen if Smapp in Wallet-Only mode. 

Before:

<img width="1392" alt="Screenshot 2023-03-10 at 23 51 45" src="https://user-images.githubusercontent.com/89876259/224445069-9b16ddb7-1a42-44ae-b459-b787eebe10ff.png">
<img width="1392" alt="Screenshot 2023-03-11 at 00 12 45" src="https://user-images.githubusercontent.com/89876259/224445153-f49de0fb-505e-4ef6-a36e-cd047a1c2a4e.png">

After: 

<img width="1392" alt="Screenshot 2023-03-11 at 00 13 56" src="https://user-images.githubusercontent.com/89876259/224445261-4d663aa2-d4be-436b-9197-54ac2d47f149.png">
<img width="1392" alt="Screenshot 2023-03-11 at 00 12 45" src="https://user-images.githubusercontent.com/89876259/224445153-f49de0fb-505e-4ef6-a36e-cd047a1c2a4e.png">
