### PR TITLE
fix: update validation for wallet name, include upper case and spaces for the consistency with default wallet name

### DIFF
--- a/app/components/wallet/AccountsOverview.tsx
+++ b/app/components/wallet/AccountsOverview.tsx
@@ -188,7 +188,7 @@ const AccountsOverview = () => {
       width={290}
       height={'calc(100% - 65px)'}
       header={meta.displayName}
-      headerTooltipName={meta.displayName.length > 10}
+      headerTooltipName={meta.displayName.length > 12}
     >
       <AccountDetails>
         {isSwitching && (

--- a/app/screens/auth/Validation.tsx
+++ b/app/screens/auth/Validation.tsx
@@ -1,17 +1,20 @@
 // eslint-disable-next-line import/prefer-default-export
 export const validationWalletName = (walletName: string) => {
+  // default wallet name
   if (walletName === '') {
     return '';
   }
 
-  const nameCheck = /^([a-z0-9-_])/;
+  const nameCheck = /^([A-Za-z0-9-_ ])+$/;
 
   if (walletName.length > 31) {
     return 'Wallet name must not exceed 31 characters';
   }
 
-  if (!nameCheck.test(walletName) || walletName.toLowerCase() !== walletName) {
-    return 'Must contain only lowercase letters, numbers and _ or -';
+  const isEmpty = walletName.replaceAll(' ', '').length === 0;
+
+  if (!nameCheck.test(walletName) || isEmpty) {
+    return 'Must contain at least latin letter or number, space, _ or -';
   }
 
   return '';

--- a/desktop/main/Wallet.ts
+++ b/desktop/main/Wallet.ts
@@ -17,7 +17,7 @@ import { CreateWalletRequest } from '../../shared/ipcMessages';
 import StoreService from '../storeService';
 import { DOCUMENTS_DIR, DEFAULT_WALLETS_DIRECTORY } from './constants';
 import { copyWalletFile, listWallets } from './walletFile';
-import { getLocalNodeConnectionConfig } from './utils';
+import { getLocalNodeConnectionConfig, getWalletFileName } from './utils';
 
 const list = async () => {
   try {
@@ -132,12 +132,11 @@ export const createWallet = async ({
       ? stringifySocketAddress(apiUrl)
       : '';
   wallet.meta.type = type;
-
-  const WALLET_NAME = wallet.meta.displayName.toLowerCase().replace(' ', '_');
+  const walletName = getWalletFileName(wallet.meta.displayName);
 
   const walletPath = path.resolve(
     DEFAULT_WALLETS_DIRECTORY,
-    `wallet_${WALLET_NAME}_${wallet.meta.created}.json`
+    `wallet_${walletName}_${wallet.meta.created}.json`
   );
   return { path: walletPath, wallet, password };
 };

--- a/desktop/main/utils.ts
+++ b/desktop/main/utils.ts
@@ -114,3 +114,7 @@ export const toPublicService = (
   name: netName,
   ...toSocketAddress(url),
 });
+
+// to lower case and replace spaces with underscores
+export const getWalletFileName = (walletName: string) =>
+  walletName.toLowerCase().replaceAll(/\s/g, '_');

--- a/desktop/main/walletFile.ts
+++ b/desktop/main/walletFile.ts
@@ -36,6 +36,7 @@ import {
 import FileEncryptionService from '../fileEncryptionService'; // TODO: Remove it in next release
 import { isFileExists } from '../utils';
 import { getISODate } from '../../shared/datetime';
+import { getWalletFileName } from './utils';
 
 export const WRONG_PASSWORD_MESSAGE = 'Wrong password';
 
@@ -168,9 +169,11 @@ export const loadWallet = async (
 };
 
 const saveRaw = async (walletPath: string, wallet: WalletFile) => {
-  const filename = `wallet_${wallet.meta.displayName}_${wallet.meta.created}.json`;
+  const walletName = getWalletFileName(wallet.meta.displayName);
+  const filename = `wallet_${walletName}_${wallet.meta.created}.json`;
   const isFileNameUpdate = path.basename(walletPath) !== filename;
   const filepath = path.resolve(path.dirname(walletPath), filename);
+
   try {
     await fs.writeFile(filepath, JSON.stringify(wallet), {
       encoding: 'utf8',


### PR DESCRIPTION
fix: update validation for wallet name, including upper case and spaces for the consistency with default wallet name

The issue with the wallet name if submitting the default one.

Updated validation and added more cases for the upper case and spaces, to be consistent with the default wallet name, right now is possible to create Wallet Name 5, and it will be valid.

<img width="702" alt="Screenshot 2023-06-13 at 13 42 36" src="https://github.com/spacemeshos/smapp/assets/54288612/6d379334-bad1-4e0c-8e31-09eb66513a1f">

record:

https://github.com/spacemeshos/smapp/assets/54288612/cf2ffc40-16b5-41b1-b5f0-48d3a45c8bb2


