### PR TITLE
Add environment info as query string in calls to discovery service

### DIFF
--- a/desktop/envinfo.ts
+++ b/desktop/envinfo.ts
@@ -1,0 +1,28 @@
+import os from 'os';
+import { exec } from 'child_process';
+import pkg from '../package.json';
+import { getNodePath } from './main/binaries';
+
+export const getNodeVersion = () =>
+  new Promise<string>((resolve, reject) =>
+    exec(`${getNodePath()} version`, (err, stdout) => {
+      if (err) return reject(err);
+      if (stdout.length === 0)
+        return reject(
+          new Error('Cannot retrieve a version from go-spacemesh binary')
+        );
+      const plusSignIndex = stdout.indexOf('+');
+      const version =
+        plusSignIndex !== -1 ? stdout.slice(0, plusSignIndex) : stdout;
+      return resolve(version);
+    })
+  );
+
+export const getEnvInfo = async () => ({
+  smapp: `v${pkg.version}`,
+  node: await getNodeVersion(),
+  platform: os.platform(),
+  arch: os.arch(),
+});
+
+export type EnvInfo = ReturnType<typeof getEnvInfo>;

--- a/desktop/envinfo.ts
+++ b/desktop/envinfo.ts
@@ -1,11 +1,11 @@
 import os from 'os';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import pkg from '../package.json';
 import { getNodePath } from './main/binaries';
 
 export const getNodeVersion = () =>
   new Promise<string>((resolve, reject) =>
-    exec(`${getNodePath()} version`, (err, stdout) => {
+    execFile(getNodePath(), ['version'], (err, stdout) => {
       if (err) return reject(err);
       if (stdout.length === 0)
         return reject(

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -28,13 +28,19 @@ export const isDevNet = (
 // Network
 // --------------------------------------------------------
 
+export const patchNoCacheQueryString = (url: string) => {
+  const res = new URL(url);
+  res.searchParams.set('no-cache', Date.now().toString());
+  return res.toString();
+};
+
 export const fetchJSON = async (url?: string) =>
-  url ? fetch(`${url}?no-cache=${Date.now()}`).then((res) => res.json()) : null;
+  url ? fetch(patchNoCacheQueryString(url)).then((res) => res.json()) : null;
 
 export const fetchNodeConfig = async (url: string): Promise<NodeConfig> =>
   isTestMode() && url === STANDALONE_GENESIS_EXTRA
     ? getTestModeNodeConfig()
-    : fetch(`${url}?no-cache=${Date.now()}`)
+    : fetch(patchNoCacheQueryString(url))
         .then((res) => res.text())
         .then((res) => configCodecByFirstChar(res).parse(res));
 

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -10,6 +10,7 @@ import {
   getTestModeNodeConfig,
   isTestMode,
 } from './testMode';
+import { getEnvInfo } from './envinfo';
 
 // --------------------------------------------------------
 // ENV modes
@@ -34,13 +35,24 @@ export const patchNoCacheQueryString = (url: string) => {
   return res.toString();
 };
 
+export const patchQueryString = (
+  url: string,
+  queryParams: Record<string, string>
+) =>
+  Object.entries(queryParams)
+    .reduce((acc, [key, val]) => {
+      acc.searchParams.set(key, val);
+      return acc;
+    }, new URL(url))
+    .toString();
+
 export const fetchJSON = async (url?: string) =>
   url ? fetch(patchNoCacheQueryString(url)).then((res) => res.json()) : null;
 
 export const fetchNodeConfig = async (url: string): Promise<NodeConfig> =>
   isTestMode() && url === STANDALONE_GENESIS_EXTRA
     ? getTestModeNodeConfig()
-    : fetch(patchNoCacheQueryString(url))
+    : fetch(patchQueryString(patchNoCacheQueryString(url), await getEnvInfo()))
         .then((res) => res.text())
         .then((res) => configCodecByFirstChar(res).parse(res));
 


### PR DESCRIPTION
It closes #1297 

The query string looks like this:
`.../config.json?no-cache=1687359541992&smapp=v0.3.10&node=v0.3.9-beta.1&platform=darwin&arch=arm64`

- Platform possible values are `aix`, `darwin`, `freebsd`,`linux`, `openbsd`, `sunos`, and `win32`.
- Arch possible values are `arm`, `arm64`, `ia32`, `mips`, `mipsel`, `ppc`, `ppc64`, `s390`, `s390x`, and `x64`.