### PR TITLE
Display selected proving options on Smesher screen

### DIFF
--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -375,6 +375,9 @@ const Node = ({ history, location }: Props) => {
   const numLabelsWritten = useSelector(
     (state: RootState) => state.smesher.numLabelsWritten
   );
+  const postProvingOpts = useSelector(
+    (state: RootState) => state.smesher.postProvingOpts
+  );
   const isWalletMode = useSelector(isWalletOnly);
   const events = useSelector((state: RootState) => state.smesher.events);
   const lastEvent = events[events.length - 1];
@@ -447,6 +450,10 @@ const Node = ({ history, location }: Props) => {
       ],
       ['Data Size', formatBytes(commitmentSize)],
       ['Max File Size', `${convertBytesToMiB(maxFileSize)} MiB`],
+      [
+        'Proof Generation',
+        `${postProvingOpts.nonces} nonces | ${postProvingOpts.threads} CPU threads`,
+      ],
       [
         'Smesher ID',
         <Address

--- a/app/types/redux.ts
+++ b/app/types/redux.ts
@@ -18,6 +18,7 @@ import {
   RewardsInfo,
   Account,
   NodeEvent,
+  PostProvingOpts,
 } from '../../shared/types';
 import { AnyWarningObject } from '../../shared/warning';
 import { UpdaterState } from '../redux/updater/slice';
@@ -64,6 +65,7 @@ export interface SmesherState {
   commitmentSize: number;
   numLabelsWritten: any;
   postSetupState: PostSetupState;
+  postProvingOpts: PostProvingOpts;
   rewards: Reward[];
   rewardsInfo?: RewardsInfo;
   activations: Activation[];

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -224,7 +224,7 @@ class SmesherManager extends AbstractManager {
         const res = await this.smesherService.stopSmeshing({
           deleteFiles: deleteFiles || false,
         });
-        await this.clearSmesherMetadata();
+        deleteFiles && (await this.clearSmesherMetadata());
 
         await updateSmeshingOpts(
           this.genesisID,

--- a/desktop/main/reactions/syncToRenderer.ts
+++ b/desktop/main/reactions/syncToRenderer.ts
@@ -228,6 +228,25 @@ export default (
       ),
       map((rewardsInfo) => ({ smesher: { rewardsInfo } }))
     ),
+    $walletOpened.pipe(
+      switchMap(() => $currentNodeConfig),
+      map((nodeConfig) => ({
+        smesher: {
+          postProvingOpts: {
+            nonces: R.pathOr(
+              0,
+              ['smeshing-proving-opts', 'smeshing-opts-proving-nonces'],
+              nodeConfig.smeshing
+            ),
+            threads: R.pathOr(
+              0,
+              ['smeshing-proving-opts', 'smeshing-opts-proving-threads'],
+              nodeConfig.smeshing
+            ),
+          },
+        },
+      }))
+    ),
     $rootHash.pipe(map((rootHash) => ({ network: { rootHash } }))),
     $currentLayer.pipe(map((currentLayer) => ({ network: { currentLayer } })))
   );


### PR DESCRIPTION
No issue.

It passes smesher proving opts into the renderer process (redux `smesher.postProvingOpts`) and then displays nonces & threads on the Smesher screen as on the screenshot:

<img width="1442" alt="image" src="https://github.com/spacemeshos/smapp/assets/1897530/e578dcc9-d99d-4787-9446-460933cd0ce2">