### PR TITLE
Fix: update the data on Smesher's screen after logout/login

### DIFF
--- a/app/screens/node/NodeEventsLog.tsx
+++ b/app/screens/node/NodeEventsLog.tsx
@@ -298,6 +298,13 @@ const NodeEventsLog = ({ history }: RouteComponentProps) => {
         <BackButton action={() => history.push(MainPath.Smeshing)} />
         <EventsWrapper ref={setRef(outerRef)}>
           <div ref={setRef(innerRef)}>
+            {items.length === 0 && (
+              <TextWrapper>
+                <EventText style={{ marginLeft: 0 }}>
+                  Node is preparing, please wait...
+                </EventText>
+              </TextWrapper>
+            )}
             {items.map(({ index, measureRef }) => (
               // Use the `measureRef` to measure the item size
               <div key={index} ref={measureRef}>

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -47,6 +47,7 @@ class SmesherManager extends AbstractManager {
     this.adminService = new AdminService();
     this.smesherService = new SmesherService();
     this.smesherService.createService();
+    this.adminService.createService();
     this.genesisID = genesisID;
   }
 

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -386,7 +386,7 @@ class SmesherManager extends AbstractManager {
     );
   };
 
-  isSmeshing = async () => {
+  isSmeshing = async (): Promise<boolean> => {
     const smeshing = (await this.smesherService.isSmeshing()).isSmeshing;
     const status = (await this.smesherService.getPostSetupStatus())
       .postSetupState;

--- a/desktop/main/reactions/syncToRenderer.ts
+++ b/desktop/main/reactions/syncToRenderer.ts
@@ -4,19 +4,22 @@ import {
   buffer,
   combineLatest,
   debounceTime,
+  distinct,
   distinctUntilChanged,
   filter,
   map,
   merge,
   Observable,
   scan,
+  shareReplay,
   skipUntil,
-  startWith,
   Subject,
+  switchMap,
   withLatestFrom,
 } from 'rxjs';
 import parse from 'parse-duration';
 
+import { getEventType } from '../../../shared/utils';
 import { epochByLayer, timestampByLayer } from '../../../shared/layerUtils';
 import {
   Activation,
@@ -154,6 +157,8 @@ const getRewardsInfo = (
   };
 };
 
+const getNodeEventKey = (e: NodeEvent) => `${e.timestamp}_${getEventType(e)}`;
+
 export default (
   $mainWindow: Subject<BrowserWindow>,
   $wallet: Subject<Wallet | null>,
@@ -170,34 +175,60 @@ export default (
   $rewards: Observable<Reward[]>,
   $nodeEvents: Observable<NodeEvent>,
   $hrp: Observable<string>
-) =>
-  sync(
+) => {
+  const $walletOpened = $wallet.pipe(
+    distinctUntilChanged(
+      (a, b) =>
+        !!a?.meta?.genesisID &&
+        !!b?.meta?.genesisID &&
+        a.meta.genesisID === b.meta.genesisID
+    ),
+    filter(Boolean),
+    map(() => {})
+  );
+
+  const $currentNodeConfig = $nodeConfig.pipe(shareReplay(1));
+
+  return sync(
     // Sync to
     $mainWindow,
     // Views
     walletView($wallet, $walletPath, $hrp),
     storeView($storeService),
-    networkView($currentNetwork, $nodeConfig),
+    networkView($currentNetwork, $currentNodeConfig),
     $networks.pipe(map(R.objOf('networks'))),
     $nodeVersion.pipe(map(R.objOf('node'))),
-    $smesherId.pipe(map((smesherId) => ({ smesher: { smesherId } }))),
-    $rewards.pipe(map((rewards) => ({ smesher: { rewards } }))),
-    $activations.pipe(map((activations) => ({ smesher: { activations } }))),
-    $nodeEvents.pipe(
-      scan((acc, next) => [...acc, next].slice(-1000), <NodeEvent[]>[]),
+    $walletOpened.pipe(
+      switchMap(() => $smesherId),
+      map((smesherId) => ({ smesher: { smesherId } }))
+    ),
+    $walletOpened.pipe(
+      switchMap(() => $rewards),
+      map((rewards) => ({ smesher: { rewards } }))
+    ),
+    $walletOpened.pipe(
+      switchMap(() => $activations),
+      map((activations) => ({ smesher: { activations } }))
+    ),
+    $walletOpened.pipe(
+      switchMap(() =>
+        $nodeEvents.pipe(
+          distinct(getNodeEventKey),
+          scan((acc, next) => [...acc, next].slice(-1000), <NodeEvent[]>[]),
+          distinctUntilChanged()
+        )
+      ),
       map((events) => ({ smesher: { events } }))
     ),
-    combineLatest([
-      $rewards.pipe(startWith([])),
-      $nodeConfig,
-      $currentLayer,
-    ]).pipe(
-      map(([rewards, cfg, curLayer]) => ({
-        smesher: {
-          rewardsInfo: getRewardsInfo(cfg, curLayer, rewards),
-        },
-      }))
+    $walletOpened.pipe(
+      switchMap(() =>
+        combineLatest([$rewards, $currentNodeConfig, $currentLayer]).pipe(
+          map(([rewards, cfg, layer]) => getRewardsInfo(cfg, layer, rewards))
+        )
+      ),
+      map((rewardsInfo) => ({ smesher: { rewardsInfo } }))
     ),
     $rootHash.pipe(map((rootHash) => ({ network: { rootHash } }))),
     $currentLayer.pipe(map((currentLayer) => ({ network: { currentLayer } })))
   );
+};


### PR DESCRIPTION
It fixes duplicates reported in #1348.

And moreover, it fixes an old issue with losing the actual state of the Smesher screen. Now it sends the actual data for the Smesher screen again from the main process to the renderer process every time the User unlocks the wallet or changes the network.

### How to test
1. Run Smapp and set up smeshing
2. Observe some rewards and activity log
3. Click the "Log out" button
4. Unlock the wallet once again
5. Observe the same Activity Log and Rewards + it keeps updating over time.