### PR TITLE
Fix: do not ask switch the network twice on unlocking wallet

### DIFF
--- a/app/components/common/Version.tsx
+++ b/app/components/common/Version.tsx
@@ -234,9 +234,10 @@ const CheckForUpdates = () => {
 
   useEffect(() => {
     const handler = () => setCurState(CheckState.NoUpdates);
+    const timer = setTimeout(() => setCurState(CheckState.Idle), 10 * 1000);
     ipcRenderer.on(ipcConsts.AU_NO_UPDATES_AVAILABLE, handler);
-    setTimeout(() => setCurState(CheckState.Idle), 10 * 1000);
     return () => {
+      clearTimeout(timer);
       ipcRenderer.off(ipcConsts.AU_NO_UPDATES_AVAILABLE, handler);
     };
   });

--- a/app/screens/auth/SwitchNetwork.tsx
+++ b/app/screens/auth/SwitchNetwork.tsx
@@ -128,6 +128,10 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
         mnemonic,
       });
     }
+    if (redirect === AuthPath.Unlock) {
+      return history.push(redirect, { withLoader: true });
+    }
+
     return history.push(redirect || AuthPath.Unlock);
   };
 

--- a/app/screens/auth/UnlockWallet.tsx
+++ b/app/screens/auth/UnlockWallet.tsx
@@ -109,7 +109,7 @@ const GrayText = styled.div`
 const UnlockWallet = ({ history, location }: AuthRouterParams) => {
   const [password, setPassword] = useState('');
   const [isWrongPassword, setWrongPassword] = useState(false);
-  const [showLoader, setShowLoader] = useState(false);
+  const [showLoader, setShowLoader] = useState(!!location?.state?.withLoader);
 
   const walletFiles = useSelector(listWalletFiles);
 
@@ -134,11 +134,6 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
       ipcRenderer.off(ipcConsts.WALLET_ACTIVATED, goNext);
     };
   }, [history, location]);
-
-  const nextPage =
-    (location.state?.redirect !== AuthPath.Unlock &&
-      location.state?.redirect) ||
-    MainPath.Wallet;
 
   const getDropDownData = () =>
     walletFiles.length === 0
@@ -171,15 +166,7 @@ const UnlockWallet = ({ history, location }: AuthRouterParams) => {
         unlockWallet(walletFiles[selectedWalletIndex].path, password)
       );
 
-      if (status.success) {
-        if (status.forceNetworkSelection) {
-          setShowLoader(false);
-          history.push(AuthPath.SwitchNetwork, {
-            redirect: nextPage,
-            isWalletOnly: status.isWalletOnly,
-          });
-        }
-      } else {
+      if (!status.success) {
         setShowLoader(false);
         setWrongPassword(true);
       }

--- a/desktop/main/reactions/ensureNetwork.ts
+++ b/desktop/main/reactions/ensureNetwork.ts
@@ -1,5 +1,12 @@
 import { BrowserWindow } from 'electron';
-import { combineLatest, filter, Observable, throttleTime } from 'rxjs';
+import {
+  combineLatest,
+  distinctUntilChanged,
+  filter,
+  Observable,
+  throttleTime,
+} from 'rxjs';
+import { equals } from 'ramda';
 import { ipcConsts } from '../../../app/vars';
 import { Network, Wallet } from '../../../shared/types';
 import { isWalletOnlyType } from '../../../shared/utils';
@@ -26,6 +33,9 @@ export default (
           nets.length > 0
         );
       }),
+      distinctUntilChanged(
+        (prev, next) => prev[0] === next[0] && equals(prev[1], next[1])
+      ),
       throttleTime(1000)
     ),
     ([wallet, nets, mw]) => {

--- a/desktop/main/sources/wallet.ipc.ts
+++ b/desktop/main/sources/wallet.ipc.ts
@@ -43,7 +43,6 @@ import Warning, {
 } from '../../../shared/warning';
 import Logger from '../../logger';
 import { SmeshingSetupState } from '../../NodeManager';
-import { hasNetwork } from '../Networks';
 import {
   explodeResult,
   fromIPC,
@@ -54,7 +53,7 @@ import {
   mapResult,
   wrapResult,
 } from '../rx.utils';
-import { createNewAccount, createWallet, isGenesisIDMissing } from '../Wallet';
+import { createNewAccount, createWallet } from '../Wallet';
 import {
   loadAndMigrateWallet,
   loadWallet,
@@ -168,26 +167,10 @@ const handleWalletIpcRequests = (
     handleIPC(
       ipcConsts.W_M_UNLOCK_WALLET,
       ({ path, password }: UnlockWalletRequest) =>
-        loadAndMigrateWallet$(path, password).pipe(
-          withLatestFrom($networks),
-          map(([hr, nets]) =>
-            mapResult(
-              (pair) =>
-                <WalletData>{
-                  ...pair,
-                  meta: {
-                    forceNetworkSelection:
-                      isGenesisIDMissing(pair.wallet) ||
-                      !hasNetwork(pair.wallet.meta.genesisID, nets),
-                  },
-                },
-              hr
-            )
-          )
-        ),
-      ({ wallet, meta }): UnlockWalletResponse['payload'] => ({
+        loadAndMigrateWallet$(path, password),
+      ({ wallet }): UnlockWalletResponse['payload'] => ({
         meta: wallet.meta,
-        forceNetworkSelection: meta?.forceNetworkSelection,
+        forceNetworkSelection: false,
       })
     ),
     //


### PR DESCRIPTION
No issue.
Previously, if the wallet points to nowhere (genesis id is not found in the networks list or is missing), Smapp shows the "Switch network" screen twice on unlocking such a wallet. Currently, it shows it once and then displays the spinner.

Also, it fixes a tiny mistake in <Version /> component: reset the timer on dismounting the component.