### PR TITLE
fix: send sentry attachments only for Feedback form

### DIFF
--- a/app/sentry.ts
+++ b/app/sentry.ts
@@ -27,11 +27,19 @@ export const init = (history) =>
       }),
     ],
     async beforeSend(event, hint) {
+      const isFeedbackFormMessage = (event?.message || '').includes(
+        'User has submitted an issue and asked to check it.'
+      );
+      if (!isFeedbackFormMessage) {
+        return event;
+      }
+
       const { payload, error } = await eventsService.getNodeAndAppLogs();
 
       if (error) {
         return event;
       }
+
       hint.attachments = [
         {
           filename: `log-genesisID-${payload?.genesisID}-eventId-${

--- a/desktop/sentry.ts
+++ b/desktop/sentry.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/electron/main';
-import { Event, EventHint } from '@sentry/types/types/event';
 import logger from 'electron-log';
 import { generateGenesisIDFromConfig } from './main/Networks';
 import { getNodeLogsPath, readLinesFromBottom } from './main/utils';
@@ -44,26 +43,6 @@ export const init = () =>
     enabled: true,
     maxValueLength: 25000,
     attachStacktrace: true,
-    attachScreenshot: true,
-    async beforeSend(event: Event, hint: EventHint) {
-      const attachmentNodeLog = await addNodeLogFile();
-      const attachmentAppLog = await addAppLogFile();
-      hint.attachments = [
-        {
-          filename: `log-genesisID-${attachmentNodeLog.genesisID}-eventId-${
-            event?.event_id || 0
-          }.txt`,
-          data: attachmentNodeLog.content,
-        },
-        {
-          filename: `appVersion-${attachmentAppLog.fileName}-eventId-${
-            event?.event_id || 0
-          }.txt`,
-          data: attachmentAppLog.content,
-        },
-      ];
-      return event;
-    },
   });
 
 export const captureMainException = (e: Error) => {


### PR DESCRIPTION
1. Allow sending client logs only for the Feedback Form 
2. Upade UI for the user feedback form, it is possible to share a unique id for the request and find it in Sentry
3. Additional integration will be in #1063, there will be added a user path, to better steps to reproduce understanding
4. In additional, it is possible to allow sending logs for other events, by request. Depends on our needs.

### How to test: 
currently, we have an issue with transactions / node events screen in develop branch on which Sentry is generating error event.
1. open smapp in TEST_MODE
2. start smeshing 
3. send transactions 
4. as result , when go to node events / transactions screen, u should not see GET_NODE_AND_APP_LOGS event in terminal
5. only the user feedback form should generate this event GET_NODE_AND_APP_LOGS and attach logs to the event for the Sentry


### Preview of updated modal: 
<img width="621" alt="Screenshot 2023-07-18 at 12 21 52" src="https://github.com/spacemeshos/smapp/assets/54288612/063e793c-3767-4fbc-bd16-dd5d0458f421">
