### PR TITLE
Do not copy key.bin on changing pos dir

### DIFF
--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import fs from 'fs';
 import { ChildProcess } from 'node:child_process';
 import { Writable } from 'stream';
 import fse from 'fs-extra';
@@ -16,6 +15,7 @@ import {
   NodeError,
   NodeErrorLevel,
   NodeStatus,
+  PostProvingOpts,
   PostSetupOpts,
   PublicService,
   SocketAddress,
@@ -31,12 +31,7 @@ import NodeService, {
   StatusStreamHandler,
 } from './NodeService';
 import SmesherManager from './SmesherManager';
-import {
-  createDebouncePool,
-  getSpawnErrorReason,
-  isEmptyDir,
-  isFileExists,
-} from './utils';
+import { createDebouncePool, getSpawnErrorReason, isEmptyDir } from './utils';
 import { NODE_CONFIG_FILE } from './main/constants';
 import {
   DEFAULT_GRPC_PRIVATE_PORT,
@@ -329,21 +324,6 @@ class NodeManager extends AbstractManager {
 
     if (!this.isNodeRunning()) {
       await this.startNode();
-    }
-
-    // Temporary solution of https://github.com/spacemeshos/smapp/issues/823
-    const CURRENT_DATADIR_PATH = await this.smesherManager.getCurrentDataDir(
-      this.genesisID
-    );
-    const CURRENT_KEYBIN_PATH = path.resolve(CURRENT_DATADIR_PATH, 'key.bin');
-    const NEXT_KEYBIN_PATH = path.resolve(postSetupOpts.dataDir, 'key.bin');
-
-    const isDefaultKeyFileExist = await isFileExists(CURRENT_KEYBIN_PATH);
-    const isDataDirKeyFileExist = await isFileExists(NEXT_KEYBIN_PATH);
-
-    if (isDefaultKeyFileExist && !isDataDirKeyFileExist) {
-      // Copy current `key.bin` file into newly created PoS directory
-      await fs.promises.copyFile(CURRENT_KEYBIN_PATH, NEXT_KEYBIN_PATH);
     }
 
     const metadata = await updateSmeshingMetadata(postSetupOpts.dataDir, {


### PR DESCRIPTION
No issue.
Removes the old workaround (well-described in https://github.com/spacemeshos/smapp/issues/823) that may cause problems with re-using the same SmesherID for the different PoS data created.

### Steps to reproduce the bug
1. Install smapp
2. Create PoS data in another dir than default
3. Move post to another machine (including key.bin etc)
4. Use "delete post" in smapp (it will also drop the PoS dir to the default.
5. Create new wallet
6. Start post data in yet another dir.

### Expected behavior
There should be a brand-new SmesherID in the key.bin file

### Actual behavior
We have some key.bin by default.
Then in step 2 Smapp is copying key.bin from the default directory.
And then in step 6, it is again copying key.bin from the default directory.