### PR TITLE
Support BIP32 standard in keypair derivation

### DIFF
--- a/desktop/main/bip32-key-derivation.ts
+++ b/desktop/main/bip32-key-derivation.ts
@@ -1,88 +1,25 @@
-import encryptionConst from '../encryptionConst';
-
-const SALT = new TextEncoder().encode(encryptionConst.DEFAULT_SALT);
+import { derive_key } from '@spacemesh/ed25519-bip32';
 
 export default class Bip32KeyDerivation {
   static COIN_TYPE = 540;
 
   static BIP_PROPOSAL = 44;
 
-  static BIP32HardenedKeyStart = 0x80000000;
-
-  static BIP44Purpose = 0x8000002c;
-
-  static BIP44SpaceMeshCoinType = 0x8000021c;
-
-  static getBIP44Account(account: number) {
-    // eslint-disable-next-line no-bitwise
-    return (Bip32KeyDerivation.BIP32HardenedKeyStart | account) >>> 0;
-  }
-
   static createWalletPath(index: number) {
-    return `${Bip32KeyDerivation.BIP_PROPOSAL}'/${Bip32KeyDerivation.COIN_TYPE}'/0'/0'/${index}'`;
+    return `m/${Bip32KeyDerivation.BIP_PROPOSAL}'/${Bip32KeyDerivation.COIN_TYPE}'/0'/0'/${index}'`;
   }
 
   static derivePath = (
     path: string,
     seed: Uint8Array
   ): { secretKey: Uint8Array; publicKey: Uint8Array } => {
-    const segments = path
-      .split('/')
-      .map((v) => v.replaceAll("'", ''))
-      .map((el) => parseInt(el, 10))
-      // convert path int num to not reserved uint for bip32
-      .map((segment, index) => {
-        if (index === 0 && segment === Bip32KeyDerivation.BIP_PROPOSAL) {
-          return Bip32KeyDerivation.BIP44Purpose;
-        }
-
-        if (index === 1 && segment === Bip32KeyDerivation.COIN_TYPE) {
-          return Bip32KeyDerivation.BIP44SpaceMeshCoinType;
-        }
-
-        return Bip32KeyDerivation.getBIP44Account(segment);
-      });
-
-    const lastKeyPair = segments.reduce(
-      (prev, curr) => {
-        const keyPair = Bip32KeyDerivation.newChildKeyPair(curr, prev.seed);
-
-        return {
-          seed: keyPair.secretKey.slice(0, 32),
-          secretKey: keyPair.secretKey,
-          publicKey: keyPair.publicKey,
-        };
-      },
-      {
-        seed,
-        secretKey: new Uint8Array(32),
-        publicKey: new Uint8Array(64),
-      }
-    );
-    return {
-      publicKey: lastKeyPair.publicKey,
-      secretKey: lastKeyPair.secretKey,
-    };
-  };
-
-  private static newChildKeyPair(index: number, seed: Uint8Array) {
-    let publicKey = new Uint8Array(32);
-    let secretKey = new Uint8Array(64);
-
-    const saveKeys = (pk: Uint8Array, sk: Uint8Array) => {
-      if (pk === null || sk === null) {
-        throw new Error('key generation failed');
-      }
-      publicKey = pk;
-      secretKey = sk;
-    };
-
-    // @ts-ignore
-    global.__deriveNewKeyPair(seed, index, SALT, saveKeys);
-
-    return {
+    const p0 = derive_key(seed, path);
+    const secretKey = p0.slice(0, 32);
+    const publicKey = p0.slice(32);
+    const pair = {
       publicKey,
       secretKey,
     };
-  }
+    return pair;
+  };
 }

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "@sentry/react": "^7.36.0",
     "@sentry/tracing": "^7.36.0",
     "@spacemesh/address-wasm": "^0.2.0",
+    "@spacemesh/ed25519-bip32": "^0.1.0",
     "@spacemesh/sm-codec": "^0.4.1",
     "auto-launch": "^5.0.5",
     "bip39": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,6 +2443,11 @@
   resolved "https://registry.yarnpkg.com/@spacemesh/address-wasm/-/address-wasm-0.2.0.tgz#7773efb5013292bd787f02f0b47fa4b4fa128145"
   integrity sha512-Q1ZQq0swhLPrz3WqOF09Umgq6L99k5aNVsa103Ne+doEMmpiSR8puLUBY9yReeqM/70AE8SAGBbvsg9YSCVnAg==
 
+"@spacemesh/ed25519-bip32@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@spacemesh/ed25519-bip32/-/ed25519-bip32-0.1.0.tgz#cbdaaa4c8606ff834a95d0434d49b57a5689ce82"
+  integrity sha512-paXkpc5Vj/XoSPGYtUyoqmc4TOfw735udx+HtIGmxhnCQaW3ar0zFOKm9ACPqsM0BF5AbSea5th3uxRmqFpcag==
+
 "@spacemesh/sm-codec@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@spacemesh/sm-codec/-/sm-codec-0.4.1.tgz#a7c6b5cfbab9a2494749f68a458dc39811076197"


### PR DESCRIPTION
No issue
This PR uses ed25519-dalek-bip32 library for key derivation, wrapped into wasm: https://github.com/spacemeshos/ed25519_bip32_wasm

Due to our wallet file structure (we're storing keypair in the wallet file), it won't affect previously generated addresses.
Not sure, but probably we'd better recommend our Users recreate wallet files from scratch (or use mnemonics), just to have all accounts derived using the newly integrated BIP32 standard.