### PR TITLE
Use proper HRP network defined by node config

### DIFF
--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -41,7 +41,7 @@ StoreService.init();
 const context = getDefaultAppContext();
 
 // TODO: Set HRP Network by retrieving it from some config?
-Bech32.setHRPNetwork(HRP.TestNet);
+Bech32.setHRPNetwork(HRP.MainNet);
 
 init();
 

--- a/desktop/main/reactions/syncToRenderer.ts
+++ b/desktop/main/reactions/syncToRenderer.ts
@@ -164,13 +164,14 @@ export default (
   $nodeVersion: Observable<NodeVersionAndBuild>,
   $smesherId: Observable<string>,
   $activations: Observable<Activation[]>,
-  $rewards: Observable<Reward[]>
+  $rewards: Observable<Reward[]>,
+  $hrp: Observable<string>
 ) =>
   sync(
     // Sync to
     $mainWindow,
     // Views
-    walletView($wallet, $walletPath),
+    walletView($wallet, $walletPath, $hrp),
     storeView($storeService),
     networkView($currentNetwork, $nodeConfig),
     $networks.pipe(map(R.objOf('networks'))),

--- a/desktop/main/startApp.ts
+++ b/desktop/main/startApp.ts
@@ -132,8 +132,8 @@ const startApp = (): AppStore => {
   const $networks = new $.BehaviorSubject<Network[]>([]);
   const $nodeConfig = new $.Subject<NodeConfig>();
   const $hrp = $nodeConfig.pipe(
-    $.map((c) => c.main['network-hrp'] ?? HRP.TestNet),
-    $.startWith(HRP.TestNet),
+    $.map((c) => c.main['network-hrp'] ?? HRP.MainNet),
+    $.startWith(HRP.MainNet),
     $.distinctUntilChanged(),
     $.tap((hrp) => Bech32.setHRPNetwork(hrp)),
     $.share()

--- a/desktop/testMode.ts
+++ b/desktop/testMode.ts
@@ -4,7 +4,7 @@ import { app } from 'electron';
 import { remove } from 'fs-extra';
 
 import pkg from '../package.json';
-import { Network } from '../shared/types';
+import { Network, NodeConfig } from '../shared/types';
 import { MINUTE } from './main/constants';
 
 export const STANDALONE_GENESIS_EXTRA = 'standalone';
@@ -28,7 +28,7 @@ export const getStandaloneNetwork = () =>
     latestSmappRelease: `v${pkg.version}`,
   } as Partial<Network>);
 
-export const getTestModeNodeConfig = () => ({
+export const getTestModeNodeConfig = (): NodeConfig => ({
   api: {
     'grpc-public-listener': '0.0.0.0:9092',
     'grpc-private-listener': '0.0.0.0:9093',
@@ -40,6 +40,7 @@ export const getTestModeNodeConfig = () => ({
     'layers-per-epoch': 10,
     'eligibility-confidence-param': 18,
     'tick-size': 67000,
+    'network-hrp': 'stest',
   },
   genesis: {
     'genesis-time': TEST_MODE_GENESIS_TIME,
@@ -53,6 +54,7 @@ export const getTestModeNodeConfig = () => ({
   post: {
     'post-labels-per-unit': 128,
     'post-max-numunits': 4,
+    'post-min-numunits': 1,
     'post-k1': 12,
     'post-k2': 4,
     'post-k3': 4,

--- a/shared/types/node.ts
+++ b/shared/types/node.ts
@@ -74,6 +74,7 @@ export interface NodeConfig {
     'poet-server': Array<string>;
     'genesis-active-size': number;
     'optimistic-filtering-threshold': number;
+    'network-hrp'?: string;
   };
   genesis: {
     'genesis-time': string;

--- a/shared/types/node.ts
+++ b/shared/types/node.ts
@@ -46,11 +46,13 @@ export const isNodeError = (e: any): e is NodeError =>
   typeof e.stackTrace === 'string';
 
 export interface NodeConfig {
-  api: {
-    grpc: string;
+  api?: {
+    'grpc-public-listener': string;
+    'grpc-private-listener': string;
+    [k: string]: any;
   };
-  preset: string;
-  p2p: {
+  preset?: string;
+  p2p?: {
     bootnodes: Array<string>;
   };
   smeshing?: {
@@ -71,10 +73,9 @@ export interface NodeConfig {
   main: {
     'layer-duration': string; // "120s"
     'layers-per-epoch': number;
-    'poet-server': Array<string>;
-    'genesis-active-size': number;
-    'optimistic-filtering-threshold': number;
+    'poet-server'?: Array<string>;
     'network-hrp'?: string;
+    [k: string]: any;
   };
   genesis: {
     'genesis-time': string;
@@ -89,9 +90,9 @@ export interface NodeConfig {
     'post-labels-per-unit': number;
     'post-max-numunits': number;
     'post-min-numunits': number;
-    'post-k1': number;
-    'post-k2': number;
-    'post-k3': number;
-    'post-k2pow-difficulty': bigint | number;
+    'post-k1'?: number;
+    'post-k2'?: number;
+    'post-k3'?: number;
+    'post-k2pow-difficulty'?: bigint | number;
   };
 }


### PR DESCRIPTION
There is no issue, but it is a critical one ☝️ 
Previously we had a hard-coded `stest` as an HRP network.
Very soon we will need to use `sm` in MainNet.

What's added:
- Smapp checks for `main -> network-hrp` property in node-config and set it as HRP network (~~`stest`~~ `sm` by default)
- It will re-calculate and re-render all addresses in case of switching networks

From now Smapp needs to have HRP specified in the node config for testnets:
```
{
  "main": {
    "network-hrp": "stest"
  }
}
```
**Why not GRPC API?**
- Smapp is able to show your past transactions even if Node does not work for some reason.
   So we can't rely on any interaction with the Node.
- Also, we need to know HRP asap to render proper addresses quickly.

### How to test
1. Prepare custom discovery with custom node-config, you can take testnet-05 for example and just set `main.network-hrp` prop
2. Run Smapp with custom discovery and test mode on, like `DISCOVERY=http://localhost:8000/networks.json TEST_MODE=1 yarn start`
3. You will be able to connect to a Standalone network and you will see `stest1...` addresses
4. Switch the network to your custom one — all addresses will be re-rendered using another HRP
