### PR TITLE
Fix rendering rewards and balances

### DIFF
--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -408,6 +408,8 @@ class SmesherManager extends AbstractManager {
       .postSetupState;
     return (
       smeshing ||
+      status === PostSetupState.STATE_PREPARED ||
+      status === PostSetupState.STATE_PAUSED ||
       status === PostSetupState.STATE_IN_PROGRESS ||
       status === PostSetupState.STATE_COMPLETE
     );

--- a/desktop/main/startApp.ts
+++ b/desktop/main/startApp.ts
@@ -165,7 +165,7 @@ const startApp = (): AppStore => {
     $smeshingStarted,
     $smeshingSetupState,
     $nodeEvents,
-  } = getSmesherInfo($managers, $isWalletActivated, $wallet);
+  } = getSmesherInfo($managers, $isWalletActivated, $wallet, $nodeConfig);
 
   const { $nodeRestartRequest } = nodeIPCStreams();
 


### PR DESCRIPTION
We had some reports, that:
1. Rewards are not rendered on Smeser screen
2. Account balance is not rendered
3. BUT transactions and rewards are rendered in Transactions Log

Sadly, I can't reproduce all cases.
But it 100% fixes the case, when Smeshing was on pause and therefore Smapp didn't retrieve rewards for the coinbase.
Now it will retrieve rewards all the time if you have `smeshing-coinbase` in the node config.

I also did some other tweaks, that hopefully will fix the rest 🤞 
Going to ask some community members to help with testing it.