### PR TITLE
Tweak: log fetch requests

### DIFF
--- a/desktop/envModes.ts
+++ b/desktop/envModes.ts
@@ -1,0 +1,13 @@
+// --------------------------------------------------------
+// ENV modes
+// --------------------------------------------------------
+
+export const isProd = () => process.env.NODE_ENV === 'production';
+export const isDev = () => process.env.NODE_ENV === 'development';
+export const isDebug = () => isDev() || !!process.env.DEBUG_PROD;
+
+export const isDevNet = (
+  proc = process
+): proc is NodeJS.Process & {
+  env: { NODE_ENV: 'development'; DEV_NET_URL: string };
+} => proc.env.NODE_ENV === 'development' && !!proc.env.DEV_NET_URL;

--- a/desktop/logger.ts
+++ b/desktop/logger.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import logger from 'electron-log';
-import { isDebug } from './utils';
+import { isDebug } from './envModes';
 import { USERDATA_DIR } from './main/constants';
 
 const formatLogMessage = (className, fn, res, args) =>

--- a/desktop/main.dev.ts
+++ b/desktop/main.dev.ts
@@ -15,7 +15,7 @@ import 'regenerator-runtime/runtime';
 import AutoStartManager from './AutoStartManager';
 import StoreService from './storeService';
 import './wasm_exec';
-import { isDebug, isProd } from './utils';
+import { isDebug, isProd } from './envModes';
 import installDevTools from './main/installDevTools';
 import subscribeIPC from './main/subscribeIPC';
 import { getDefaultAppContext } from './main/context';

--- a/desktop/main/Networks.ts
+++ b/desktop/main/Networks.ts
@@ -3,8 +3,9 @@ import { app } from 'electron';
 import { Network, NodeConfig, PublicService } from '../../shared/types';
 import { toHexString } from '../../shared/utils';
 import { getStandaloneNetwork, isTestMode } from '../testMode';
-import { fetchJSON, isDevNet, patchQueryString } from '../utils';
+import { fetchJSON, patchQueryString } from '../utils';
 import { getEnvInfo } from '../envinfo';
+import { isDevNet } from '../envModes';
 import { toPublicService } from './utils';
 
 //

--- a/desktop/main/autoUpdater.ts
+++ b/desktop/main/autoUpdater.ts
@@ -9,7 +9,8 @@ import { Subject } from 'rxjs';
 
 import pkg from '../../package.json';
 import { ipcConsts } from '../../app/vars';
-import { isDev, isNetError, fetch } from '../utils';
+import { isNetError, fetch } from '../utils';
+import { isDev } from '../envModes';
 import { Network } from '../../shared/types';
 import { verifySignature } from '../verifyFileSignature';
 import { GPG_PUBLIC_KEY_URL } from './constants';

--- a/desktop/main/createWindow.ts
+++ b/desktop/main/createWindow.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { BrowserWindow, shell } from 'electron';
 import MenuBuilder from '../menu';
-import { isDev } from '../utils';
+import { isDev } from '../envModes';
 
 export default async () => {
   const pagePath = `file://${path.resolve(

--- a/desktop/main/installDevTools.ts
+++ b/desktop/main/installDevTools.ts
@@ -2,7 +2,7 @@ import installExtension, {
   REDUX_DEVTOOLS,
   REACT_DEVELOPER_TOOLS,
 } from 'electron-devtools-installer';
-import { isDebug } from '../utils';
+import { isDebug } from '../envModes';
 
 export default async () => {
   if (!isDebug()) return;

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -12,18 +12,6 @@ import {
 } from './testMode';
 import { getEnvInfo } from './envinfo';
 
-// --------------------------------------------------------
-// ENV modes
-// --------------------------------------------------------
-export const isProd = () => process.env.NODE_ENV === 'production';
-export const isDev = () => process.env.NODE_ENV === 'development';
-export const isDebug = () => isDev() || !!process.env.DEBUG_PROD;
-
-export const isDevNet = (
-  proc = process
-): proc is NodeJS.Process & {
-  env: { NODE_ENV: 'development'; DEV_NET_URL: string };
-} => proc.env.NODE_ENV === 'development' && !!proc.env.DEV_NET_URL;
 
 // --------------------------------------------------------
 // Network

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -11,7 +11,9 @@ import {
   isTestMode,
 } from './testMode';
 import { getEnvInfo } from './envinfo';
+import Logger from './logger';
 
+const logger = Logger({ className: 'desktop/utils' });
 
 // --------------------------------------------------------
 // Network
@@ -28,15 +30,23 @@ export const patchQueryString = (
     }, new URL(url))
     .toString();
 
-export const fetch = async (url: string, options?: RequestInit) =>
-  electronFetch(url, {
-    // Use `https` or `http` modules of NodeJS stdlib
-    // instead of electron's `net` module
-    // to avoid caching on the client
-    useElectronNet: false,
-    // But keep the flexibility
-    ...options,
-  });
+export const fetch = async (url: string, options?: RequestInit) => {
+  try {
+    const res = await electronFetch(url, {
+      // Use `https` or `http` modules of NodeJS stdlib
+      // instead of electron's `net` module
+      // to avoid caching on the client
+      useElectronNet: false,
+      // But keep the flexibility
+      ...options,
+    });
+    logger.log('fetch:success', res.status, { url, options });
+    return res;
+  } catch (err) {
+    logger.error('fetch:error', err, { url, options });
+    throw err;
+  }
+};
 
 export const fetchJSON = async (url: string) =>
   fetch(url).then((res) => res.json());

--- a/tests/nodeConfig.spec.ts
+++ b/tests/nodeConfig.spec.ts
@@ -19,6 +19,12 @@ describe('NodeConfig.ts', () => {
     jest.mock('fs/promises');
     jest.mock('fs');
     jest.mock('electron-store');
+    jest.mock('electron-log', () => ({
+      transports: {
+        file: {},
+        console: {},
+      },
+    }));
   });
 
   afterEach(() => {


### PR DESCRIPTION
For better debugging experience we're going to log all fetch requests in app logs, like this:
```
[2023-08-14 17:21:07.148] [info]  desktop/utils, in fetch:success, output: 200 ; args: {"url":"https://smapp.spacemesh.network/networks.json?smapp=v1.0.15&node=v1.0.15&platform=darwin&arch=arm64"}
[2023-08-14 17:21:07.489] [info]  desktop/utils, in fetch:success, output: 200 ; args: {"url":"https://configs.spacemesh.network/config.mainnet.json?smapp=v1.0.15&node=v1.0.15&platform=darwin&arch=arm64"}
[2023-08-14 17:21:14.045] [debug] handleIPC(W_M_UNLOCK_WALLET) got request::   {"path":"/Users/brusher/Library/Application Support/Electron/wallet_wallet_7_2023-08-08T13-44-44.289Z.json","password":"HIDDEN"}
[2023-08-14 17:21:14.138] [debug] handleIPC(W_M_UNLOCK_WALLET) replied::   {"status":0,"payload":{"meta":{"displayName":"Wallet 7","created":"2023-08-08T13-44-44.289Z","genesisID":"7c8cef2bfd54447d60c3ffcc5daf974b24b74605","remoteApi":"","type":"local-node"},"forceNetworkSelection":false},"error":null}
[2023-08-14 17:21:14.274] [info]  desktop/utils, in fetch:success, output: 200 ; args: {"url":"https://configs.spacemesh.network/config.mainnet.json?smapp=v1.0.15&node=v1.0.15&platform=darwin&arch=arm64"}
```