### PR TITLE
Fix network status layers

### DIFF
--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -20,6 +20,7 @@ const Progress = styled.div`
 type Props = {
   status: NodeStatus | null;
   error: any;
+  isGenesis: boolean;
   isRestarting: boolean;
   isWalletMode: boolean;
 };
@@ -27,13 +28,14 @@ type Props = {
 const NetworkStatus = ({
   status,
   error,
+  isGenesis,
   isRestarting,
   isWalletMode,
 }: Props) => {
   const getSyncLabelPercentage = (): number => {
-    if (status && status.syncedLayer && status.topLayer) {
+    if (status && status.verifiedLayer && status.topLayer) {
       const percentage = Math.floor(
-        (status.syncedLayer * 100) / status.topLayer
+        (status.verifiedLayer * 100) / status.topLayer
       );
       const maxPercentage = status.isSynced ? 100 : 99;
       return constrain(0, maxPercentage, percentage);
@@ -46,16 +48,16 @@ const NetworkStatus = ({
       return <ProgressLabel>Connecting...</ProgressLabel>;
     }
 
-    const syncedLayer = status.syncedLayer || 0;
+    const verifiedLayer = status.verifiedLayer || 0;
     const topLayer = status.topLayer || 0;
 
-    if (topLayer < syncedLayer) {
-      const progress = Math.floor((topLayer / syncedLayer) * 100);
+    if (isGenesis) {
+      const progress = Math.floor((topLayer / verifiedLayer) * 100);
       return (
         <>
           <ProgressLabel>Genesis</ProgressLabel>
           <ProgressLabel>{progress}%</ProgressLabel>
-          <ProgressLabel>{`${topLayer} / ${syncedLayer}`}</ProgressLabel>
+          <ProgressLabel>{`${topLayer} / ${verifiedLayer}`}</ProgressLabel>
           <Progress>
             <ProgressBar progress={progress} />
           </Progress>
@@ -68,7 +70,7 @@ const NetworkStatus = ({
       <>
         <ProgressLabel>syncing</ProgressLabel>
         <ProgressLabel>{progress}%</ProgressLabel>
-        <ProgressLabel>{`${syncedLayer} / ${topLayer}`}</ProgressLabel>
+        <ProgressLabel>{`${verifiedLayer} / ${topLayer}`}</ProgressLabel>
         <Progress>
           <ProgressBar progress={progress} />
         </Progress>
@@ -79,7 +81,7 @@ const NetworkStatus = ({
   const renderSyncingStatus = () => {
     return (
       <>
-        {status?.isSynced && status.topLayer === status.syncedLayer ? (
+        {status?.isSynced && status.topLayer === status.verifiedLayer ? (
           <>
             <ColorStatusIndicator color={smColors.green} />
             <ProgressLabel>synced</ProgressLabel>

--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -81,7 +81,7 @@ const NetworkStatus = ({
   const renderSyncingStatus = () => {
     return (
       <>
-        {status?.isSynced && status.topLayer === status.verifiedLayer ? (
+        {status?.isSynced && status.verifiedLayer - status.topLayer <= 2 ? (
           <>
             <ColorStatusIndicator color={smColors.green} />
             <ProgressLabel>synced</ProgressLabel>

--- a/app/redux/network/selectors.ts
+++ b/app/redux/network/selectors.ts
@@ -17,3 +17,6 @@ export const getTimestampByLayerFn = (state: RootState) =>
 
 export const getFirstLayerInEpochFn = (state: RootState) =>
   firstLayerInEpoch(state.network.layersPerEpoch);
+
+export const isGenesisPhase = (state: RootState) =>
+  (state.node.status?.verifiedLayer || 0) < getFirstLayerInEpochFn(state)(2);

--- a/app/redux/network/selectors.ts
+++ b/app/redux/network/selectors.ts
@@ -19,4 +19,4 @@ export const getFirstLayerInEpochFn = (state: RootState) =>
   firstLayerInEpoch(state.network.layersPerEpoch);
 
 export const isGenesisPhase = (state: RootState) =>
-  (state.node.status?.verifiedLayer || 0) < getFirstLayerInEpochFn(state)(2);
+  (state.node.status?.topLayer || 0) < getFirstLayerInEpochFn(state)(2);

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -23,6 +23,7 @@ import Address from '../../components/common/Address';
 import {
   getFirstLayerInEpochFn,
   getTimestampByLayerFn,
+  isGenesisPhase,
 } from '../../redux/network/selectors';
 
 const Container = styled.div`
@@ -97,6 +98,7 @@ const Network = ({ history }) => {
 
   const getFirstLayerInEpoch = useSelector(getFirstLayerInEpochFn);
   const getTimestampByLayer = useSelector(getTimestampByLayerFn);
+  const isGenesis = useSelector(isGenesisPhase);
 
   const genesisTime = useSelector(
     (state: RootState) => state.network.genesisTime
@@ -175,12 +177,13 @@ const Network = ({ history }) => {
           <NetworkStatus
             status={status}
             error={nodeError}
+            isGenesis={isGenesis}
             isRestarting={isRestarting}
             isWalletMode={isWalletMode}
           />
         </GrayText>
       </DetailsRow>
-      {status && status.topLayer < status.syncedLayer ? (
+      {status && isGenesis ? (
         <DetailsRow>
           <DetailsTextWrap>
             <DetailsText>Genesis will end in</DetailsText>
@@ -206,16 +209,6 @@ const Network = ({ history }) => {
               />
             </DetailsTextWrap>
             <GrayText>{status?.topLayer || 0}</GrayText>
-          </DetailsRow>
-          <DetailsRow>
-            <DetailsTextWrap>
-              <DetailsText>Verified Layer</DetailsText>
-              <Tooltip
-                width={250}
-                text="The last processed and synced Layer number. Usually lags behind Current Layer by a layer or two."
-              />
-            </DetailsTextWrap>
-            <GrayText>{status?.verifiedLayer || 0}</GrayText>
           </DetailsRow>
         </>
       )}


### PR DESCRIPTION
The problem is that Smapp started rendering "Genesis phase" because of some problem with "syncedLayer":
![image](https://github.com/spacemeshos/smapp/assets/1897530/7dd37473-7e0c-48a5-a716-bacb10cef829)

As @dshulyak proposed:

> i think there should be two things:
> clock layer: 12080  // latest according to the clock
> applied layer: 12079 // latest that was applied to vm. right now it is returned as verified. and later we will add a field that explains why it was applied (e.g hare success or tortoise weight)

So what I did:
1. Stop using `syncedLayer` and use `verifiedLayer` instead.
2. Do not render "Genesis" even if `verifiedLayer` is greater than `topLayer` for some reason. And display "genesis" only for the first two epochs.
3. If the verified layer is not more than 2 layers behind — do not scare Users and keep showing "SYNCED" status.

Video-preview against the standalone network:
https://github.com/spacemeshos/smapp/assets/1897530/6a588b03-1598-4faf-990e-ad75d0a63021
