### PR TITLE
fix: hide "modify PoS" action

### DIFF
--- a/app/components/node/PoSModifyPostData.tsx
+++ b/app/components/node/PoSModifyPostData.tsx
@@ -6,7 +6,8 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
-  justify-content: space-around;
+  justify-content: start;
+  margin-top: 50px;
 `;
 const Row = styled.div`
   display: flex;
@@ -38,22 +39,12 @@ const Dots = styled.div`
 `;
 
 type Props = {
-  modify: () => void;
   deleteData: () => void;
 };
 
-const PoSModifyPostData = ({ modify, deleteData }: Props) => (
+const PoSModifyPostData = ({ deleteData }: Props) => (
   <>
     <Wrapper>
-      <Row>
-        <Text>Change your PoS data</Text>
-        <Tooltip
-          width={200}
-          text="Modify the parameters, such as POS directory, allocated memory, or processor."
-        />
-        <Dots>.....................................................</Dots>
-        <Button onClick={modify} text="MODIFY POS" isPrimary={false} />
-      </Row>
       <Row>
         <Text>Stop smeshing and delete PoS data</Text>
         <Tooltip

--- a/app/screens/node/NodeSetup.tsx
+++ b/app/screens/node/NodeSetup.tsx
@@ -170,12 +170,7 @@ const NodeSetup = ({ history, location }: Props) => {
   const renderRightSection = () => {
     switch (mode) {
       case 0:
-        return (
-          <PoSModifyPostData
-            modify={handleNextAction}
-            deleteData={handleDeletePosData}
-          />
-        );
+        return <PoSModifyPostData deleteData={handleDeletePosData} />;
       case 1:
         return (
           <PoSDirectory


### PR DESCRIPTION
No issue
Right now, the modify PoS functionality not working properly.
<img width="1052" alt="Screenshot 2023-04-20 at 15 10 39" src="https://user-images.githubusercontent.com/54288612/233392685-db14de9e-a326-404b-8782-30131f07a7cd.png">
