### PR TITLE
Prevent caching responses from discovery service

### DIFF
--- a/desktop/main/autoUpdater.ts
+++ b/desktop/main/autoUpdater.ts
@@ -3,14 +3,13 @@ import { unlink } from 'fs/promises';
 import { BrowserWindow, Notification } from 'electron';
 import { ProgressInfo } from 'builder-util-runtime';
 import { autoUpdater, UpdateInfo } from 'electron-updater';
-import fetch from 'electron-fetch';
 import logger from 'electron-log';
 import { SemVer } from 'semver';
 import { Subject } from 'rxjs';
 
 import pkg from '../../package.json';
 import { ipcConsts } from '../../app/vars';
-import { isDev, isNetError } from '../utils';
+import { isDev, isNetError, fetch } from '../utils';
 import { Network } from '../../shared/types';
 import { verifySignature } from '../verifyFileSignature';
 import { GPG_PUBLIC_KEY_URL } from './constants';

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -2,7 +2,7 @@ import util from 'util';
 import fs from 'fs';
 import { F_OK } from 'constants';
 import cs from 'checksum';
-import fetch from 'electron-fetch';
+import electronFetch, { RequestInit } from 'electron-fetch';
 import { configCodecByFirstChar } from '../shared/utils';
 import { NodeConfig } from '../shared/types';
 import {
@@ -40,8 +40,18 @@ export const patchQueryString = (
     }, new URL(url))
     .toString();
 
-export const fetchJSON = async (url?: string) =>
-  url ? fetch(url).then((res) => res.json()) : null;
+export const fetch = async (url: string, options?: RequestInit) =>
+  electronFetch(url, {
+    // Use `https` or `http` modules of NodeJS stdlib
+    // instead of electron's `net` module
+    // to avoid caching on the client
+    useElectronNet: false,
+    // But keep the flexibility
+    ...options,
+  });
+
+export const fetchJSON = async (url: string) =>
+  fetch(url).then((res) => res.json());
 
 export const fetchNodeConfig = async (url: string): Promise<NodeConfig> =>
   isTestMode() && url === STANDALONE_GENESIS_EXTRA


### PR DESCRIPTION
No issue.

But we have found that `electron-fetch` uses `net` module from electron's stdlib.
By default, it behaves as a browser and stores cache on fs (in appdir).

We want to mitigate possible problems with cache and decided to switch to `https` and `http` modules from the node js stdlib. Fortunately `electron-fetch` implements an easy way to switch by changing the `useElectronNet` flag.