### PR TITLE
fix: update smeshing metadata and return empty object if no file exists

### DIFF
--- a/desktop/SmesherMetadataUtils.ts
+++ b/desktop/SmesherMetadataUtils.ts
@@ -47,7 +47,7 @@ export const getSmeshingMetadata = async (
   const isExists = await isFileExists(metadataPath);
 
   if (!isExists) {
-    return null;
+    return {};
   }
 
   const metadata = await readFileAsync(metadataPath, 'utf8');


### PR DESCRIPTION
It closes #1325 
