### PR TITLE
Hide tapbot link from Request SMH page for mainnet

### DIFF
--- a/app/components/common/Feedback.tsx
+++ b/app/components/common/Feedback.tsx
@@ -324,7 +324,7 @@ const FeedbackButton = () => {
     setUniqIdentifierForSuccessDialog('');
   };
 
-  const openDiscord = () => window.open(ExternalLinks.DiscordTapAccount);
+  const openDiscord = () => window.open(ExternalLinks.Discord);
 
   if (isLoading) {
     return (

--- a/app/redux/network/initialState.ts
+++ b/app/redux/network/initialState.ts
@@ -9,6 +9,7 @@ const networkInitialState: NetworkState = {
   rootHash: '',
   explorerUrl: '',
   layersPerEpoch: 0,
+  tapBotDiscordURL: '',
 };
 
 export default networkInitialState;

--- a/app/redux/network/selectors.ts
+++ b/app/redux/network/selectors.ts
@@ -20,3 +20,6 @@ export const getFirstLayerInEpochFn = (state: RootState) =>
 
 export const isGenesisPhase = (state: RootState) =>
   (state.node.status?.topLayer || 0) < getFirstLayerInEpochFn(state)(2);
+
+export const getNetworkTapBotDiscordURL = (state: RootState) =>
+  getNetworkInfo(state).tapBotDiscordURL;

--- a/app/screens/wallet/RequestCoins.tsx
+++ b/app/screens/wallet/RequestCoins.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { RouteComponentProps } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import CopyButton from '../../basicComponents/CopyButton';
 import { Link, Button, BoldText } from '../../basicComponents';
 import { smColors } from '../../vars';
 import { MainPath } from '../../routerPaths';
 import { ExternalLinks } from '../../../shared/constants';
 import { Account } from '../../../shared/types';
+import { getNetworkTapBotDiscordURL } from '../../redux/network/selectors';
 
 const Wrapper = styled.div`
   display: flex;
@@ -88,6 +90,7 @@ const RequestCoins = ({ history, location }: Props) => {
   const {
     state: { account, isSmesherActive },
   } = location;
+  const netowrkTabBotUrl = useSelector(getNetworkTapBotDiscordURL);
   const [isCopied, setIsCopied] = useState<boolean>(false);
 
   const navigateToNodeSetup = () => {
@@ -96,7 +99,7 @@ const RequestCoins = ({ history, location }: Props) => {
 
   const navigateToGuide = () => window.open(ExternalLinks.GetCoinGuide);
 
-  const navigateToTap = () => window.open(ExternalLinks.DiscordTapAccount);
+  const navigateToTap = () => window.open(netowrkTabBotUrl);
 
   return (
     <Wrapper>
@@ -120,15 +123,17 @@ const RequestCoins = ({ history, location }: Props) => {
       </SubHeader>
       <Text>* This address is public and safe to share with anyone.</Text>
       <Text>* Send this address to anyone you want to receive Smesh from.</Text>
-      <ComplexText>
-        <Text>* You may also paste this address in the&nbsp;</Text>
-        <Link
-          onClick={navigateToTap}
-          text="Testnet Tap"
-          style={{ fontSize: 16, lineHeight: '22px' }}
-        />
-        <TextElement>.</TextElement>
-      </ComplexText>
+      {netowrkTabBotUrl && (
+        <ComplexText>
+          <Text>* You may also paste this address in the&nbsp;</Text>
+          <Link
+            onClick={navigateToTap}
+            text="Testnet Tap"
+            style={{ fontSize: 16, lineHeight: '22px' }}
+          />
+          <TextElement>.</TextElement>
+        </ComplexText>
+      )}
       <br />
       {!isSmesherActive && (
         <ComplexText>

--- a/app/screens/wallet/RequestCoins.tsx
+++ b/app/screens/wallet/RequestCoins.tsx
@@ -106,10 +106,11 @@ const RequestCoins = ({ history, location }: Props) => {
       <Header>
         Request SMH
         <br />
+        <br />
         --
       </Header>
       <SubHeader>
-        <Text>Request SMH by sharing your wallet&apos;s address:</Text>
+        <Text>Here&apos;s your Account address:</Text>
         <CopyButton
           value={account.address}
           hideCopyIcon={isCopied}
@@ -121,8 +122,8 @@ const RequestCoins = ({ history, location }: Props) => {
           </AddressWrapper>
         </CopyButton>
       </SubHeader>
-      <Text>* This address is public and safe to share with anyone.</Text>
-      <Text>* Send this address to anyone you want to receive Smesh from.</Text>
+      <Text>* This address is public and safe to share.</Text>
+      <Text>* Send it to anyone you want to request SMH from.</Text>
       {netowrkTabBotUrl && (
         <ComplexText>
           <Text>* You may also paste this address in the&nbsp;</Text>

--- a/desktop/main/reactions/views/networkView.ts
+++ b/desktop/main/reactions/views/networkView.ts
@@ -18,6 +18,7 @@ export default (
           layerDurationSec: parse(nodeConfig.main['layer-duration'], 's'),
           layersPerEpoch: nodeConfig.main['layers-per-epoch'],
           explorerUrl: curNet?.explorer || '',
+          tapBotDiscordURL: curNet?.tapBotDiscordURL || '',
         }
     ),
     map(objOf('network'))

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -38,7 +38,6 @@ export enum ExternalLinks {
   RestoreFileGuide = 'https://testnet.spacemesh.io/#/backup?id=restoring-from-a-backup-file',
   RestoreMnemoGuide = 'https://testnet.spacemesh.io/#/backup?id=restoring-from-a-12-words-list',
   Help = 'https://testnet.spacemesh.io/#/help',
-  DiscordTapAccount = 'https://discord.gg/ASpy52C',
 }
 
 export const BITS_PER_LABEL = 128;

--- a/shared/types/states.ts
+++ b/shared/types/states.ts
@@ -7,4 +7,5 @@ export interface NetworkState {
   rootHash: string;
   explorerUrl: string;
   genesisID: string;
+  tapBotDiscordURL: string;
 }


### PR DESCRIPTION
It closes #1487 
Example network:
<img width="761" alt="Screenshot 2023-09-04 at 12 33 42" src="https://github.com/spacemeshos/smapp/assets/54288612/411520f4-0cd3-4e62-96cf-890648a3a3e2">
Value persist in store:
<img width="273" alt="Screenshot 2023-09-04 at 12 20 11" src="https://github.com/spacemeshos/smapp/assets/54288612/ddbc15f5-a957-4609-aea1-04317a8d8a1d">
