### PR TITLE
Fix renaming walletFile and bring tests back into CI

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -140,7 +140,7 @@ jobs:
 
       # Run tests
       - name: yarn test
-        if: matrix.os == 'macos-latest'
+        if: matrix.id == 'macos'
         run: yarn test --forceExit
 
       # Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
 
       # Run tests and build
       - name: Test
-        if: matrix.os == 'macos-latest'
+        if: matrix.image == 'macos-latest'
         run: yarn test --forceExit
 
       - name: Build

--- a/desktop/main/walletFile.ts
+++ b/desktop/main/walletFile.ts
@@ -170,9 +170,13 @@ export const loadWallet = async (
 
 const saveRaw = async (walletPath: string, wallet: WalletFile) => {
   const walletName = getWalletFileName(wallet.meta.displayName);
-  const filename = `wallet_${walletName}_${wallet.meta.created}.json`;
-  const isFileNameUpdate = path.basename(walletPath) !== filename;
-  const filepath = path.resolve(path.dirname(walletPath), filename);
+  const filename = path.basename(walletPath);
+  const stdFilename = `wallet_${walletName}_${wallet.meta.created}.json`;
+  const nextFilename = /^(my_wallet_|wallet_.*_)[\d-TZ.]+\.json$/.test(filename)
+    ? stdFilename
+    : filename;
+  const isFileNameUpdate = nextFilename !== filename;
+  const filepath = path.resolve(path.dirname(walletPath), nextFilename);
 
   try {
     await fs.writeFile(filepath, JSON.stringify(wallet), {

--- a/tests/walletFiles.spec.ts
+++ b/tests/walletFiles.spec.ts
@@ -143,7 +143,8 @@ describe('Save/update wallet file', () => {
   });
   it('saves wallet file', async () => {
     const wallet = await loadWallet(LEGACY_WALLET_PATH, '1');
-    const { filepath } = await saveWallet(outDir, 'password', wallet);
+    const output = path.resolve(outDir, path.basename(LEGACY_WALLET_PATH));
+    const { filepath } = await saveWallet(output, 'password', wallet);
     const result = await loadWallet(filepath, 'password');
 
     expect(result).toStrictEqual(wallet);


### PR DESCRIPTION
No issue.

But I've discovered:
1. That we accidentally turned off running tests in CI. So I've turned it on again.
2. That a couple of tests fail within the renaming feature. 
    The bug is reproducible in Smapp if you will import a wallet file with the custom name — it tries to rename it and fails.
     <img width="1442" alt="Screenshot 2023-06-22 at 22 15 23" src="https://github.com/spacemeshos/smapp/assets/1897530/15488b2f-9669-4622-9518-da01f79a5499">
