### PR TITLE
fix: set up local node TCP/UDP port

### DIFF
--- a/app/infra/eventsService/eventsService.ts
+++ b/app/infra/eventsService/eventsService.ts
@@ -226,8 +226,8 @@ class EventsService {
   };
 
   static switchApiProvider = (
-    apiUrl: SocketAddress | null,
-    genesisID: string
+    genesisID: string,
+    apiUrl: SocketAddress | null = null
   ) => ipcRenderer.invoke(ipcConsts.SWITCH_API_PROVIDER, { apiUrl, genesisID });
 
   /** **************************************  WALLET MANAGER  **************************************** */

--- a/app/redux/wallet/actions.ts
+++ b/app/redux/wallet/actions.ts
@@ -168,7 +168,7 @@ export const switchApiProvider = (
   genesisID?: string
 ) => async (dispatch: AppThDispatch, getState: GetState) => {
   const nextGenesisID = genesisID || getGenesisID(getState());
-  await eventsService.switchApiProvider(api, nextGenesisID);
+  await eventsService.switchApiProvider(nextGenesisID, api);
   dispatch({
     type: SET_REMOTE_API,
     payload: {

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -30,7 +30,7 @@ import { pauseSmeshing, resumeSmeshing } from '../../redux/smesher/actions';
 import SubHeader from '../../basicComponents/SubHeader';
 import ErrorMessage from '../../basicComponents/ErrorMessage';
 import { eventsService } from '../../infra/eventsService';
-import { ExternalLinks, LOCAL_NODE_API_URL } from '../../../shared/constants';
+import { ExternalLinks } from '../../../shared/constants';
 import Address, { AddressType } from '../../components/common/Address';
 import { AuthPath, MainPath } from '../../routerPaths';
 import { getGenesisID } from '../../redux/network/selectors';
@@ -526,7 +526,7 @@ const Node = ({ history, location }: Props) => {
   const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
 
   const handleSetupSmesher = () => {
-    eventsService.switchApiProvider(LOCAL_NODE_API_URL, curNet).catch((err) => {
+    eventsService.switchApiProvider(curNet).catch((err) => {
       console.error(err); // eslint-disable-line no-console
       dispatch(setUiError(err));
     });

--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -25,7 +25,7 @@ import { AppThDispatch, RootState } from '../../types';
 import { Modal } from '../../components/common';
 import { Account } from '../../../shared/types';
 import { isWalletOnly } from '../../redux/wallet/selectors';
-import { ExternalLinks, LOCAL_NODE_API_URL } from '../../../shared/constants';
+import { ExternalLinks } from '../../../shared/constants';
 import { goToSwitchNetwork } from '../../routeUtils';
 import { getGenesisID, getNetworkName } from '../../redux/network/selectors';
 import { AuthPath, MainPath, RouterPath } from '../../routerPaths';
@@ -104,7 +104,6 @@ interface Props extends RouteComponentProps {
   rootHash: string;
   build: string;
   version: string;
-  port: string;
   dataPath: string;
   backupTime: string;
   isDarkMode: boolean;
@@ -128,8 +127,6 @@ type State = {
   accountDisplayNames: Array<string>;
   showPasswordModal: boolean;
   passwordModalSubmitAction: ({ password }: { password: string }) => void;
-  changedPort: string;
-  isPortSet: boolean;
   signMessageModalAccountIndex: number;
   showModal: boolean;
 };
@@ -149,8 +146,6 @@ class Settings extends Component<Props, State> {
       accountDisplayNames,
       showPasswordModal: false,
       passwordModalSubmitAction: () => {},
-      changedPort: props.port,
-      isPortSet: false,
       signMessageModalAccountIndex: -1,
       showModal: false,
     };
@@ -180,8 +175,6 @@ class Settings extends Component<Props, State> {
       editedAccountIndex,
       showPasswordModal,
       passwordModalSubmitAction,
-      changedPort,
-      isPortSet,
       signMessageModalAccountIndex,
       showModal,
     } = this.state;
@@ -526,25 +519,6 @@ class Settings extends Component<Props, State> {
                 rowName="Move node data directory (restarts node)"
               />
               <SettingRow
-                upperPartLeft={
-                  isPortSet ? (
-                    <Text>Please restart application to apply changes</Text>
-                  ) : (
-                    <Input
-                      value={changedPort}
-                      onChange={({ value }) =>
-                        this.setState({ changedPort: value })
-                      }
-                      maxLength="10"
-                    />
-                  )
-                }
-                upperPartRight={
-                  <Button onClick={this.setPort} text="SET PORT" width={180} />
-                }
-                rowName="Local node TCP and UDP port number"
-              />
-              <SettingRow
                 upperPartLeft="Delete all wallets, app data and logs"
                 isUpperPartLeftText
                 upperPartRight={
@@ -623,17 +597,6 @@ class Settings extends Component<Props, State> {
     setClientSettingsTheme(index.toString());
     // @ts-ignore
     switchSkin(index.toString());
-  };
-
-  setPort = async () => {
-    const { changedPort } = this.state;
-    const parsedPort = parseInt(changedPort);
-    if (parsedPort && parsedPort > 1024) {
-      await eventsService.setPort({ port: changedPort });
-      this.setState({ isPortSet: true });
-    } else {
-      this.setState({ showModal: true });
-    }
   };
 
   restoreFromMnemonics = () => this.goTo(AuthPath.RecoverFromMnemonics);
@@ -778,7 +741,7 @@ class Settings extends Component<Props, State> {
   switchToLocalNode = () => {
     const { setUiError, switchApiProvider } = this.props;
     // @ts-ignore
-    switchApiProvider(LOCAL_NODE_API_URL).catch((err) => {
+    switchApiProvider().catch((err) => {
       console.error(err); // eslint-disable-line no-console
       setUiError(err);
     });
@@ -805,7 +768,6 @@ const mapStateToProps = (state: RootState) => ({
   rootHash: state.network.rootHash,
   build: state.node.build,
   version: state.node.version,
-  port: state.node.port,
   dataPath: state.node.dataPath,
   backupTime: state.wallet.backupTime,
   isDarkMode: state.ui.isDarkMode,

--- a/desktop/NetServiceFactory.ts
+++ b/desktop/NetServiceFactory.ts
@@ -2,10 +2,10 @@ import path from 'path';
 import * as grpc from '@grpc/grpc-js';
 import { loadSync } from '@grpc/proto-loader';
 import { PublicService, SocketAddress } from '../shared/types';
-import { LOCAL_NODE_API_URL } from '../shared/constants';
 import { debounceShared, delay, isNodeApiEq } from '../shared/utils';
 import Logger from './logger';
 import { MINUTE } from './main/constants';
+import { getLocalNodeConnectionConfig } from './main/utils';
 
 // Types
 type Proto = { spacemesh: { v1: any; [k: string]: any }; [k: string]: any };
@@ -76,7 +76,7 @@ class NetServiceFactory<
 
   createNetService = (
     protoPath: string,
-    apiUrl: SocketAddress | PublicService = LOCAL_NODE_API_URL,
+    apiUrl: SocketAddress | PublicService = getLocalNodeConnectionConfig(),
     serviceName: string
   ) => {
     this.logger?.debug(`createNetService(${serviceName})`, apiUrl);

--- a/desktop/NodeService.ts
+++ b/desktop/NodeService.ts
@@ -8,10 +8,10 @@ import {
   PublicService,
   SocketAddress,
 } from '../shared/types';
-import { LOCAL_NODE_API_URL } from '../shared/constants';
 import { longToNumber } from '../shared/utils';
 import NetServiceFactory from './NetServiceFactory';
 import Logger from './logger';
+import { getLocalNodeConnectionConfig } from './main/utils';
 
 const PROTO_PATH = 'proto/node.proto';
 
@@ -45,7 +45,7 @@ class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
   createService = (apiUrl?: SocketAddress | PublicService) => {
     this.createNetService(
       PROTO_PATH,
-      apiUrl || LOCAL_NODE_API_URL,
+      apiUrl || getLocalNodeConnectionConfig(),
       'NodeService'
     );
   };

--- a/desktop/SmesherService.ts
+++ b/desktop/SmesherService.ts
@@ -8,12 +8,12 @@ import {
   PostSetupStatus,
 } from '../shared/types';
 import memoDebounce from '../shared/memoDebounce';
-import { PRIVATE_NODE_API_URL } from '../shared/constants';
 import { BITS_PER_LABEL } from '../app/types/smesher';
 
 import Logger from './logger';
 import NetServiceFactory, { Service } from './NetServiceFactory';
 import { MINUTE } from './main/constants';
+import { getPrivateNodeConnectionConfig } from './main/utils';
 
 const PROTO_PATH = 'proto/smesher.proto';
 
@@ -45,7 +45,11 @@ class SmesherService extends NetServiceFactory<
   logger = Logger({ className: 'SmesherService' });
 
   createService = () => {
-    this.createNetService(PROTO_PATH, PRIVATE_NODE_API_URL, 'SmesherService');
+    this.createNetService(
+      PROTO_PATH,
+      getPrivateNodeConnectionConfig(),
+      'SmesherService'
+    );
   };
 
   getPostConfig = () =>

--- a/desktop/WalletManager.ts
+++ b/desktop/WalletManager.ts
@@ -13,7 +13,6 @@ import {
   isLocalNodeType,
   isRemoteNodeApi,
   toHexString,
-  toSocketAddress,
 } from '../shared/utils';
 import { Reward__Output } from '../proto/spacemesh/v1/Reward';
 import { isActivation, isNodeError } from '../shared/types/guards';
@@ -27,6 +26,7 @@ import Logger from './logger';
 import { GRPC_QUERY_BATCH_SIZE as BATCH_SIZE } from './main/constants';
 import AbstractManager from './AbstractManager';
 import { sign } from './ed25519';
+import { toSocketAddress } from './main/utils';
 
 const logger = Logger({ className: 'WalletManager' });
 

--- a/desktop/main/Networks.ts
+++ b/desktop/main/Networks.ts
@@ -1,8 +1,9 @@
 import { hash } from '@spacemesh/sm-codec';
 import { app } from 'electron';
 import { Network, NodeConfig, PublicService } from '../../shared/types';
-import { toHexString, toPublicService } from '../../shared/utils';
+import { toHexString } from '../../shared/utils';
 import { fetchJSON, isDevNet } from '../utils';
+import { toPublicService } from './utils';
 
 //
 // Assertions

--- a/desktop/main/Wallet.ts
+++ b/desktop/main/Wallet.ts
@@ -13,10 +13,10 @@ import { stringifySocketAddress } from '../../shared/utils';
 import CryptoService from '../cryptoService';
 import { getISODate } from '../../shared/datetime';
 import { CreateWalletRequest } from '../../shared/ipcMessages';
-import { LOCAL_NODE_API_URL } from '../../shared/constants';
 import StoreService from '../storeService';
 import { DOCUMENTS_DIR, DEFAULT_WALLETS_DIRECTORY } from './constants';
 import { copyWalletFile, listWallets } from './walletFile';
+import { getLocalNodeConnectionConfig } from './utils';
 
 const list = async () => {
   try {
@@ -122,7 +122,7 @@ export const createWallet = async ({
 
   wallet.meta.genesisID = genesisID;
   wallet.meta.remoteApi =
-    apiUrl && apiUrl !== LOCAL_NODE_API_URL
+    apiUrl && apiUrl !== getLocalNodeConnectionConfig()
       ? stringifySocketAddress(apiUrl)
       : '';
   wallet.meta.type = type;

--- a/desktop/main/reactions/handleWalletType.ts
+++ b/desktop/main/reactions/handleWalletType.ts
@@ -1,8 +1,9 @@
 import { combineLatest, Observable, Subject } from 'rxjs';
 import { Wallet } from '../../../shared/types';
-import { isRemoteNodeApi, toSocketAddress } from '../../../shared/utils';
+import { isRemoteNodeApi } from '../../../shared/utils';
 import { Managers } from '../app.types';
 import { makeSubscription } from '../rx.utils';
+import { toSocketAddress } from '../utils';
 
 export default ($wallet: Subject<Wallet>, $managers: Observable<Managers>) =>
   makeSubscription(

--- a/desktop/main/sources/wallet.ipc.ts
+++ b/desktop/main/sources/wallet.ipc.ts
@@ -18,7 +18,6 @@ import {
   withLatestFrom,
 } from 'rxjs';
 import { ipcConsts } from '../../../app/vars';
-import { LOCAL_NODE_API_URL } from '../../../shared/constants';
 import {
   AddContactRequest,
   ChangePasswordRequest,
@@ -63,6 +62,7 @@ import {
   updateWalletMeta,
   WRONG_PASSWORD_MESSAGE,
 } from '../walletFile';
+import { getLocalNodeConnectionConfig } from '../utils';
 
 type WalletData = {
   // path to wallet file
@@ -227,7 +227,10 @@ const handleWalletIpcRequests = (
     //
     handleIPC(
       ipcConsts.SWITCH_API_PROVIDER,
-      ({ apiUrl, genesisID }: SwitchApiRequest) =>
+      ({
+        apiUrl = getLocalNodeConnectionConfig(),
+        genesisID,
+      }: SwitchApiRequest) =>
         of(null).pipe(
           withLatestFrom($wallet, $walletPath),
           map(([_, wallet, path]) => {
@@ -364,7 +367,7 @@ const handleWalletIpcRequests = (
             ...wallet,
             meta: {
               ...wallet.meta,
-              remoteApi: stringifySocketAddress(LOCAL_NODE_API_URL),
+              remoteApi: stringifySocketAddress(getLocalNodeConnectionConfig()),
               type: WalletType.LocalNode,
             },
           },

--- a/desktop/storeService.ts
+++ b/desktop/storeService.ts
@@ -6,6 +6,7 @@ import { Split } from 'ts-toolbelt/out/String/Split';
 import { HexString } from '../shared/types';
 import { USERDATA_DIR } from './main/constants';
 import { ValidSmeshingOpts } from './main/smeshingOpts';
+import { getGrpcPublicPort } from './main/utils';
 
 export interface ConfigStore {
   isAutoStartEnabled: boolean;
@@ -23,7 +24,7 @@ const CONFIG_STORE_DEFAULTS = {
   startNodeOnNextLaunch: false,
   node: {
     dataPath: path.resolve(USERDATA_DIR, 'node-data'),
-    port: '9092',
+    port: getGrpcPublicPort(),
   },
   smeshing: {},
   walletFiles: [],

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,15 +1,4 @@
-import { NodeStatus, SocketAddress, TxState } from './types';
-
-export const LOCAL_NODE_API_URL: SocketAddress = {
-  host: 'localhost',
-  port: '9092',
-  protocol: 'http:',
-};
-
-export const PRIVATE_NODE_API_URL: SocketAddress = {
-  ...LOCAL_NODE_API_URL,
-  port: '9093',
-};
+import { NodeStatus, TxState } from './types';
 
 export const TX_STATE_LABELS: Record<TxState, string> = {
   [TxState.UNSPECIFIED]: 'Unknown state',


### PR DESCRIPTION
It closes #1051 

Settings section with the port number removed.

Example. 

will be available at 127.0.0.1:PORT
```
DISCOVERY_URL=http://127.0.0.1:8000/networks.json GRPC_PUBLIC_PORT=9099 yarn start 
DISCOVERY_URL=http://127.0.0.1:8000/networks.json GRPC_PRIVATE_PORT=9094 yarn start
```