### PR TITLE
Fix rewards and balances

### DIFF
--- a/app/screens/node/NodeEventActivityRow.tsx
+++ b/app/screens/node/NodeEventActivityRow.tsx
@@ -70,7 +70,7 @@ export default (event: NodeEvent) => {
       return event?.eligibilities?.eligibilities
         ? `Eligible for rewards in layers ${event.eligibilities.eligibilities
             .map((el) => el.layer)
-            .sort((a,b) => (a||0)-(b||0))
+            .sort((a, b) => (a || 0) - (b || 0))
             .join(', ')}`
         : `Computed eligibilities for the epoch ${
             event.eligibilities?.epoch || ''

--- a/desktop/GlobalStateService.ts
+++ b/desktop/GlobalStateService.ts
@@ -6,11 +6,11 @@ import { AccountDataStreamResponse__Output } from '../proto/spacemesh/v1/Account
 import { Reward__Output } from '../proto/spacemesh/v1/Reward';
 import { TransactionReceipt__Output } from '../proto/spacemesh/v1/TransactionReceipt';
 import { PublicService, SocketAddress } from '../shared/types';
-import { delay, toHexString } from '../shared/utils';
+import { toHexString } from '../shared/utils';
 import { GlobalStateHash } from '../app/types/events';
 import Logger from './logger';
 import NetServiceFactory from './NetServiceFactory';
-import { GRPC_QUERY_BATCH_SIZE, MINUTE } from './main/constants';
+import { GRPC_QUERY_BATCH_SIZE } from './main/constants';
 
 const PROTO_PATH = 'proto/global_state.proto';
 
@@ -125,42 +125,12 @@ class GlobalStateService extends NetServiceFactory<
   listenRewardsByCoinbase = (
     coinbase: string,
     handler: (data: Reward__Output) => void
-  ) => {
-    // TODO: https://github.com/spacemeshos/go-spacemesh/issues/3935
-    // this.activateAccountDataStream(
-    //   coinbase,
-    //   AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD,
-    //   handler
-    // );
-    // Temporary workaround:
-    let counter = 0;
-
-    const doQuery = () => {
-      return this.sendAccountDataQuery({
-        filter: {
-          accountId: { address: coinbase },
-          accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD,
-        },
-        offset: counter,
-      })
-        .then(async (res) => {
-          res.data.forEach((reward) => {
-            counter += 1;
-            handler(reward);
-          });
-          if (res.totalResults > counter) {
-            await delay(100);
-            return doQuery();
-          }
-          return res;
-        })
-        .catch(() => {});
-    };
-
-    doQuery();
-    const ival = setInterval(doQuery, 1 * MINUTE);
-    return () => clearInterval(ival);
-  };
+  ) =>
+    this.activateAccountDataStream(
+      coinbase,
+      AccountDataFlag.ACCOUNT_DATA_FLAG_REWARD,
+      handler
+    );
 }
 
 export default GlobalStateService;

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -206,7 +206,13 @@ class SmesherManager extends AbstractManager {
     this.mainWindow.webContents.send(ipcConsts.SMESHER_METADATA_INFO, {});
   };
 
-  getCoinbase = () => this.smesherService.getCoinbase();
+  getCoinbase = async () => {
+    // return this.smesherService.getCoinbase();
+    // Node returns wrong coinbase when smeshing is paused
+    // To avoid flaky behavior here is a workaround:
+    const config = await this.getSmeshingConfig();
+    return { coinbase: config['smeshing-coinbase'] ?? '' };
+  };
 
   subscribeIPCEvents() {
     // handlers

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -436,11 +436,11 @@ class TransactionManager extends AbstractManager {
     }
   };
 
-  getOldRewards = (coinbase: HexString) =>
+  getStoredRewards = (coinbase: HexString) =>
     this.accountStates[coinbase]?.getRewards() || [];
 
   retrieveNewRewards = async (coinbase: string) => {
-    const oldRewards = this.getOldRewards(coinbase);
+    const oldRewards = this.getStoredRewards(coinbase);
     const newRewards = (await this.retrieveRewards(coinbase, 0)).reduce(
       (acc, reward) => {
         if (!reward || !hasRequiredRewardFields(reward)) return acc;

--- a/desktop/TransactionManager.ts
+++ b/desktop/TransactionManager.ts
@@ -189,7 +189,6 @@ class TransactionManager extends AbstractManager {
         accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_ACCOUNT,
       },
       handler: updateAccountData,
-      retries: 0,
     });
 
     this.unsubs[address].push(
@@ -359,27 +358,20 @@ class TransactionManager extends AbstractManager {
   retrieveAccountData = async <F extends AccountDataValidFlags>({
     filter,
     handler,
-    retries,
   }: {
     filter: {
       accountId: { address: string };
       accountDataFlags: F;
     };
     handler: (data: AccountDataStreamHandlerArg[F]) => void;
-    retries: number;
   }) => {
     const { data, error } = await this.glStateService.sendAccountDataQuery({
       filter,
       offset: 0,
     });
-    if (error && retries < 5) {
-      await this.retrieveAccountData({
-        filter,
-        handler,
-        retries: retries + 1,
-      });
-    } else {
-      data?.length > 0 && handler(data[0]);
+    data?.length > 0 && handler(data[0]);
+    if (error) {
+      this.logger.error('retrieveAccountData', error, filter);
     }
   };
 
@@ -592,7 +584,6 @@ class TransactionManager extends AbstractManager {
           accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_ACCOUNT,
         },
         handler: this.updateAccountData(address),
-        retries: 0,
       });
 
       return { error, tx };
@@ -689,7 +680,6 @@ class TransactionManager extends AbstractManager {
           accountDataFlags: AccountDataFlag.ACCOUNT_DATA_FLAG_ACCOUNT,
         },
         handler: this.updateAccountData(address),
-        retries: 0,
       });
 
       return { error, tx };

--- a/desktop/WalletManager.ts
+++ b/desktop/WalletManager.ts
@@ -230,8 +230,8 @@ class WalletManager extends AbstractManager {
     }
   };
 
-  getOldRewardsByCoinbase = (coinbase: HexString) =>
-    this.txManager.getOldRewards(coinbase);
+  getStoredRewards = (coinbase: HexString) =>
+    this.txManager.getStoredRewards(coinbase);
 
   requestRewardsByCoinbase = async (coinbase: string): Promise<Reward[]> =>
     this.txManager.retrieveNewRewards(coinbase);


### PR DESCRIPTION
It contains a few fixes:
1. It removes the old workaround for the bug in the node. Now it is gone. Should work better, than requesting a new rewards every 1 minute.
2. Also I found that if Smeshing is on pause, then the Node returns the wrong coinbase in response to `SmesherService.Coinbase`
3. And removed excessive retry wrapper on top of requests to AccountDataQuery.