### PR TITLE
add update proving opts on the edit page

### DIFF
--- a/app/components/node/PoSModifyPostData.tsx
+++ b/app/components/node/PoSModifyPostData.tsx
@@ -2,8 +2,11 @@ import { RootState } from 'app/types';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
+import { useHistory } from 'react-router';
 import { Tooltip, Button } from '../../basicComponents';
 import { Modal } from '../common';
+import PoSProvingOptsUpdateModal from '../../screens/modal/PoSProvingOptsUpdateModal';
+import { MainPath } from '../../routerPaths';
 
 const Wrapper = styled.div`
   display: flex;
@@ -49,14 +52,15 @@ const StyledRow = styled(Row)`
 
 type Props = {
   deleteData: () => void;
+  isDeleting: boolean;
 };
 
-const PoSModifyPostData = ({ deleteData }: Props) => {
+const PoSModifyPostData = ({ deleteData, isDeleting }: Props) => {
+  const history = useHistory();
   const nodeError = useSelector((state: RootState) => state.node.error);
-  const [showModal, setShowModal] = useState<boolean>(false);
-  const onDeleteClick = () => {
-    setShowModal(true);
-  };
+  const [showDeletePoSModal, setShowDeletePoSModal] = useState<boolean>(false);
+  const [showPoSProfiler, setShowPoSProfiler] = useState<boolean>(false);
+
   return (
     <>
       <Wrapper>
@@ -69,21 +73,48 @@ const PoSModifyPostData = ({ deleteData }: Props) => {
           <Dots>.....................................................</Dots>
           <Button
             isDisabled={!!nodeError}
-            onClick={onDeleteClick}
+            onClick={() => setShowDeletePoSModal(true)}
             text="DELETE DATA"
             isPrimary={false}
           />
-          {showModal && (
+          {showDeletePoSModal && (
             <Modal header="Are you sure you want to delete your POS data?">
               <StyledRow>
                 <Button
                   isPrimary={false}
                   text="CANCEL"
-                  onClick={() => setShowModal(false)}
+                  onClick={() => setShowDeletePoSModal(false)}
                 />
-                <Button text="CONFIRM" onClick={() => deleteData()} />
+                <Button
+                  text={isDeleting ? 'Deleting...' : 'CONFIRM'}
+                  onClick={() => deleteData()}
+                  isDisabled={isDeleting}
+                />
               </StyledRow>
             </Modal>
+          )}
+        </Row>
+        <Row>
+          <Text>Update PoS proving opts</Text>
+          <Tooltip
+            width={200}
+            text={`Allows updating the number of Nonces and CPU threads. 
+          These values will be used in the proving process.`}
+          />
+          <Dots>.....................................................</Dots>
+          <Button
+            isDisabled={!!nodeError}
+            onClick={() => setShowPoSProfiler(true)}
+            text="UPDATE"
+            isPrimary={false}
+          />
+          {showPoSProfiler && (
+            <PoSProvingOptsUpdateModal
+              closeHandler={() => {
+                setShowPoSProfiler(false);
+                history.push(MainPath.Smeshing);
+              }}
+            />
           )}
         </Row>
       </Wrapper>

--- a/app/screens/modal/PoSProvingOptsUpdateModal.tsx
+++ b/app/screens/modal/PoSProvingOptsUpdateModal.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PoSProfiler from '../../components/node/PoSProfiler';
+import { Modal } from '../../components/common';
+
+import useUpdatePostProvingOpts from '../../hooks/useUpdatePostProvingOpts';
+import ReactPortal from './ReactPortal';
+
+interface Props {
+  closeHandler: () => void;
+}
+const PoSProvingOptsUpdateModal = ({ closeHandler }: Props) => {
+  const {
+    updateConfigHandler,
+    numUnits,
+    dataDir,
+    singleCommitmentSize,
+    loading,
+    nonces,
+    threads,
+  } = useUpdatePostProvingOpts(closeHandler);
+
+  return (
+    <ReactPortal modalId="pos-profiler-modal">
+      <Modal
+        header={'Update PoS proving opts'}
+        subHeader={`This screen allows updating the number of Nonces and CPU threads. 
+          These values will be used in the proving process.`}
+        width={750}
+        height={530}
+      >
+        <PoSProfiler
+          nextAction={updateConfigHandler}
+          numUnitSize={singleCommitmentSize}
+          maxUnits={numUnits}
+          dataDir={dataDir}
+          threads={threads}
+          nonces={nonces}
+          posFooterProps={{
+            isDisabled: loading,
+            nextLabel: loading ? ' Updating...' : 'Update',
+            skipLabel: 'Close',
+            skipAction: loading ? undefined : closeHandler,
+          }}
+        />
+      </Modal>
+    </ReactPortal>
+  );
+};
+
+export default PoSProvingOptsUpdateModal;

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -358,6 +358,9 @@ const Node = ({ history, location }: Props) => {
   );
   const currentEpoch = getEpochByLayer(status?.topLayer || 0);
 
+  const postProvingOpts = useSelector(
+    (state: RootState) => state.smesher.postProvingOpts
+  );
   const commitmentSize = useSelector(
     (state: RootState) => state.smesher.commitmentSize
   );
@@ -448,6 +451,10 @@ const Node = ({ history, location }: Props) => {
       ['Data Size', formatBytes(commitmentSize)],
       ['Max File Size', `${convertBytesToMiB(maxFileSize)} MiB`],
       [
+        'Proof Generation',
+        `${postProvingOpts.nonces} nonces | ${postProvingOpts.threads} CPU threads`,
+      ],
+      [
         'Smesher ID',
         <Address
           key="smesherId"
@@ -492,9 +499,13 @@ const Node = ({ history, location }: Props) => {
             <ButtonWrapper>
               <Button
                 isDisabled={!!nodeError}
-                onClick={() =>
-                  history.push(MainPath.SmeshingSetup, { modifyPostData: true })
-                }
+                onClick={() => {
+                  // @TODO find out the reason for the stale state, and get rid of hideSmesherLeftPanel call
+                  dispatch(hideSmesherLeftPanel());
+                  history.push(MainPath.SmeshingSetup, {
+                    modifyPostData: true,
+                  });
+                }}
                 img={posDirectoryWhite}
                 text="EDIT"
                 isPrimary={false}

--- a/app/screens/node/NodeSetup.tsx
+++ b/app/screens/node/NodeSetup.tsx
@@ -108,6 +108,7 @@ const NodeSetup = ({ history, location }: Props) => {
   const [rewardAddress, setRewardAddress] = useState(accounts[0].address);
   const [nonces, setNonces] = useState(16);
   const [threads, setThreads] = useState(1);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const singleCommitmentSize =
     (smesherConfig.bitsPerLabel * smesherConfig.labelsPerUnit) / BITS;
@@ -220,7 +221,9 @@ const NodeSetup = ({ history, location }: Props) => {
   };
 
   const handleDeletePosData = async () => {
+    setIsDeleting(true);
     await dispatch(deletePosData());
+    setIsDeleting(false);
     history.push('/main/wallet/');
   };
 
@@ -235,7 +238,12 @@ const NodeSetup = ({ history, location }: Props) => {
   const renderRightSection = () => {
     switch (mode) {
       case SetupMode.Modify:
-        return <PoSModifyPostData deleteData={handleDeletePosData} />;
+        return (
+          <PoSModifyPostData
+            deleteData={handleDeletePosData}
+            isDeleting={isDeleting}
+          />
+        );
       case SetupMode.Directory:
         return (
           <PoSDirectory


### PR DESCRIPTION
Additional improvement for #1385.
No issue, the additional way how to update proving opts from the Edit screen on the Smesher screen.