### PR TITLE
Add tool to easily read secrets from wallet files

### DIFF
--- a/desktop/main/walletFile.ts
+++ b/desktop/main/walletFile.ts
@@ -34,7 +34,6 @@ import {
 } from '../aes-gcm';
 import FileEncryptionService from '../fileEncryptionService'; // TODO: Remove it in next release
 import { isFileExists } from '../utils';
-import { DEFAULT_WALLETS_DIRECTORY } from './constants';
 
 export const WRONG_PASSWORD_MESSAGE = 'Wrong password';
 
@@ -245,9 +244,7 @@ export const listWalletsByPaths = (files: string[]) => {
   );
 };
 
-export const listWalletsInDirectory = async (
-  walletsDir: string = DEFAULT_WALLETS_DIRECTORY
-) => {
+export const listWalletsInDirectory = async (walletsDir: string) => {
   const files = await fs.readdir(walletsDir);
   const regex = new RegExp('(my_wallet_).*.(json)', 'i');
   const walletFiles = files

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "jest",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "debug:tx": "ts-node ./scripts/composeTx.ts"
+    "debug:tx": "ts-node ./scripts/composeTx.ts",
+    "debug:wallet": "ts-node ./scripts/readSecrets.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/composeTx.ts
+++ b/scripts/composeTx.ts
@@ -4,6 +4,7 @@ import prompts from 'prompts';
 
 import { sign } from '../desktop/ed25519';
 import { fromHexString } from '../shared/utils';
+import { SingleSigMethods } from '../shared/templateConsts';
 import { generateGenesisID } from "../desktop/main/Networks";
 
 (async () => {
@@ -55,12 +56,12 @@ import { generateGenesisID } from "../desktop/main/Networks";
       ],
     },
     {
-      type: (_, values) => values.templateAddress === sm.SingleSigTemplate.key && values.method === 1 ? 'text' : null,
+      type: (_, values) => values.templateAddress === sm.SingleSigTemplate.key && values.method === SingleSigMethods.Spend ? 'text' : null,
       name: 'spendDestination',
       message: 'Type the destination address (Bech32)'
     },
     {
-      type: (_, values) => values.templateAddress === sm.SingleSigTemplate.key && values.method === 1 ? 'number' : null,
+      type: (_, values) => values.templateAddress === sm.SingleSigTemplate.key && values.method === SingleSigMethods.Spend ? 'number' : null,
       name: 'spendAmount',
       message: 'Type the amount to send (in Smidge)',
       validate: (val) => val > 0,

--- a/scripts/readSecrets.ts
+++ b/scripts/readSecrets.ts
@@ -1,0 +1,53 @@
+import prompts from 'prompts';
+import fs from 'fs';
+import { decryptWallet } from '../desktop/main/walletFile';
+import { WalletFile } from '../shared/types';
+
+(async () => {
+  console.log('Attention!');
+  console.log('This tool will output secrets in stdout, which might be unsafe');
+  console.log('Use it on your own risk');
+
+  const inputs = await prompts([
+    {
+      type: 'text',
+      name: 'walletpath',
+      message: 'Absolute path to the wallet file',
+      validate: (val) => {
+        try {
+          return fs.statSync(val).isFile()
+        } catch (err) { 
+          return false;
+        }
+      },
+    },
+    {
+      type: 'password',
+      name: 'password',
+      message: 'Type password',
+    }
+  ],
+  {
+    onCancel: () => {
+      console.log('Reading wallet file secrets cancelled');
+      process.exit(0);
+    },
+  });
+
+  try {
+    const wallet = JSON.parse(
+      fs.readFileSync(inputs.walletpath, 'utf-8')
+    ) as WalletFile;
+
+    decryptWallet(wallet.crypto, inputs.password).then(
+      (secrets) => {
+        console.dir(secrets, { depth: null, colors: true });
+        process.exit(0);
+      }
+    );
+  } catch (err) {
+    process.stderr.write('Can not decode wallet file\n');
+    console.error(err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
It adds the `yarn debug:wallet` cli-script, which decodes the wallet file and dumps secrets in stdout.