### PR TITLE
Show fatal errors on the network screen

### DIFF
--- a/app/basicComponents/ErrorMessage.tsx
+++ b/app/basicComponents/ErrorMessage.tsx
@@ -3,7 +3,7 @@ import { smColors } from '../vars';
 
 interface ErrorMessageProps {
   align?: 'left' | 'right';
-  oneLine?: boolean;
+  compact?: boolean;
 }
 
 const ErrorMessage = styled.span<ErrorMessageProps>`
@@ -15,13 +15,13 @@ const ErrorMessage = styled.span<ErrorMessageProps>`
   display: -webkit-box;
   overflow: hidden;
   text-align: ${({ align }) => align || 'left'};
-  ${({ oneLine }) =>
-    oneLine && '-webkit-line-clamp: 1; -webkit-box-orient: vertical;'}
+  ${({ compact }) =>
+    compact && '-webkit-line-clamp: 2; -webkit-box-orient: vertical;'}
 `;
 
 ErrorMessage.defaultProps = {
   align: 'left',
-  oneLine: true,
+  compact: false,
 };
 
 export default ErrorMessage;

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -275,7 +275,9 @@ const Network = ({ history }) => {
       <SubHeader>
         {netName}
         {nodeError && (
-          <ErrorMessage>{nodeError.msg || nodeError.stackTrace}</ErrorMessage>
+          <ErrorMessage compact>
+            {nodeError.msg || nodeError.stackTrace}
+          </ErrorMessage>
         )}
       </SubHeader>
       <Container>

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -275,7 +275,7 @@ const Network = ({ history }) => {
       <SubHeader>
         {netName}
         {nodeError && (
-          <ErrorMessage compact>
+          <ErrorMessage compact title={nodeError.msg || nodeError.stackTrace}>
             {nodeError.msg || nodeError.stackTrace}
           </ErrorMessage>
         )}

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -468,14 +468,10 @@ const Node = ({ history, location }: Props) => {
     return (
       <>
         {isErrorState && (
-          <ErrorMessage oneLine={false} align="right">
-            {ERR_MESSAGE_ERR_STATE}
-          </ErrorMessage>
+          <ErrorMessage align="right">{ERR_MESSAGE_ERR_STATE}</ErrorMessage>
         )}
         {nodeStatusError && (
-          <ErrorMessage oneLine={false} align="right">
-            {ERR_MESSAGE_NODE_ERROR}
-          </ErrorMessage>
+          <ErrorMessage align="right">{ERR_MESSAGE_NODE_ERROR}</ErrorMessage>
         )}
         <EventsWrap>
           <TextWrapper>

--- a/app/screens/node/NodeSetup.tsx
+++ b/app/screens/node/NodeSetup.tsx
@@ -137,7 +137,7 @@ const NodeSetup = ({ history, location }: Props) => {
   const getPosDirectorySubheader = () => (
     <>
       {Number.isNaN(commitmentSize) ? (
-        <ErrorMessage align="left" oneLine={false}>
+        <ErrorMessage align="left">
           {!status?.connectedPeers ? (
             <>
               The Node is not connected yet.

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -79,6 +79,8 @@ export enum SmeshingSetupState {
   ViaRestart = 2,
 }
 
+const FATAL_REGEXP = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{4})\sFATAL\s/gm;
+
 class NodeManager extends AbstractManager {
   private nodeService: NodeService;
 
@@ -127,9 +129,7 @@ class NodeManager extends AbstractManager {
         getNodeLogsPath(this.genesisID),
         100
       );
-      const fatalErrorLine = lastLines.find((line) =>
-        /^\{"L":"FATAL",.+\}$/.test(line)
-      );
+      const fatalErrorLine = lastLines.find((line) => FATAL_REGEXP.test(line));
       if (!fatalErrorLine) {
         // If we can't find fatal error — show default crash error
         this.sendNodeError(defaultCrashError());
@@ -137,9 +137,10 @@ class NodeManager extends AbstractManager {
       }
       // If we found fatal error — parse it and convert to NodeError
       try {
-        const json = JSON.parse(fatalErrorLine);
+        // const json = JSON.parse(fatalErrorLine);
+        const message = fatalErrorLine.replace(FATAL_REGEXP, '');
         const fatalError = {
-          msg: json.errmsg || json.M,
+          msg: message,
           level: NodeErrorLevel.LOG_LEVEL_FATAL,
           module: 'NodeManager',
           stackTrace: '',


### PR DESCRIPTION
Sometime ago log format of the Node was changed from JSON to text.
Since this change, Smapp displays a default Node crash error instead of an actual fatal error from the log.
Now it is fixed without changing the log format (still user-friendly text).