### PR TITLE
fix: missed waiting time for `poetWaitProof` event

### DIFF
--- a/app/screens/node/NodeEventActivityRow.tsx
+++ b/app/screens/node/NodeEventActivityRow.tsx
@@ -57,7 +57,7 @@ export default (event: NodeEvent) => {
             : ''
         }`,
         event.timestamp,
-        event.poetWaitRound?.wait
+        event.poetWaitProof?.wait
       );
     }
     case 'postStart':


### PR DESCRIPTION
No issue.
Returns back the time in the event `Wait for the finish of PoET round for epoch N in 2 hours`