### PR TITLE
Use `setWindowOpenHandler()` in favor of deprecated `new-window` event

### DIFF
--- a/desktop/main/createWindow.ts
+++ b/desktop/main/createWindow.ts
@@ -27,9 +27,9 @@ export default async () => {
   menuBuilder.buildMenu();
 
   // Open urls in the user's browser
-  mainWindow.webContents.on('new-window', (event, url) => {
-    event.preventDefault();
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url);
+    return { action: 'deny' };
   });
 
   // Load page after initialization complete

--- a/desktop/main/reactions/handleOpenDashboard.ts
+++ b/desktop/main/reactions/handleOpenDashboard.ts
@@ -18,9 +18,9 @@ export default (
     ([_, currentNetwork, mainWindow]) => {
       const browserView = new BrowserView({});
       mainWindow.setBrowserView(browserView);
-      browserView.webContents.on('new-window', (event, url) => {
-        event.preventDefault();
+      browserView.webContents.setWindowOpenHandler(({ url }) => {
         shell.openExternal(url);
+        return { action: 'deny' };
       });
       const contentBounds = mainWindow.getContentBounds();
       browserView.setBounds({


### PR DESCRIPTION
noticed a warning for this one in stderr. the event is removed in electron 22