### PR TITLE
Fix: use PPROF_SERVER env variable as a boolean switch

### DIFF
--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -39,7 +39,7 @@ import {
   getGrpcPrivatePort,
   getGrpcPublicPort,
   getNodeLogsPath,
-  getProofOfServerClientValue,
+  getPprofServerArgument,
   readLinesFromBottom,
 } from './main/utils';
 import AbstractManager from './AbstractManager';
@@ -374,7 +374,7 @@ class NodeManager extends AbstractManager {
     );
 
     const nodeArgumentsMap = {
-      'pprof-server': getProofOfServerClientValue(),
+      'pprof-server': getPprofServerArgument(),
     };
 
     const nodeUserArguments = {
@@ -393,9 +393,9 @@ class NodeManager extends AbstractManager {
       NODE_CONFIG_FILE,
       '-d',
       nodeDataFilesPath,
-      ...Object.values(nodeArgumentsMap)
-        .filter((value) => value)
-        .map((value) => `--${value}`), // ['--key']
+      ...Object.entries(nodeArgumentsMap)
+        .filter(([_, value]) => value)
+        .map(([key]) => `--${key}`), // ['--key']
       ...Object.keys(nodeUserArguments)
         .filter((key) => nodeUserArguments[key])
         .map((key) => [`--${key}`, nodeUserArguments[key]])

--- a/desktop/main/utils.ts
+++ b/desktop/main/utils.ts
@@ -67,8 +67,8 @@ export const getGrpcPrivatePort = () =>
   app.commandLine.getSwitchValue('grpc-private-listener') ||
   DEFAULT_GRPC_PRIVATE_PORT;
 
-export const getProofOfServerClientValue = () =>
-  process.env.PPROF_SERVER || app.commandLine.hasSwitch('pprof-server');
+export const getPprofServerArgument = () =>
+  !!process.env.PPROF_SERVER || app.commandLine.hasSwitch('pprof-server');
 
 export const getLocalNodeConnectionConfig = (): SocketAddress => ({
   host: 'localhost',


### PR DESCRIPTION
No issue.
Fixes usage of `--pprof-server` argument and `PPROF_SERVER` env variable.