### PR TITLE
Return back dynamic HRP

### DIFF
--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -12,8 +12,6 @@ import 'json-bigint-patch';
 
 import { app } from 'electron';
 import 'regenerator-runtime/runtime';
-import Bech32 from '@spacemesh/address-wasm';
-import HRP from '../shared/hrp';
 import AutoStartManager from './AutoStartManager';
 import StoreService from './storeService';
 import './wasm_exec';
@@ -39,9 +37,6 @@ StoreService.init();
 
 // State
 const context = getDefaultAppContext();
-
-// TODO: Set HRP Network by retrieving it from some config?
-Bech32.setHRPNetwork(HRP.MainNet);
 
 init();
 

--- a/desktop/main/startApp.ts
+++ b/desktop/main/startApp.ts
@@ -1,5 +1,6 @@
 import * as $ from 'rxjs';
 import { app } from 'electron';
+import Bech32 from '@spacemesh/address-wasm';
 
 import HRP from '../../shared/hrp';
 import {
@@ -136,7 +137,12 @@ const startApp = (): AppStore => {
   const $walletPath = new $.BehaviorSubject<string>('');
   const $networks = new $.BehaviorSubject<Network[]>([]);
   const $nodeConfig = new $.Subject<NodeConfig>();
-  const $hrp = $.of(HRP.MainNet);
+  const $hrp = $nodeConfig.pipe(
+    $.map((c) => c.main['network-hrp'] ?? HRP.MainNet),
+    $.startWith(HRP.MainNet),
+    $.distinctUntilChanged(),
+    $.tap((hrp) => Bech32.setHRPNetwork(hrp))
+  );
   const $warnings = new $.Subject<Warning>();
   const startNodeAfterUpdate = StoreService.get('startNodeOnNextLaunch');
   const $runNodeBeforeLogin = new $.BehaviorSubject<boolean>(


### PR DESCRIPTION
It fixes #1376.

Please, check it out carefully — previously we got some problems in Genesis because of this HRP thingy 🙏 

### Known issue (out of scope)
If you have a slow GPU like mine (M1) and you're initializing PoS data — switching networks may work with some bugs (because of the large compute-batch and long waiting for the Node response).
To avoid these glitches you can pause smeshing.
I've reproduced it on `develop` as well.