### PR TITLE
Fix: don't restart node every hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Smapp can be started with additional arguments:
   _e.g._ `./Spacemesh --test-mode`
   It runs Smapp and the Node under the hood in standalone mode, making it much easier to test and debug the application.
   Env variable alias: `TEST_MODE`
+- `--check-interval` (number)
+  _e.g._ `./Spacemesh --check-interval=60` to check for updates every 60 seconds
+  Smapp checks every N seconds for the updates the software updates and new config.
+  If new config arrived — it automatically merges it with the custom User settings and
+  restarts the Node.
+  Default: `3600` seconds, or every hour
 
 To run the application in dev mode with the same behavior set env variables instead:
 ```

--- a/desktop/main/sources/fetchDiscovery.ts
+++ b/desktop/main/sources/fetchDiscovery.ts
@@ -25,6 +25,9 @@ import {
 import { handleIPC, handlerResult, makeSubscription } from '../rx.utils';
 import { fetchNodeConfig } from '../../utils';
 import { Managers } from '../app.types';
+import Logger from '../../logger';
+
+const logger = Logger({ className: 'fetchDiscovery' });
 
 export const fromNetworkConfig = (net: Network) =>
   from(fetchNodeConfig(net.conf)).pipe(
@@ -96,6 +99,10 @@ export const listenNodeConfigAndRestartNode = (
           !equals(prevNodeConfig, nextNodeConfig) &&
           managers.node.isNodeRunning()
         ) {
+          logger.log(
+            'listenNodeConfigAndRestartNode',
+            'Node config changed. Restart the Node'
+          );
           await managers.node.restartNode();
         }
       })();

--- a/desktop/main/startApp.ts
+++ b/desktop/main/startApp.ts
@@ -48,7 +48,12 @@ const positiveNum = (def: number, n: number) => (n > 0 ? n : def);
 const CHECK_UPDATES_INTERVAL =
   positiveNum(
     3600, // hour
-    parseInt(app.commandLine.getSwitchValue('checkInterval'), 10)
+    parseInt(
+      process.env.CHECK_INTERVAL ||
+        app.commandLine.getSwitchValue('check-interval') ||
+        '0',
+      10
+    )
   ) * 1000;
 
 const loadNetworkData = () => {


### PR DESCRIPTION
No issue on GH.

### BUG
Smapp restarts the Node every hour when checking for the Node config update.

#### How to test
1. Serve your custom discovery (`networks.json` and `config.json`)
2. Run Smapp with arguments:
    - `--check-interval=60` argument (or `CHECK_INTERVAL=60` env var) to check for updates every 60 seconds
    - `--discovery=http://localhost:8000/networks.json` (or same as `DISCOVERY_URL=...`)
3. Wait a couple of minutes to ensure it is not restarting the Node
4. Change the config served in your custom discovery (you can add any property into json, just keep it valid and keep valid props)
5. Wait for one minute more — your Node will restart and Smapp should continue working
6. Wait for a couple more minutes to ensure it is not restarting the Node

You should be able to reproduce it on `v1.0.3` on any network, just change `--check-interval` to any small amount, because it is one hour by default.