### PR TITLE
Start smeshing without calling GRPC API

### DIFF
--- a/app/redux/smesher/actions.ts
+++ b/app/redux/smesher/actions.ts
@@ -37,10 +37,6 @@ export const startSmeshing = ({
       computeProviderId: provider,
       throttle,
     });
-
-    localStorage.setItem('smesherInitTimestamp', `${new Date().getTime()}`);
-    localStorage.removeItem('smesherSmeshingTimestamp');
-
     dispatch({
       type: STARTED_SMESHING,
       payload: { coinbase, dataDir, numUnits, provider, throttle, maxFileSize },

--- a/app/screens/node/NodeSetup.tsx
+++ b/app/screens/node/NodeSetup.tsx
@@ -2,11 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
-import {
-  deletePosData,
-  pauseSmeshing,
-  startSmeshing,
-} from '../../redux/smesher/actions';
+import { deletePosData, startSmeshing } from '../../redux/smesher/actions';
 import { CorneredContainer, BackButton } from '../../components/common';
 import {
   PoSModifyPostData,
@@ -131,7 +127,9 @@ const NodeSetup = ({ history, location }: Props) => {
   const hasBackButton = location?.state?.modifyPostData || mode !== 1;
 
   const setupAndInitMining = async () => {
-    if (!provider) return; // TODO
+    if (!provider) return;
+    localStorage.setItem('smesherInitTimestamp', `${new Date().getTime()}`);
+    localStorage.removeItem('smesherSmeshingTimestamp');
     const done = await dispatch(
       startSmeshing({
         coinbase: accounts[0].address,
@@ -156,11 +154,6 @@ const NodeSetup = ({ history, location }: Props) => {
     }
   };
 
-  const handleModifyPosData = async () => {
-    await dispatch(pauseSmeshing());
-    handleNextAction();
-  };
-
   const handleDeletePosData = async () => {
     await dispatch(deletePosData());
     history.push('/main/wallet/');
@@ -179,7 +172,7 @@ const NodeSetup = ({ history, location }: Props) => {
       case 0:
         return (
           <PoSModifyPostData
-            modify={handleModifyPosData}
+            modify={handleNextAction}
             deleteData={handleDeletePosData}
           />
         );

--- a/desktop/main/smeshingOpts.ts
+++ b/desktop/main/smeshingOpts.ts
@@ -18,6 +18,7 @@ export type SmeshingOpts = {
     'smeshing-opts-numunits': number;
     'smeshing-opts-provider': number;
     'smeshing-opts-throttle': boolean;
+    'smeshing-opts-compute-batch-size': number;
   };
   'smeshing-start': boolean;
 };
@@ -70,6 +71,15 @@ export const safeSmeshingOpts = (
         ...opts['smeshing-opts'],
         'smeshing-opts-datadir':
           opts['smeshing-opts']['smeshing-opts-datadir'] || defaultPosDir,
+        // Temporary kludge
+        // TODO: Remove it once https://github.com/spacemeshos/go-spacemesh/pull/4293
+        //       will be merged and newer go-spacemesh version will be released
+        /* eslint-disable no-bitwise */
+        'smeshing-opts-compute-batch-size':
+          opts['smeshing-opts']['smeshing-opts-provider'] === 1
+            ? 1 << 10 // Kludge that makes Node behave well with CPU provider
+            : 1 << 22,
+        /* eslint-enable no-bitwise */
       },
       'smeshing-coinbase': coinbase,
     };


### PR DESCRIPTION
No issue.
In short, now Smapp won't call `SmesherService.StartSmeshing` at all.
And it will update the config and restart the Node instead.
