### PR TITLE
improving text-wallet custom name

### DIFF
--- a/app/screens/auth/CreateWallet.tsx
+++ b/app/screens/auth/CreateWallet.tsx
@@ -244,7 +244,7 @@ const CreateWallet = ({ history, location }: AuthRouterParams) => {
                 <Input
                   value={convenientWalletName}
                   type="text"
-                  placeholder="CONVENIENT NAME"
+                  placeholder="MAX 31 CHARACTERS"
                   onChange={handleNameTyping}
                 />
               </InputSection>

--- a/app/screens/auth/Validation.tsx
+++ b/app/screens/auth/Validation.tsx
@@ -14,7 +14,7 @@ export const validationWalletName = (walletName: string) => {
   const isEmpty = walletName.replaceAll(' ', '').length === 0;
 
   if (!nameCheck.test(walletName) || isEmpty) {
-    return 'Must contain at least latin letter or number, space, _ or -';
+    return 'Only latin letters, numbers, space, _ and - are accepted';
   }
 
   return '';


### PR DESCRIPTION
no issue
corrected the correctnes of the phrase on the error message and added a tip about the limitation in naming the wallet