### PR TITLE
Fix default post-dir: add genesis id into default post-dir path (required as a default location of key.bin)

### DIFF
--- a/app/redux/smesher/selectors.ts
+++ b/app/redux/smesher/selectors.ts
@@ -26,11 +26,11 @@ export const isErrorState = (state: RootState) =>
   getPostSetupState(state) === PostSetupState.STATE_ERROR;
 
 export const isSmeshingPaused = (state: RootState) => {
-  const isPausedState =
-    getPostSetupState(state) === PostSetupState.STATE_PAUSED;
+  const posState = getPostSetupState(state);
   const opts = getSmeshingOpts(state);
   return (
-    (isPausedState || !state.smesher.isSmeshingStarted) &&
+    (posState === PostSetupState.STATE_PAUSED ||
+      posState === PostSetupState.STATE_NOT_STARTED) &&
     isValidSmeshingOpts(opts)
   );
 };

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -324,7 +324,9 @@ class NodeManager extends AbstractManager {
     }
 
     // Temporary solution of https://github.com/spacemeshos/smapp/issues/823
-    const CURRENT_DATADIR_PATH = await this.smesherManager.getCurrentDataDir();
+    const CURRENT_DATADIR_PATH = await this.smesherManager.getCurrentDataDir(
+      this.genesisID
+    );
     const CURRENT_KEYBIN_PATH = path.resolve(CURRENT_DATADIR_PATH, 'key.bin');
     const NEXT_KEYBIN_PATH = path.resolve(postSetupOpts.dataDir, 'key.bin');
 

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -349,6 +349,10 @@ class SmesherManager extends AbstractManager {
     error: any,
     status: Partial<PostSetupStatus>
   ) => {
+    if (error) {
+      logger.error('handlePostDataCreationStatusStream', error);
+      return;
+    }
     this.mainWindow.webContents.send(
       ipcConsts.SMESHER_POST_DATA_CREATION_PROGRESS,
       { error, status }

--- a/desktop/main/NodeConfig.ts
+++ b/desktop/main/NodeConfig.ts
@@ -23,8 +23,7 @@ export const loadNodeConfig = async (): Promise<NodeConfig> =>
 const loadSmeshingOpts = async (nodeConfig) => {
   const id = generateGenesisIDFromConfig(nodeConfig);
   const opts = StoreService.get(`smeshing.${id}`);
-  // const opts = (await loadNodeConfig()).smeshing;
-  return safeSmeshingOpts(opts);
+  return safeSmeshingOpts(opts, id);
 };
 
 export const downloadNodeConfig = async (networkConfigUrl: string) => {

--- a/desktop/main/reactions/handleSmesherIpc.ts
+++ b/desktop/main/reactions/handleSmesherIpc.ts
@@ -1,4 +1,4 @@
-import { from, Observable, Subject, switchMap, withLatestFrom } from 'rxjs';
+import { from, Subject, switchMap, withLatestFrom } from 'rxjs';
 import { ipcConsts } from '../../../app/vars';
 import { PostSetupOpts } from '../../../shared/types';
 import { SmeshingSetupState } from '../../NodeManager';
@@ -13,7 +13,7 @@ const startSmeshing = (managers: Managers, opts: PostSetupOpts) =>
 
 export default (
   $managers: Subject<Managers>,
-  $smeshingStarted: Observable<SmeshingSetupState>
+  $smeshingSetupState: Subject<SmeshingSetupState>
 ) => {
   const startSmeshingRequest = fromIPC<PostSetupOpts>(
     ipcConsts.SMESHER_START_SMESHING
@@ -28,7 +28,7 @@ export default (
     } else if (!res) {
       logger.error('NodeManager.startSmeshing not started', err, res);
     } else {
-      $smeshingStarted.next(res);
+      $smeshingSetupState.next(res);
     }
   });
 

--- a/desktop/main/startApp.ts
+++ b/desktop/main/startApp.ts
@@ -208,7 +208,7 @@ const startApp = (): AppStore => {
       $warnings
     ),
     // Handle Start Smeshing request
-    handleSmesherIpc($managers, $smeshingStarted),
+    handleSmesherIpc($managers, $smeshingSetupState),
     // Handle show file
     handleShowFile($currentNetwork),
     // IPC Reactions

--- a/desktop/storeService.ts
+++ b/desktop/storeService.ts
@@ -5,7 +5,7 @@ import { AutoPath } from 'ts-toolbelt/out/Function/AutoPath';
 import { Split } from 'ts-toolbelt/out/String/Split';
 import { HexString } from '../shared/types';
 import { USERDATA_DIR } from './main/constants';
-import { SmeshingOpts } from './main/smeshingOpts';
+import { ValidSmeshingOpts } from './main/smeshingOpts';
 
 export interface ConfigStore {
   isAutoStartEnabled: boolean;
@@ -14,7 +14,7 @@ export interface ConfigStore {
     dataPath: string;
     port: string;
   };
-  smeshing: Record<HexString, SmeshingOpts>;
+  smeshing: Record<HexString, ValidSmeshingOpts>;
   walletFiles: string[];
 }
 

--- a/shared/types/node.ts
+++ b/shared/types/node.ts
@@ -58,10 +58,10 @@ export interface NodeConfig {
     'smeshing-start'?: boolean;
     'smeshing-opts'?: {
       'smeshing-opts-datadir': string;
-      'smeshing-opts-maxfilesize': number;
-      'smeshing-opts-numunits': number;
-      'smeshing-opts-provider': number;
-      'smeshing-opts-throttle': boolean;
+      'smeshing-opts-maxfilesize'?: number;
+      'smeshing-opts-numunits'?: number;
+      'smeshing-opts-provider'?: number;
+      'smeshing-opts-throttle'?: boolean;
     };
   };
   main: {


### PR DESCRIPTION
No issue.

Currently Node panics in case `~/post` already has a stale `key.bin` inside, left from another network.
Currently, it will put it into a subdirectory named with 8 first chars from genesis id.
E.g. `~/post/12345678`