### PR TITLE
Add test mode, which runs go-spacemesh in standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Smapp can be started with additional arguments:
   _e.g._ `./Spacemesh --pprof-server`
   It makes Smapp runs go-spacemesh with the `--pprof-server` flag.
   Env variable alias: `PPROF_SERVER`
+- `--test-mode` (boolean)
+  _e.g._ `./Spacemesh --test-mode`
+  It runs Smapp and the Node under the hood in standalone mode, making it much easier to test and debug application.
+  Env variable alias: `TEST_MODE`
 
 To run application in dev mode with same behavior set env variables instead:
 ```

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -24,6 +24,7 @@ import { getDefaultAppContext } from './main/context';
 import Wallet from './main/Wallet';
 import startApp from './main/startApp';
 import { init, captureMainException } from './sentry';
+import { cleanupTmpDir } from './testMode';
 
 // Ensure that we run only single instance of Smapp
 !app.requestSingleInstanceLock() && app.quit();
@@ -63,6 +64,7 @@ app
   .then(() => subscribeIPC(context))
   .then(() => Wallet.subscribe())
   .then(() => {
+    cleanupTmpDir();
     context.state = startApp();
     return context.state;
   })

--- a/desktop/main/Networks.ts
+++ b/desktop/main/Networks.ts
@@ -2,6 +2,7 @@ import { hash } from '@spacemesh/sm-codec';
 import { app } from 'electron';
 import { Network, NodeConfig, PublicService } from '../../shared/types';
 import { toHexString } from '../../shared/utils';
+import { getStandaloneNetwork, isTestMode } from '../testMode';
 import { fetchJSON, isDevNet } from '../utils';
 import { toPublicService } from './utils';
 
@@ -44,9 +45,11 @@ const getDiscoveryUrl = () =>
 
 export const fetchNetworksFromDiscovery = async () => {
   const networks: Network[] = await fetchJSON(getDiscoveryUrl());
-  const result: Network[] = isDevNet()
-    ? [(await getDevNet()) as Network, ...networks]
-    : networks || [];
+  const result: Network[] = [
+    ...(isTestMode() ? ([await getStandaloneNetwork()] as Network[]) : []),
+    ...(isDevNet() ? ([await getDevNet()] as Network[]) : []),
+    ...(networks || []),
+  ];
   return result;
 };
 

--- a/desktop/testMode.ts
+++ b/desktop/testMode.ts
@@ -1,0 +1,70 @@
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { app } from 'electron';
+import { remove } from 'fs-extra';
+
+import pkg from '../package.json';
+import { Network } from '../shared/types';
+import { MINUTE } from './main/constants';
+
+export const STANDALONE_GENESIS_EXTRA = 'standalone';
+
+export const TEST_MODE_GENESIS_TIME = new Date(
+  Date.now() + 2 * MINUTE
+).toISOString();
+
+export const isTestMode = () =>
+  process.env.TEST_MODE || app.commandLine.hasSwitch('test-mode');
+
+export const getStandaloneNetwork = () =>
+  ({
+    netName: 'Standalone Testnet',
+    conf: 'standalone',
+    explorer: '',
+    dash: '',
+    genesisID: TEST_MODE_GENESIS_TIME,
+    grpcAPI: 'http://0.0.0.0:9092',
+    minSmappRelease: `v${pkg.version}`,
+    latestSmappRelease: `v${pkg.version}`,
+  } as Partial<Network>);
+
+export const getTestModeNodeConfig = () => ({
+  api: {
+    'grpc-public-listener': '0.0.0.0:9092',
+    'grpc-private-listener': '0.0.0.0:9093',
+    'grpc-json-listener': '0.0.0.0:9094',
+  },
+  preset: 'standalone',
+  main: {
+    'layer-duration': '6s',
+    'layers-per-epoch': 10,
+    'eligibility-confidence-param': 18,
+    'tick-size': 67000,
+  },
+  genesis: {
+    'genesis-time': TEST_MODE_GENESIS_TIME,
+    'genesis-extra-data': 'standalone',
+  },
+  poet: {
+    'phase-shift': '30s',
+    'cycle-gap': '30s',
+    'grace-period': '10s',
+  },
+  post: {
+    'post-labels-per-unit': 128,
+    'post-max-numunits': 4,
+    'post-k1': 12,
+    'post-k2': 4,
+    'post-k3': 4,
+  },
+});
+
+export const cleanupTmpDir = () => {
+  if (isTestMode()) {
+    const netTmpDir = join(tmpdir(), 'spacemesh');
+    remove(netTmpDir, (err) =>
+      // eslint-disable-next-line no-console
+      console.error('Can not remove temporary directory on start up', err)
+    );
+  }
+};

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -5,6 +5,11 @@ import cs from 'checksum';
 import fetch from 'electron-fetch';
 import { configCodecByFirstChar } from '../shared/utils';
 import { NodeConfig } from '../shared/types';
+import {
+  STANDALONE_GENESIS_EXTRA,
+  getTestModeNodeConfig,
+  isTestMode,
+} from './testMode';
 
 // --------------------------------------------------------
 // ENV modes
@@ -27,9 +32,11 @@ export const fetchJSON = async (url?: string) =>
   url ? fetch(`${url}?no-cache=${Date.now()}`).then((res) => res.json()) : null;
 
 export const fetchNodeConfig = async (url: string): Promise<NodeConfig> =>
-  fetch(`${url}?no-cache=${Date.now()}`)
-    .then((res) => res.text())
-    .then((res) => configCodecByFirstChar(res).parse(res));
+  isTestMode() && url === STANDALONE_GENESIS_EXTRA
+    ? getTestModeNodeConfig()
+    : fetch(`${url}?no-cache=${Date.now()}`)
+        .then((res) => res.text())
+        .then((res) => configCodecByFirstChar(res).parse(res));
 
 export const isNetError = (error: Error) => error.message.startsWith('net::');
 


### PR DESCRIPTION
Now Smapp can run the node in [standalone mode](https://github.com/spacemeshos/go-spacemesh/pull/4495) (against a single-node local network), which makes the testing and development process much easier and quicker.

https://github.com/spacemeshos/smapp/assets/1897530/d931b67f-ad74-453b-8f2b-ba49a58ed8d4

## How to test
There is no released go-spacemesh with the new feature.
So to test a new feature, you will need to replace the go-spacemesh with the more recenter version built from the source (`develop` branch).

## How to use
1. Run Smapp with the env variable or argument:
   - `TEST_MODE=1 yarn start`
   - `./Spacemesh --test-mode`
2. Unlock/create a wallet
3. Choose the "STANDALONE TESTNET" network on the network selection screen
     If you unlock the wallet connected to another network, go to settings and select "Switch network".

❗ **Important note:** The standalone network will have a genesis time as the time Smapp started + 2 minutes. So you need to connect to this STANDALONE TESTNET within this time, or something may go wrong. It should be fixed in the future.

## Out of scope
We'll need to remove the kludge mentioned above and make it possible to connect to a standalone network without specifying any arguments on start-up. But it will require some refactoring.