### PR TITLE
"Open a wallet from a wallet file" screen colors

### DIFF
--- a/app/screens/auth/FileRestore.tsx
+++ b/app/screens/auth/FileRestore.tsx
@@ -15,8 +15,9 @@ import { AuthRouterParams } from './routerParams';
 const DdArea = styled.div`
   display: flex;
   flex: 1;
+  margin-top: 20px;
   margin-bottom: 20px;
-  background-color: ${smColors.restoreGreen};
+  background-color: ${smColors.disabledGray10Alpha};
 `;
 
 const BottomSection = styled.div`

--- a/app/theme/variants/modern.ts
+++ b/app/theme/variants/modern.ts
@@ -185,7 +185,7 @@ export default {
         base: colors.primary100,
         hover: colors.primary90,
         focus: colors.dark,
-        inactive: colors.light140,
+        inactive: colors.dark20,
       },
     },
     secondary: {


### PR DESCRIPTION
The "Open a wallet from a wallet file" screen was not contrasty enough. The colors choice makes it a bit hard to read. I would suggest a bit darker background (+slight change on the inactive primary button): 

Before:
<img width="1392" alt="Screenshot 2023-04-26 at 18 36 05" src="https://user-images.githubusercontent.com/89876259/234670437-5717c02d-8391-4553-915c-36d2b5dba782.png">

After: 
<img width="1442" alt="Screenshot 2023-04-26 at 20 28 18" src="https://user-images.githubusercontent.com/89876259/234670499-a3bc3fdd-55df-4c40-87ed-ce91ad66d807.png">

