### PR TITLE
Disable ways to switch into Wallet Only mode

### DIFF
--- a/app/screens/auth/WalletConnectionType.tsx
+++ b/app/screens/auth/WalletConnectionType.tsx
@@ -136,11 +136,14 @@ const WalletConnectionType = ({ history, location }: AuthRouterParams) => {
             <RowText>Setup a wallet that uses a public</RowText>
             <RowText>Spacemesh web service</RowText>
           </RowColumn>
-          <Button
-            text="WALLET ONLY"
-            width={150}
-            onClick={handleNextStep(true)}
-          />
+          <div title="Temporarily unavailable">
+            <Button
+              text="WALLET ONLY"
+              width={150}
+              onClick={handleNextStep(true)}
+              isDisabled
+            />
+          </div>
         </RowSecond>
         <BottomPart>
           <Link

--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -278,11 +278,14 @@ class Settings extends Component<Props, State> {
                   rowName="Application mode"
                   upperPartLeft="Local node"
                   upperPartRight={
-                    <Button
-                      onClick={this.switchToRemoteApi}
-                      text="SWITCH TO WALLET ONLY"
-                      width={190}
-                    />
+                    <div title="Temporarily unavailable">
+                      <Button
+                        onClick={this.switchToRemoteApi}
+                        text="SWITCH TO WALLET ONLY"
+                        width={190}
+                        isDisabled
+                      />
+                    </div>
                   }
                 />
               )}


### PR DESCRIPTION
No issue.
It's a temporary solution to turn off this feature since our Infra is not ready yet.

It disabled buttons that switch the wallet into Wallet Only mode in two places:
- in Wallet creation/recovering workflow
- in the Settings page (button "switch to local node" still works in case the wallet is in a wallet-only mode for some reason)

If I miss something — let me know 🙏 