### PR TITLE
Release hotfix 0.3.2

### DIFF
--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -19,6 +19,7 @@ import AbstractManager from './AbstractManager';
 import StoreService from './storeService';
 import { generateGenesisIDFromConfig } from './main/Networks';
 import { safeSmeshingOpts } from './main/smeshingOpts';
+import { DEFAULT_SMESHING_BATCH_SIZE } from './main/constants';
 
 const checkDiskSpace = require('check-disk-space');
 
@@ -272,6 +273,7 @@ class SmesherManager extends AbstractManager {
       throttle,
       maxFileSize,
     } = postSetupOpts;
+    const prevOpts = StoreService.get(`smeshing.${genesisID}`);
     const opts = safeSmeshingOpts(
       {
         'smeshing-coinbase': coinbase,
@@ -281,6 +283,11 @@ class SmesherManager extends AbstractManager {
           'smeshing-opts-numunits': numUnits,
           'smeshing-opts-provider': computeProviderId,
           'smeshing-opts-throttle': throttle,
+          'smeshing-opts-compute-batch-size': R.pathOr(
+            DEFAULT_SMESHING_BATCH_SIZE,
+            ['smeshing-opts', 'smeshing-opts-compute-batch-size'],
+            prevOpts
+          ),
         },
         'smeshing-start': true,
       },

--- a/desktop/main/constants.ts
+++ b/desktop/main/constants.ts
@@ -16,3 +16,9 @@ export const NODE_CONFIG_FILE = path.resolve(USERDATA_DIR, 'node-config.json');
 export const DEFAULT_WALLETS_DIRECTORY = USERDATA_DIR;
 
 export const GRPC_QUERY_BATCH_SIZE = 100;
+
+// Temporary kludge
+// TODO: Remove this contant and places were it used
+//       once https://github.com/spacemeshos/go-spacemesh/pull/4293
+//       will be merged and newer go-spacemesh version will be released
+export const DEFAULT_SMESHING_BATCH_SIZE = 1 << 20; // eslint-disable-line no-bitwise

--- a/desktop/main/smeshingOpts.ts
+++ b/desktop/main/smeshingOpts.ts
@@ -74,12 +74,7 @@ export const safeSmeshingOpts = (
         // Temporary kludge
         // TODO: Remove it once https://github.com/spacemeshos/go-spacemesh/pull/4293
         //       will be merged and newer go-spacemesh version will be released
-        /* eslint-disable no-bitwise */
-        'smeshing-opts-compute-batch-size':
-          opts['smeshing-opts']['smeshing-opts-provider'] === 1
-            ? 1 << 10 // Kludge that makes Node behave well with CPU provider
-            : 1 << 22,
-        /* eslint-enable no-bitwise */
+        'smeshing-opts-compute-batch-size': 1 << 22, // eslint-disable-line no-bitwise
       },
       'smeshing-coinbase': coinbase,
     };

--- a/desktop/main/smeshingOpts.ts
+++ b/desktop/main/smeshingOpts.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import Bech32 from '@spacemesh/address-wasm';
 import { HexString } from '../../shared/types';
 import { fromHexString } from '../../shared/utils';
+import { DEFAULT_SMESHING_BATCH_SIZE } from './constants';
 
 export type NoSmeshingDefaults = {
   'smeshing-opts': {
@@ -71,10 +72,9 @@ export const safeSmeshingOpts = (
         ...opts['smeshing-opts'],
         'smeshing-opts-datadir':
           opts['smeshing-opts']['smeshing-opts-datadir'] || defaultPosDir,
-        // Temporary kludge
-        // TODO: Remove it once https://github.com/spacemeshos/go-spacemesh/pull/4293
-        //       will be merged and newer go-spacemesh version will be released
-        'smeshing-opts-compute-batch-size': 1 << 22, // eslint-disable-line no-bitwise
+        'smeshing-opts-compute-batch-size':
+          opts['smeshing-opts']['smeshing-opts-compute-batch-size'] ||
+          DEFAULT_SMESHING_BATCH_SIZE,
       },
       'smeshing-coinbase': coinbase,
     };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spacemesh_app",
   "productName": "Spacemesh",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Spacemesh",
     "email": "info@spacemesh.io",


### PR DESCRIPTION
It contains changes:
1. Updates kludge for `smeshing-opts-compute-batch-size`. Now it always defaults to `1 << 20`
2. Make it possible to overwrite `smeshing-opts-compute-batch-size` by changing the value in `config.json` (Smapp setting file)

Part of [release process](https://github.com/spacemeshos/smapp/wiki/Release-new-version).