### PR TITLE
feature: add breadcrumbs for react view

### DIFF
--- a/app/ErrorBoundary.tsx
+++ b/app/ErrorBoundary.tsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 import { captureException } from '@sentry/react';
 import { connect } from 'react-redux';
+import { captureReactBreadcrumb } from './sentry';
 import { Modal } from './components/common';
 import { Button } from './basicComponents';
 import { RootState } from './types';
@@ -101,6 +102,13 @@ class ErrorBoundary extends Component<Props, State> {
     const { setUiError } = this.props;
     setUiError(null);
     this.setState({ isRenderingError: false });
+    captureReactBreadcrumb({
+      category: 'Error Boundary',
+      data: {
+        action: 'Click close button (reset error)',
+      },
+      level: 'info',
+    });
   };
 }
 

--- a/app/components/auth/DragAndDrop.tsx
+++ b/app/components/auth/DragAndDrop.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { Link } from '../../basicComponents';
 import { smColors } from '../../vars';
 import { incorrectFile } from '../../assets/images';
@@ -76,12 +77,30 @@ const DragAndDrop = ({ onFilesAdded, fileName, hasError }: Props) => {
 
   const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+
+    captureReactBreadcrumb({
+      category: 'Drug and drop',
+      data: {
+        action:
+          'Default drop when the dragged content is released on the element',
+      },
+      level: 'info',
+    });
+
     if (e.dataTransfer?.files) {
       onFilesAdded({
         fileName: e.dataTransfer.files[0].name,
         filePath: e.dataTransfer.files[0].path,
       });
       setIsDragging(false);
+
+      captureReactBreadcrumb({
+        category: 'Drug and drop',
+        data: {
+          action: 'On drop when the dragged content is released on the element',
+        },
+        level: 'info',
+      });
     }
   };
 
@@ -91,22 +110,52 @@ const DragAndDrop = ({ onFilesAdded, fileName, hasError }: Props) => {
         target: { files },
       } = e;
       onFilesAdded({ fileName: files[0].name, filePath: files[0].path });
+      captureReactBreadcrumb({
+        category: 'Drug and drop',
+        data: {
+          action: 'On files added',
+        },
+        level: 'info',
+      });
     }
   };
 
   const onDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     setIsDragging(true);
+    captureReactBreadcrumb({
+      category: 'Drug and drop',
+      data: {
+        action:
+          'On drag over when element where the dragged content will be dropped',
+      },
+      level: 'info',
+    });
   };
 
   const onDragLeave = () => {
     setIsDragging(false);
+    captureReactBreadcrumb({
+      category: 'Drug and drop',
+      data: {
+        action:
+          'On drag leave when the element is out of the allowed wrapping zone',
+      },
+      level: 'info',
+    });
   };
 
   const openFileDialog = () => {
     if (fileInputRef && fileInputRef.current) {
       fileInputRef.current.click();
     }
+    captureReactBreadcrumb({
+      category: 'Drug and drop',
+      data: {
+        action: 'Open file dialog',
+      },
+      level: 'info',
+    });
   };
 
   let preLinkText;

--- a/app/components/common/Feedback.tsx
+++ b/app/components/common/Feedback.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { Button, Link, Tooltip } from '../../basicComponents';
-import { captureReactMessage, captureReactUserFeedback } from '../../sentry';
+import {
+  captureReactBreadcrumb,
+  captureReactMessage,
+  captureReactUserFeedback,
+} from '../../sentry';
 import { smColors } from '../../vars';
 import { ExternalLinks } from '../../../shared/constants';
 import CopyButton from '../../basicComponents/CopyButton';
@@ -272,6 +276,14 @@ const FeedbackButton = () => {
 
   const handleReport = () => {
     if (!validate()) {
+      captureReactBreadcrumb({
+        category: 'Feedback',
+        data: {
+          action: 'Send a feedback report',
+        },
+        level: 'info',
+      });
+
       return;
     }
 
@@ -290,9 +302,37 @@ const FeedbackButton = () => {
 
   const handleCloseSuccessMessageModal = () => {
     setUniqIdentifierForSuccessDialog('');
+    captureReactBreadcrumb({
+      category: 'Feedback',
+      data: {
+        action: 'Close success message',
+      },
+      level: 'info',
+    });
   };
 
-  const openDiscord = () => window.open(ExternalLinks.Discord);
+  const openDiscord = () => {
+    window.open(ExternalLinks.Discord);
+    captureReactBreadcrumb({
+      category: 'Feedback',
+      data: {
+        action: 'Open discord',
+      },
+      level: 'info',
+    });
+  };
+
+  const reportButtonHandler = () => {
+    resetForm();
+    setShowReportDialog(true);
+    captureReactBreadcrumb({
+      category: 'Feedback',
+      data: {
+        action: 'Button report an issue',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <Container>
@@ -403,12 +443,7 @@ const FeedbackButton = () => {
         </Modal>
       )}
 
-      <ReportButton
-        onClick={() => {
-          resetForm();
-          setShowReportDialog(true);
-        }}
-      >
+      <ReportButton onClick={reportButtonHandler}>
         Report an issue!
       </ReportButton>
     </Container>

--- a/app/components/contacts/CreateNewContact.tsx
+++ b/app/components/contacts/CreateNewContact.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { addToContacts } from '../../redux/wallet/actions';
 import { EnterPasswordModal } from '../settings';
 import { Input, Link, ErrorPopup, BoldText } from '../../basicComponents';
@@ -96,14 +97,69 @@ const CreateNewContact = ({
     const error = validate(nickname, address, contacts);
     if (error) {
       setError(error);
-    } else {
-      setShouldShowPasswordModal(true);
+      captureReactBreadcrumb({
+        category: 'Create New Contact',
+        data: {
+          action: `Save contact error: ${error}`,
+        },
+        level: 'info',
+      });
     }
+    setShouldShowPasswordModal(true);
+    captureReactBreadcrumb({
+      category: 'Create New Contact',
+      data: {
+        action: 'Click onSave for create new contact',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleOnCancel = () => {
+    onCancel();
+    captureReactBreadcrumb({
+      category: 'Create New Contact',
+      data: {
+        action: 'Click cancel save contact',
+      },
+      level: 'info',
+    });
   };
 
   const onValidPassword = async ({ password }: { password: string }) => {
     dispatch(addToContacts({ password, contact: { address, nickname } }));
     onCompleteAction();
+    captureReactBreadcrumb({
+      category: 'Create New Contact',
+      data: {
+        action: 'Check valid password',
+      },
+      level: 'info',
+    });
+  };
+
+  const submitInputNickname = ({ value }) => {
+    setNickname(value);
+    setError(null);
+    captureReactBreadcrumb({
+      category: 'Create New Contact',
+      data: {
+        action: 'Input nickname',
+      },
+      level: 'info',
+    });
+  };
+
+  const submitInputAccountAddress = ({ value }) => {
+    setAddress(value);
+    setError(null);
+    captureReactBreadcrumb({
+      category: 'Create New Contact',
+      data: {
+        action: 'Input account address',
+      },
+      level: 'info',
+    });
   };
 
   return (
@@ -119,10 +175,7 @@ const CreateNewContact = ({
           <Input
             value={nickname}
             placeholder="Nickname"
-            onChange={({ value }) => {
-              setNickname(value);
-              setError(null);
-            }}
+            onChange={submitInputNickname}
             maxLength="50"
             style={isStandalone ? inputStyle2 : inputStyle1}
             autofocus
@@ -130,10 +183,7 @@ const CreateNewContact = ({
           <Input
             value={address}
             placeholder="Account address"
-            onChange={({ value }) => {
-              setAddress(value);
-              setError(null);
-            }}
+            onChange={submitInputAccountAddress}
             maxLength="90"
             style={isStandalone ? inputStyle3 : inputStyle1}
             onFocus={handleInputFocus}
@@ -161,7 +211,7 @@ const CreateNewContact = ({
           style={{ color: smColors.green, marginRight: 15 }}
         />
         <Link
-          onClick={onCancel}
+          onClick={handleOnCancel}
           text="CANCEL"
           style={{ color: smColors.orange }}
         />

--- a/app/components/contacts/EditContact.tsx
+++ b/app/components/contacts/EditContact.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { addToContacts, removeFromContacts } from '../../redux/wallet/actions';
 import { EnterPasswordModal } from '../settings';
 import { Input, Link, ErrorPopup } from '../../basicComponents';
@@ -60,9 +61,22 @@ const EditContact = ({
     const error = validate(nickname, address, contacts, oldAddress);
     if (error) {
       setError(error);
-    } else {
-      setShouldShowPasswordModal(true);
+      captureReactBreadcrumb({
+        category: 'Edit Contact',
+        data: {
+          action: `Save when editing contacts error: ${error}`,
+        },
+        level: 'info',
+      });
     }
+    setShouldShowPasswordModal(true);
+    captureReactBreadcrumb({
+      category: 'Edit Contact',
+      data: {
+        action: 'Click onSave for editing contacts',
+      },
+      level: 'info',
+    });
   };
 
   const onValidPassword = async ({ password }: { password: string }) => {
@@ -79,6 +93,47 @@ const EditContact = ({
       );
       onCompleteAction();
     }, 1000);
+    captureReactBreadcrumb({
+      category: 'Edit Contact',
+      data: {
+        action: 'Check valid password',
+      },
+      level: 'info',
+    });
+  };
+
+  const submitInputNickname = ({ value }) => {
+    setNickname(value);
+    setError(null);
+    captureReactBreadcrumb({
+      category: 'Edit Contact',
+      data: {
+        action: 'Input nickname',
+      },
+      level: 'info',
+    });
+  };
+  const submitInputAccountAddress = ({ value }) => {
+    setAddress(value);
+    setError(null);
+    captureReactBreadcrumb({
+      category: 'Edit Contact',
+      data: {
+        action: 'Input account address',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleOnCancel = () => {
+    onCancel();
+    captureReactBreadcrumb({
+      category: 'Edit Contact',
+      data: {
+        action: 'Click on cancel button',
+      },
+      level: 'info',
+    });
   };
 
   return (
@@ -87,10 +142,7 @@ const EditContact = ({
         <Input
           value={nickname}
           placeholder="Nickname"
-          onChange={({ value }) => {
-            setNickname(value);
-            setError(null);
-          }}
+          onChange={submitInputNickname}
           maxLength="50"
           style={nicknameStyle}
           autofocus
@@ -98,10 +150,7 @@ const EditContact = ({
         <Input
           value={address}
           placeholder="Account address"
-          onChange={({ value }) => {
-            setAddress(value);
-            setError(null);
-          }}
+          onChange={submitInputAccountAddress}
           maxLength="90"
           style={addressStyle}
           onFocus={handleInputFocus}
@@ -125,7 +174,7 @@ const EditContact = ({
             style={{ color: smColors.green, marginRight: 15 }}
           />
           <Link
-            onClick={onCancel}
+            onClick={handleOnCancel}
             text="CANCEL"
             style={{ color: smColors.orange }}
           />

--- a/app/components/node/PoSDirectory.tsx
+++ b/app/components/node/PoSDirectory.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { Link } from '../../basicComponents';
 import { eventsService } from '../../infra/eventsService';
 import { smColors } from '../../vars';
@@ -112,11 +113,47 @@ const PoSDirectory = ({
     } = await eventsService.selectPostFolder();
     if (error) {
       setHasPermissionError(true);
+      captureReactBreadcrumb({
+        category: 'PoS Directory',
+        data: {
+          action: `Opening folder select dialog error: ${error}`,
+        },
+        level: 'info',
+      });
     } else {
       setDataDir(dataDir);
       setFreeSpace(calculatedFreeSpace);
       setHasPermissionError(false);
     }
+    captureReactBreadcrumb({
+      category: 'PoS Directory',
+      data: {
+        action: 'Select directory',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleNextAction = () => {
+    nextAction();
+    captureReactBreadcrumb({
+      category: 'PoS Directory',
+      data: {
+        action: 'Click on Next Action',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleSkipAction = () => {
+    skipAction();
+    captureReactBreadcrumb({
+      category: 'Edit Contact',
+      data: {
+        action: 'Click on Skip Action',
+      },
+      level: 'info',
+    });
   };
 
   return (
@@ -143,8 +180,8 @@ const PoSDirectory = ({
       </Wrapper>
       <PoSFooter
         skipLabel="CANCEL"
-        action={nextAction}
-        skipAction={skipAction}
+        action={handleNextAction}
+        skipAction={handleSkipAction}
         isDisabled={!dataDir || hasPermissionError || !status}
       />
     </>

--- a/app/components/node/PoSFooter.tsx
+++ b/app/components/node/PoSFooter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { ExternalLinks } from '../../../shared/constants';
 import { Link, Button } from '../../basicComponents';
 
@@ -34,7 +35,16 @@ const PoSFooter = ({
   skipLabel,
   nextLabel,
 }: PoSFooterProps) => {
-  const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToExplanation = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'PoS Footer',
+      data: {
+        action: 'Open post setup guide',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <Footer>

--- a/app/components/node/PoSProvider.tsx
+++ b/app/components/node/PoSProvider.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { smColors } from '../../vars';
 import { PostSetupProvider, NodeStatus } from '../../../shared/types';
+import { captureReactBreadcrumb } from '../../sentry';
 import { eventsService } from '../../infra/eventsService';
 import Carousel from './Carousel';
 import PoSFooter from './PoSFooter';
@@ -72,9 +73,27 @@ const PoSProvider = ({
       setProvider(providers[selectedProviderIndex]);
     }
   }, [provider, providers, selectedProviderIndex, setProvider]);
-
-  const handleSetProcessor = ({ index }: { index: number }) =>
+  const handleSetProcessor = ({ index }: { index: number }) => {
     setSelectedProviderIndex(index);
+    captureReactBreadcrumb({
+      category: 'PoS Provider',
+      data: {
+        action: 'Calculating PoS processor',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleNextAction = () => {
+    nextAction();
+    captureReactBreadcrumb({
+      category: 'PoS Provider',
+      data: {
+        action: 'Click on next action button',
+      },
+      level: 'info',
+    });
+  };
 
   const hasProviders = providers && providers.length > 0;
 
@@ -94,7 +113,7 @@ const PoSProvider = ({
       )}
       {/* eslint-enable no-nested-ternary */}
       <PoSFooter
-        action={nextAction}
+        action={handleNextAction}
         skipAction={providers.length === 0 ? skipAction : undefined}
         isDisabled={selectedProviderIndex === -1 || !status}
       />

--- a/app/components/node/SmesherIntro.tsx
+++ b/app/components/node/SmesherIntro.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { Link, Button, BoldText } from '../../basicComponents';
 import {
   posIcon,
@@ -88,10 +89,38 @@ type Props = {
 };
 
 const SmesherIntro = ({ hideIntro }: Props) => {
-  const navigateToMiningGuide = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToMiningGuide = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Smesher intro',
+      data: {
+        action: 'Navigate to mini guide',
+      },
+      level: 'info',
+    });
+  };
 
-  const navigateToPreventComputerSleep = () =>
+  const navigateToPreventComputerSleep = () => {
     window.open(ExternalLinks.NoSleepGuide);
+    captureReactBreadcrumb({
+      category: 'Smesher intro',
+      data: {
+        action: 'Prevent computer to sleep',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleHideIntro = () => {
+    hideIntro();
+    captureReactBreadcrumb({
+      category: 'Smesher intro',
+      data: {
+        action: 'Click on hide intro',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <>
@@ -129,7 +158,7 @@ const SmesherIntro = ({ hideIntro }: Props) => {
       </TextWrapper>
       <Footer>
         <Link onClick={navigateToMiningGuide} text="SMESHING GUIDE" />
-        <Button onClick={hideIntro} text="GOT IT" width={175} />
+        <Button onClick={handleHideIntro} text="GOT IT" width={175} />
       </Footer>
     </>
   );

--- a/app/components/settings/ChangePassword.tsx
+++ b/app/components/settings/ChangePassword.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { eventsService } from '../../infra/eventsService';
 import { ErrorPopup, Input, Link, Loader, Button } from '../../basicComponents';
 import { smColors } from '../../vars';
@@ -60,20 +61,49 @@ const ChangePassword = () => {
     (state: RootState) => state.wallet.currentWalletPath
   );
   const dispatch: AppThDispatch = useDispatch();
-
   const handlePasswordTyping = ({ value }: { value: string }) => {
     setNewPassword(value);
+    captureReactBreadcrumb({
+      category: 'Change password',
+      data: {
+        action: 'Type new password',
+      },
+      level: 'info',
+    });
   };
 
   const handlePasswordVerifyTyping = ({ value }: { value: string }) => {
     setVerifiedPassword(value);
+    captureReactBreadcrumb({
+      category: 'Change password',
+      data: {
+        action: 'Type verify password',
+      },
+      level: 'info',
+    });
   };
 
   const handleCurrentPassword = ({ value }: { value: string }) => {
     setCurrentPassword(value);
+    captureReactBreadcrumb({
+      category: 'Change password',
+      data: {
+        action: 'Type current password',
+      },
+      level: 'info',
+    });
   };
 
-  const startUpdatingPassword = () => setIsEditMode(true);
+  const startUpdatingPassword = () => {
+    setIsEditMode(true);
+    captureReactBreadcrumb({
+      category: 'Change password',
+      data: {
+        action: 'Start updating password',
+      },
+      level: 'info',
+    });
+  };
 
   const isCurrentPasswordValid = async () => {
     const { success } = await dispatch(unlockCurrentWallet(currentPassword));
@@ -87,6 +117,13 @@ const ChangePassword = () => {
     setIsEditMode(false);
     setNewPasswordError(null);
     setIsLoaderVisible(false);
+    captureReactBreadcrumb({
+      category: 'Change password',
+      data: {
+        action: 'Close modal updating password',
+      },
+      level: 'info',
+    });
   };
 
   const updatePassword = (prevPassword: string) => {
@@ -101,6 +138,13 @@ const ChangePassword = () => {
 
       setTimeout(cancel, 500);
     }
+    captureReactBreadcrumb({
+      category: 'Change password',
+      data: {
+        action: 'Check process updating password',
+      },
+      level: 'info',
+    });
   };
 
   if (isLoaderVisible) {
@@ -127,6 +171,13 @@ const ChangePassword = () => {
 
   const savePassword = async () => {
     const isCurrentPasswordValidStatus = await isCurrentPasswordValid();
+    captureReactBreadcrumb({
+      category: 'Change password',
+      data: {
+        action: 'Click button save password',
+      },
+      level: 'info',
+    });
 
     if (!isCurrentPasswordValidStatus) {
       setNewPasswordError({

--- a/app/components/settings/EnterPasswordModal.tsx
+++ b/app/components/settings/EnterPasswordModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { unlockCurrentWallet } from '../../redux/wallet/actions';
 import { Modal } from '../common';
 import { Button, Input, ErrorPopup } from '../../basicComponents';
@@ -57,26 +58,63 @@ const EnterPasswordModal = ({
   const [hasError, setHasError] = useState(false);
 
   const dispatch = useDispatch();
-
   const handlePasswordTyping = ({ value }: { value: string }) => {
     setPassword(value);
     setHasError(false);
+    captureReactBreadcrumb({
+      category: 'Enter Password Modal',
+      data: {
+        action: 'Password typing',
+      },
+      level: 'info',
+    });
   };
 
   const reset = () => {
     setPassword('');
     setHasError(false);
+    captureReactBreadcrumb({
+      category: 'Enter Password Modal',
+      data: {
+        action: 'Reset error password',
+      },
+      level: 'info',
+    });
   };
 
   const submitActionWrapper = async () => {
     // @ts-ignore
     const { success } = await dispatch(unlockCurrentWallet(password));
-
     if (success) {
       submitAction({ password });
+      captureReactBreadcrumb({
+        category: 'Enter Password Modal',
+        data: {
+          action: 'Active action wrapper',
+        },
+        level: 'info',
+      });
     } else {
       setHasError(true);
+      captureReactBreadcrumb({
+        category: 'Enter Password Modal',
+        data: {
+          action: 'Active action wrapper error',
+        },
+        level: 'info',
+      });
     }
+  };
+
+  const handleCancelModal = () => {
+    closeModal();
+    captureReactBreadcrumb({
+      category: 'Enter Password Modal',
+      data: {
+        action: 'Click cancel button',
+      },
+      level: 'info',
+    });
   };
 
   return (
@@ -112,7 +150,7 @@ const EnterPasswordModal = ({
           isDisabled={!password.trim() || hasError}
           onClick={submitActionWrapper}
         />
-        <Button text="CANCEL" isPrimary={false} onClick={closeModal} />
+        <Button text="CANCEL" isPrimary={false} onClick={handleCancelModal} />
       </ButtonsWrapper>
     </Modal>
   );

--- a/app/components/settings/SignMessage.tsx
+++ b/app/components/settings/SignMessage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { eventsService } from '../../infra/eventsService';
 import { Modal } from '../common';
 import { Input, Button } from '../../basicComponents';
@@ -81,6 +82,24 @@ const SignMessage = ({ index, close }: Props) => {
     await navigator.clipboard.writeText(result);
     copiedTimeout = setTimeout(() => setIsCopied(false), 10000);
     setIsCopied(true);
+    captureReactBreadcrumb({
+      category: 'Sign Message',
+      data: {
+        action: 'Sign text message',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleClose = () => {
+    close();
+    captureReactBreadcrumb({
+      category: 'Sign Message',
+      data: {
+        action: 'Click cancel button',
+      },
+      level: 'info',
+    });
   };
 
   return (
@@ -112,7 +131,7 @@ const SignMessage = ({ index, close }: Props) => {
           width={150}
           isDisabled={!message}
         />
-        <Button onClick={close} isPrimary={false} text="Cancel" />
+        <Button onClick={handleClose} isPrimary={false} text="Cancel" />
       </ButtonsWrapper>
     </Modal>
   );

--- a/app/components/transactions/RewardRow.tsx
+++ b/app/components/transactions/RewardRow.tsx
@@ -4,6 +4,7 @@ import { formatSmidge, getFormattedTimestamp } from '../../infra/utils';
 import { smColors } from '../../vars';
 import { RewardView } from '../../redux/wallet/selectors';
 import { Bech32Address } from '../../../shared/types';
+import { captureReactBreadcrumb } from '../../sentry';
 import Address from '../common/Address';
 
 const Wrapper = styled.div<{ isDetailed: boolean; isHidden: boolean }>`
@@ -135,9 +136,15 @@ type Props = {
 const RewardRow = ({ tx, address, isHidden = false }: Props) => {
   const [isDetailed, setIsDetailed] = useState(false);
   const { layer, layerReward, amount } = tx;
-
   const toggleTxDetails = () => {
     setIsDetailed(!isDetailed);
+    captureReactBreadcrumb({
+      category: 'Reward Row',
+      data: {
+        action: 'Toggle tx details',
+      },
+      level: 'info',
+    });
   };
 
   const renderDetails = () => (

--- a/app/components/transactions/TxRow.tsx
+++ b/app/components/transactions/TxRow.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { Modal } from '../common';
 import {
   Button,
@@ -273,19 +274,62 @@ const TxRow = ({
 
   const isSent = tx.principal === address;
   const color = getStatusColor(tx.status, isSent);
-
   const save = async () => {
     await eventsService.updateTransactionNote(address, tx.id, noteInput);
     setIsDetailed(false);
     setShowNoteModal(false);
+    captureReactBreadcrumb({
+      category: 'Tx Row',
+      data: {
+        action: 'Type save button',
+      },
+      level: 'info',
+    });
   };
+
   const cancel = () => {
     setNoteInput(note);
     setShowNoteModal(false);
+    captureReactBreadcrumb({
+      category: 'Tx Row',
+      data: {
+        action: 'Click cancel link',
+      },
+      level: 'info',
+    });
   };
 
   const toggleTxDetails = () => {
     setIsDetailed(!isDetailed);
+    captureReactBreadcrumb({
+      category: 'Tx Row',
+      data: {
+        action: 'Open transaction details',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToSendCoinGuide = () => {
+    window.open(ExternalLinks.SendCoinGuide);
+    captureReactBreadcrumb({
+      category: 'Tx Row',
+      data: {
+        action: 'Navigate to send coin guide',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleEdit = () => {
+    setShowNoteModal(true);
+    captureReactBreadcrumb({
+      category: 'Tx Row',
+      data: {
+        action: 'Click edit button',
+      },
+      level: 'info',
+    });
   };
 
   const txFrom = isSent ? address : tx.principal;
@@ -329,7 +373,7 @@ const TxRow = ({
       <Row title="FEE">{formatSmidge(tx.gas.fee)}</Row>
       <Row title="NOTE">
         {note ? `${note}` : 'NO NOTE'}
-        <LinkEdit onClick={() => setShowNoteModal(true)}>EDIT</LinkEdit>
+        <LinkEdit onClick={handleEdit}>EDIT</LinkEdit>
       </Row>
     </DetailsSection>
   );
@@ -393,10 +437,7 @@ const TxRow = ({
             />
           </InputSection>
           <ButtonsWrapper>
-            <Link
-              onClick={() => window.open(ExternalLinks.SendCoinGuide)}
-              text="TRANSACTION GUIDE"
-            />
+            <Link onClick={navigateToSendCoinGuide} text="TRANSACTION GUIDE" />
             <RightButton>
               <Link
                 style={{ color: smColors.orange, marginRight: '10px' }}

--- a/app/components/wallet/AccountsOverview.tsx
+++ b/app/components/wallet/AccountsOverview.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import ExplorerButton from '../../basicComponents/ExplorerButton';
 import CopyButton from '../../basicComponents/CopyButton';
 import { setCurrentAccount } from '../../redux/wallet/actions';
@@ -140,6 +141,13 @@ const AccountsOverview = () => {
 
   const handleSetCurrentAccount = ({ index }: { index: number }) => {
     dispatch(setCurrentAccount(index));
+    captureReactBreadcrumb({
+      category: 'Accounts Overview',
+      data: {
+        action: 'Set Current Account',
+      },
+      level: 'info',
+    });
   };
 
   const renderAccountRow = ({

--- a/app/components/wallet/TxConfirmation.tsx
+++ b/app/components/wallet/TxConfirmation.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { SecondaryButton, Link, Button, BoldText } from '../../basicComponents';
 import { chevronLeftWhite } from '../../assets/images';
 import { smColors } from '../../vars';
@@ -129,8 +130,39 @@ const TxConfirmation = ({
   backButtonRoute,
 }: Props) => {
   const history = useHistory();
+  const handleSend = () => {
+    captureReactBreadcrumb({
+      category: 'Tx Confirmation',
+      data: {
+        action: 'Click send button',
+      },
+      level: 'info',
+    });
+    editTx();
+  };
 
-  const navigateToGuide = () => window.open(ExternalLinks.SendCoinGuide);
+  const handleEditTx = () => {
+    doneAction();
+    captureReactBreadcrumb({
+      category: 'Tx Confirmation',
+      data: {
+        action: 'Navigate to edit transaction',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToGuide = () => {
+    window.open(ExternalLinks.SendCoinGuide);
+    captureReactBreadcrumb({
+      category: 'Tx Confirmation',
+      data: {
+        action: 'Navigate to send coin guide',
+      },
+      level: 'info',
+    });
+  };
+
   const renderFieldValue = (field: TxConfirmationField) => {
     switch (field.type) {
       case TxConfirmationFieldType.Total:
@@ -142,7 +174,15 @@ const TxConfirmation = ({
   };
   const cancelButton = () => {
     history.replace(backButtonRoute);
+    captureReactBreadcrumb({
+      category: 'Tx Confirmation',
+      data: {
+        action: 'Click cancel transaction button',
+      },
+      level: 'info',
+    });
   };
+
   return (
     <Wrapper>
       <Header>
@@ -168,7 +208,7 @@ const TxConfirmation = ({
       <Footer>
         <ComplexButton>
           <SecondaryButton
-            onClick={editTx}
+            onClick={handleEditTx}
             img={chevronLeftWhite}
             imgWidth={10}
             imgHeight={15}
@@ -177,7 +217,7 @@ const TxConfirmation = ({
         </ComplexButton>
         <Link onClick={navigateToGuide} text="SEND SMH GUIDE" />
         <Button
-          onClick={doneAction}
+          onClick={handleSend}
           text="SEND"
           style={{ marginLeft: 'auto' }}
           isDisabled={isDisabled}

--- a/app/components/wallet/TxParams.tsx
+++ b/app/components/wallet/TxParams.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import {
   Link,
   Input,
@@ -139,15 +140,32 @@ const TxParams = ({
     setSelectedFeeIndex(index);
   };
 
-  const navigateToGuide = () => window.open(ExternalLinks.SendCoinGuide);
+  const navigateToGuide = () => {
+    window.open(ExternalLinks.SendCoinGuide);
+    captureReactBreadcrumb({
+      category: 'TX params',
+      data: {
+        action: 'Navigate to coin guide',
+      },
+      level: 'info',
+    });
+  };
 
   const handleAmountChange = useCallback(
     (value) => updateTxAmount(parseFloat(value)),
     [updateTxAmount]
   );
   const history = useHistory();
+
   const cancelButton = () => {
     history.replace(backButtonRoute);
+    captureReactBreadcrumb({
+      category: 'TX params',
+      data: {
+        action: 'Click cancel transaction link',
+      },
+      level: 'info',
+    });
   };
 
   return (

--- a/app/components/wallet/TxSent.tsx
+++ b/app/components/wallet/TxSent.tsx
@@ -7,6 +7,8 @@ import { smColors } from '../../vars';
 import Address, { AddressType } from '../common/Address';
 import { ExternalLinks } from '../../../shared/constants';
 import { safeReactKey } from '../../infra/utils';
+// eslint-disable-next-line import/no-cycle
+import { captureReactBreadcrumb } from '../../sentry';
 
 const Wrapper = styled.div`
   display: flex;
@@ -108,11 +110,41 @@ type Props = {
 };
 
 const TxSent = ({ fields, txId, navigateToTxList, doneButtonRoute }: Props) => {
-  const navigateToGuide = () => window.open(ExternalLinks.SendCoinGuide);
+  const navigateToGuide = () => {
+    window.open(ExternalLinks.SendCoinGuide);
+    captureReactBreadcrumb({
+      category: 'TX Sent',
+      data: {
+        action: 'Click to send SMH guide',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleNavigateToTxList = () => {
+    navigateToTxList();
+    captureReactBreadcrumb({
+      category: 'TX Sent',
+      data: {
+        action: 'Navigate to view transaction',
+      },
+      level: 'info',
+    });
+  };
+
   const history = useHistory();
+
   const doneButton = () => {
     history.replace(doneButtonRoute);
+    captureReactBreadcrumb({
+      category: 'TX Sent',
+      data: {
+        action: 'Click done button',
+      },
+      level: 'info',
+    });
   };
+
   return (
     <Wrapper>
       <Header>
@@ -143,7 +175,7 @@ const TxSent = ({ fields, txId, navigateToTxList, doneButtonRoute }: Props) => {
         <Link onClick={navigateToGuide} text="SEND SMH GUIDE" />
         <ButtonsBlock>
           <Button
-            onClick={navigateToTxList}
+            onClick={handleNavigateToTxList}
             text="VIEW TRANSACTION"
             isPrimary={false}
             width={170}

--- a/app/screens/auth/ConnectToApi.tsx
+++ b/app/screens/auth/ConnectToApi.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { CorneredContainer, BackButton } from '../../components/common';
 import { Button, Link, DropDown } from '../../basicComponents';
 import { eventsService } from '../../infra/eventsService';
@@ -73,6 +74,14 @@ const ConnectToApi = ({ history, location }: AuthRouterParams) => {
             },
           })),
         };
+        captureReactBreadcrumb({
+          category: 'Connect to API',
+          data: {
+            action: 'Update API public services',
+          },
+          level: 'info',
+        });
+
         return setPublicServices(state);
       })
       .catch((err) => {
@@ -81,14 +90,39 @@ const ConnectToApi = ({ history, location }: AuthRouterParams) => {
           services: [],
         });
         console.error(err); // eslint-disable-line no-console
+        captureReactBreadcrumb({
+          category: 'Connect to API',
+          data: {
+            action: `Update API public services error: ${err}`,
+          },
+          level: 'info',
+        });
       });
   };
 
   useEffect(updatePublicServices, [genesisID]);
 
-  const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToExplanation = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Connect to API',
+      data: {
+        action: 'Navigate to explanation setup',
+      },
+      level: 'info',
+    });
+  };
 
-  const selectItem = ({ index }) => setSelectedItemIndex(index);
+  const selectItem = ({ index }) => {
+    setSelectedItemIndex(index);
+    captureReactBreadcrumb({
+      category: 'Connect to API',
+      data: {
+        action: 'Select item',
+      },
+      level: 'info',
+    });
+  };
 
   const hasPublicServices = publicServices.services.length > 0;
 
@@ -107,11 +141,26 @@ const ConnectToApi = ({ history, location }: AuthRouterParams) => {
       publicServices.services.length > selectedItemIndex
         ? publicServices.services[selectedItemIndex].value
         : undefined;
+    captureReactBreadcrumb({
+      category: 'Connect to API',
+      data: {
+        action: 'Click next button',
+      },
+      level: 'info',
+    });
 
     value &&
       dispatch(switchApiProvider(value, genesisID)).catch((err) => {
         console.error(err); // eslint-disable-line no-console
         dispatch(setUiError(err));
+
+        captureReactBreadcrumb({
+          category: 'Connect to API',
+          data: {
+            action: `Click next button with error: ${err}`,
+          },
+          level: 'info',
+        });
       });
 
     history.push(location?.state?.redirect || AuthPath.Unlock, {

--- a/app/screens/auth/CreateWallet.tsx
+++ b/app/screens/auth/CreateWallet.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { createNewWallet } from '../../redux/wallet/actions';
 import { CorneredContainer, PasswordInput } from '../../components/common';
 import { Input, Button, Link, Loader, ErrorPopup } from '../../basicComponents';
@@ -148,15 +149,36 @@ const CreateWallet = ({ history, location }: AuthRouterParams) => {
 
   const handlePasswordTyping = ({ value }: { value: string }) => {
     setPassword(value);
+    captureReactBreadcrumb({
+      category: 'Create Wallet',
+      data: {
+        action: 'Input password typing',
+      },
+      level: 'info',
+    });
   };
 
   const handlePasswordVerifyTyping = ({ value }: { value: string }) => {
     setVerifiedPassword(value);
     setVerifyPasswordError('');
+    captureReactBreadcrumb({
+      category: 'Create Wallet',
+      data: {
+        action: 'Input password verify typing',
+      },
+      level: 'info',
+    });
   };
 
   const handleNameTyping = ({ value }: { value: string }) => {
     setConvenientWalletName(value);
+    captureReactBreadcrumb({
+      category: 'Create Wallet',
+      data: {
+        action: 'Input convenient name typing',
+      },
+      level: 'info',
+    });
   };
 
   const nextAction = () => {
@@ -171,9 +193,25 @@ const CreateWallet = ({ history, location }: AuthRouterParams) => {
 
       history.push(AuthPath.ProtectWallet);
     }
+    captureReactBreadcrumb({
+      category: 'Create Wallet',
+      data: {
+        action: 'Click button next',
+      },
+      level: 'info',
+    });
   };
 
-  const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToExplanation = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Create Wallet',
+      data: {
+        action: 'Navigate to explanation setup guide',
+      },
+      level: 'info',
+    });
+  };
 
   if (isLoaderVisible) {
     return (

--- a/app/screens/auth/FileRestore.tsx
+++ b/app/screens/auth/FileRestore.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { restoreFile } from '../../redux/wallet/actions';
 import { BackButton } from '../../components/common';
 import { DragAndDrop } from '../../components/auth';
@@ -43,11 +44,25 @@ const FileRestore = ({ history }: AuthRouterParams) => {
   }) => {
     if (fileName.split('.').pop() !== 'json') {
       setHasError(true);
+      captureReactBreadcrumb({
+        category: 'File Restore',
+        data: {
+          action: 'Add restore wallet file with error',
+        },
+        level: 'info',
+      });
     } else {
       setFileName(fileName);
       setFilePath(filePath);
       setHasError(false);
     }
+    captureReactBreadcrumb({
+      category: 'File Restore',
+      data: {
+        action: 'Add restore wallet file',
+      },
+      level: 'info',
+    });
   };
 
   const openWalletFile = async () => {
@@ -56,10 +71,36 @@ const FileRestore = ({ history }: AuthRouterParams) => {
       setLastSelectedWalletPath(filePath);
       history.push(AuthPath.Unlock);
     }
+    captureReactBreadcrumb({
+      category: 'File Restore',
+      data: {
+        action: 'Open wallet file for restore',
+      },
+      level: 'info',
+    });
   };
 
-  const navigateToBackupGuide = () =>
+  const navigateToBackButton = () => {
+    history.push(AuthPath.Recover);
+    captureReactBreadcrumb({
+      category: 'File Restore',
+      data: {
+        action: 'Navigate to back button',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToBackupGuide = () => {
     window.open(ExternalLinks.RestoreFileGuide);
+    captureReactBreadcrumb({
+      category: 'File Restore',
+      data: {
+        action: 'Navigate to backup guide',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <WrapperWith2SideBars
@@ -68,7 +109,7 @@ const FileRestore = ({ history }: AuthRouterParams) => {
       header="OPEN WALLET"
       subHeader="Open a wallet from a wallet file"
     >
-      <BackButton action={history.goBack} />
+      <BackButton action={navigateToBackButton} />
       <DdArea>
         <DragAndDrop
           onFilesAdded={addFile}

--- a/app/screens/auth/Leaving.tsx
+++ b/app/screens/auth/Leaving.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { CorneredContainer, BackButton } from '../../components/common';
 import { Button, Link, Tooltip } from '../../basicComponents';
 import { bigInnerSideBar } from '../../assets/images';
@@ -69,7 +70,49 @@ const Leaving = ({ history }: AuthRouterParams) => {
     (state: RootState) => state.wallet.walletFiles.length > 0
   );
 
-  const navigateToSetupGuide = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToSetupGuide = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Leaving Setup',
+      data: {
+        action: 'Navigate to setup guide',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToBackButton = () => {
+    history.push(AuthPath.ConnectionType);
+    captureReactBreadcrumb({
+      category: 'Leaving Setup',
+      data: {
+        action: 'Navigate to back button',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToRecoverIt = () => {
+    history.push(AuthPath.Recover);
+    captureReactBreadcrumb({
+      category: 'Leaving Setup',
+      data: {
+        action: 'Navigate to recover it',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToLeaveSetup = () => {
+    history.push(hasWalletFiles ? AuthPath.Unlock : AuthPath.Welcome);
+    captureReactBreadcrumb({
+      category: 'Leaving Setup',
+      data: {
+        action: 'Navigate to leave setup',
+      },
+      level: 'info',
+    });
+  };
 
   const header = 'LEAVING SETUP';
 
@@ -83,28 +126,20 @@ const Leaving = ({ history }: AuthRouterParams) => {
       >
         <SideBar src={bigInnerSideBar} />
         <Indicator />
-        <BackButton action={history.goBack} />
+        <BackButton action={navigateToBackButton} />
         <BottomPart>
           <ComplexLink>
             <Link onClick={navigateToSetupGuide} text="SETUP GUIDE" />
             <Row>
               <Text>ALREADY HAVE A WALLET? &nbsp;</Text>
-              <Link
-                onClick={() => history.push(AuthPath.Recover)}
-                text="RECOVER IT"
-              />
+              <Link onClick={navigateToRecoverIt} text="RECOVER IT" />
               <Tooltip
                 width={140}
                 text="You can recover your wallet from file or mnemonics"
               />
             </Row>
           </ComplexLink>
-          <Button
-            text="LEAVE SETUP"
-            onClick={() =>
-              history.push(hasWalletFiles ? AuthPath.Unlock : AuthPath.Welcome)
-            }
-          />
+          <Button text="LEAVE SETUP" onClick={navigateToLeaveSetup} />
         </BottomPart>
       </CorneredContainer>
     </Wrapper>

--- a/app/screens/auth/RestoreWallet.tsx
+++ b/app/screens/auth/RestoreWallet.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useHistory } from 'react-router';
 import { CorneredContainer, BackButton } from '../../components/common';
+import { captureReactBreadcrumb } from '../../sentry';
 import { Button, Link } from '../../basicComponents';
 import { AuthPath } from '../../routerPaths';
 import { ExternalLinks } from '../../../shared/constants';
@@ -9,7 +10,49 @@ const btnStyle = { margin: '7px 0' };
 
 const RestoreWallet = () => {
   const history = useHistory();
-  const navigateToWalletGuide = () => window.open(ExternalLinks.RestoreGuide);
+  const navigateToWalletGuide = () => {
+    window.open(ExternalLinks.RestoreGuide);
+    captureReactBreadcrumb({
+      category: 'Restore wallet',
+      data: {
+        action: 'Navigate to wallet guide',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToOpenFromFile = () => {
+    history.push(AuthPath.RecoverFromFile);
+    captureReactBreadcrumb({
+      category: 'Restore wallet',
+      data: {
+        action: 'Navigate to open from file',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToRestoreFrom12Words = () => {
+    history.push(AuthPath.RecoverFromMnemonics);
+    captureReactBreadcrumb({
+      category: 'Unlock wallet',
+      data: {
+        action: 'Navigate to restore from 12 words',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToRestoreFrom24Words = () => {
+    history.push(AuthPath.RecoverFromMnemonics, { wordsAmount: 24 });
+    captureReactBreadcrumb({
+      category: 'Unlock wallet',
+      data: {
+        action: 'Navigate to restore from 24 words',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <CorneredContainer
@@ -22,23 +65,21 @@ const RestoreWallet = () => {
       <Button
         text="OPEN FROM FILE"
         isPrimary={false}
-        onClick={() => history.push(AuthPath.RecoverFromFile)}
+        onClick={navigateToOpenFromFile}
         width={250}
         style={btnStyle}
       />
       <Button
         text="RESTORE FROM 12 WORDS"
         isPrimary={false}
-        onClick={() => history.push(AuthPath.RecoverFromMnemonics)}
+        onClick={navigateToRestoreFrom12Words}
         width={250}
         style={btnStyle}
       />
       <Button
         text="RESTORE FROM 24 WORDS"
         isPrimary={false}
-        onClick={() =>
-          history.push(AuthPath.RecoverFromMnemonics, { wordsAmount: 24 })
-        }
+        onClick={navigateToRestoreFrom24Words}
         width={250}
         style={btnStyle}
       />

--- a/app/screens/auth/SwitchNetwork.tsx
+++ b/app/screens/auth/SwitchNetwork.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { CorneredContainer } from '../../components/common';
 import { Button, Link, DropDown, Loader } from '../../basicComponents';
 import { eventsService } from '../../infra/eventsService';
@@ -69,9 +70,23 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
       const { payload } = await eventsService.listNetworks();
       setNetworks(payload || []);
       setNetworksLoading(false);
+      captureReactBreadcrumb({
+        category: 'Switch network',
+        data: {
+          action: 'Update wallet network list',
+        },
+        level: 'info',
+      });
     } catch (err) {
       setNetworksLoading(false);
       console.error(err); // eslint-disable-line no-console
+      captureReactBreadcrumb({
+        category: 'Switch network',
+        data: {
+          action: `Update wallet network list error: ${err}`,
+        },
+        level: 'info',
+      });
     }
   };
 
@@ -84,9 +99,38 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOnline]);
 
-  const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToExplanation = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Switch network',
+      data: {
+        action: 'Navigate to setup guide',
+      },
+      level: 'info',
+    });
+  };
 
-  const selectItem = ({ index }) => setSelectedItemIndex(index);
+  const selectItem = ({ index }) => {
+    setSelectedItemIndex(index);
+    captureReactBreadcrumb({
+      category: 'Switch network',
+      data: {
+        action: 'Select a public Spacemesh network for your wallet',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToCancelButton = () => {
+    history.push(MainPath.Settings);
+    captureReactBreadcrumb({
+      category: 'Switch network',
+      data: {
+        action: 'Navigate to cancel button',
+      },
+      level: 'info',
+    });
+  };
 
   const hasAvailableNetworks = networks.length > 0;
   const getDropDownData = () => {
@@ -104,7 +148,6 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
         description: genesisID?.length ? `(ID ${genesisID})` : '',
       }));
     }
-
     return [{ label: 'NO NETWORKS AVAILABLE', isDisabled: true }];
   };
 
@@ -145,6 +188,13 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
     if (redirect === AuthPath.Unlock) {
       return history.push(redirect, { withLoader: true });
     }
+    captureReactBreadcrumb({
+      category: 'Switch network',
+      data: {
+        action: 'Navigate to next action',
+      },
+      level: 'info',
+    });
 
     return history.push(redirect || AuthPath.Unlock);
   };
@@ -163,6 +213,13 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
         if (err instanceof Error) {
           dispatch(setUiError(err));
         }
+        captureReactBreadcrumb({
+          category: 'Switch network',
+          data: {
+            action: `Next button error: ${err}`,
+          },
+          level: 'info',
+        });
       }
     }
 
@@ -212,7 +269,7 @@ const SwitchNetwork = ({ history, location }: AuthRouterParams) => {
           <RightSide>
             {location?.state?.showBackButton && (
               <Button
-                onClick={() => history.push(MainPath.Settings)}
+                onClick={navigateToCancelButton}
                 isPrimary={false}
                 text="CANCEL"
               />

--- a/app/screens/auth/WalletConnectionType.tsx
+++ b/app/screens/auth/WalletConnectionType.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { CorneredContainer, BackButton } from '../../components/common';
 import { Button, Link, Tooltip } from '../../basicComponents';
 import { AuthPath } from '../../routerPaths';
@@ -86,8 +87,41 @@ const BottomPart = styled.div`
 `;
 
 const WalletConnectionType = ({ history, location }: AuthRouterParams) => {
-  const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToExplanation = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Wallet connection type',
+      data: {
+        action: 'Navigate to explanation setup',
+      },
+      level: 'info',
+    });
+  };
+
   const isRecoveryMode = isMnemonicExisting(location?.state?.mnemonic);
+
+  const navigateToBackButton = () => {
+    history.push(AuthPath.Leaving);
+    captureReactBreadcrumb({
+      category: 'Wallet connection type',
+      data: {
+        action: 'Navigate to back button',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToRestoreExistingWallet = () => {
+    history.push(AuthPath.Recover);
+    captureReactBreadcrumb({
+      category: 'Wallet connection type',
+      data: {
+        action: 'Navigate to restore existing wallet',
+      },
+      level: 'info',
+    });
+  };
+
   const handleNextStep = (walletOnly: boolean) => () => {
     if (location?.state?.mnemonic) {
       history.push(AuthPath.SwitchNetwork, {
@@ -95,8 +129,22 @@ const WalletConnectionType = ({ history, location }: AuthRouterParams) => {
         mnemonic: location.state.mnemonic,
         creatingWallet: true,
       });
+      captureReactBreadcrumb({
+        category: 'Wallet connection type',
+        data: {
+          action: 'Click next wallet step',
+        },
+        level: 'info',
+      });
     } else {
       history.push(AuthPath.WalletType, { isWalletOnly: walletOnly });
+      captureReactBreadcrumb({
+        category: 'Wallet connection type',
+        data: {
+          action: 'Click next wallet only step',
+        },
+        level: 'info',
+      });
     }
   };
 
@@ -109,7 +157,7 @@ const WalletConnectionType = ({ history, location }: AuthRouterParams) => {
         header="NEW WALLET"
         subHeader="Configure your new wallet"
       >
-        <BackButton action={() => history.push(AuthPath.Leaving)} />
+        <BackButton action={navigateToBackButton} />
         <RowJust>
           <RowColumn>
             <Row>
@@ -154,7 +202,7 @@ const WalletConnectionType = ({ history, location }: AuthRouterParams) => {
           <Row>
             {!isRecoveryMode && (
               <Link
-                onClick={() => history.push(AuthPath.Recover)}
+                onClick={navigateToRestoreExistingWallet}
                 text="RESTORE EXISTING WALLET"
               />
             )}

--- a/app/screens/auth/WalletType.tsx
+++ b/app/screens/auth/WalletType.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { CorneredContainer, BackButton } from '../../components/common';
 import { Button, Link, Tooltip } from '../../basicComponents';
 import { walletSecondWhite } from '../../assets/images';
@@ -99,7 +100,38 @@ const BottomPart = styled.div`
 `;
 
 const WalletType = ({ history, location }: AuthRouterParams) => {
-  const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToExplanation = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Wallet type',
+      data: {
+        action: 'Navigate to setup guide',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToBackButton = () => {
+    history.push(AuthPath.ConnectionType);
+    captureReactBreadcrumb({
+      category: 'Wallet type',
+      data: {
+        action: 'Navigate to back button',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToRestoreWallet = () => {
+    history.push(AuthPath.Recover);
+    captureReactBreadcrumb({
+      category: 'Wallet type',
+      data: {
+        action: 'Navigate to restore wallet',
+      },
+      level: 'info',
+    });
+  };
 
   const navigateToCreateWallet = async () => {
     const { isWalletOnly } = location.state;
@@ -108,6 +140,13 @@ const WalletType = ({ history, location }: AuthRouterParams) => {
         ? { isWalletOnly }
         : { redirect: AuthPath.CreateWallet }),
       creatingWallet: true,
+    });
+    captureReactBreadcrumb({
+      category: 'Wallet type',
+      data: {
+        action: 'Click button create wallet',
+      },
+      level: 'info',
     });
   };
 
@@ -120,7 +159,7 @@ const WalletType = ({ history, location }: AuthRouterParams) => {
         header="WALLET SETUP"
         subHeader="Select which features you`d like to setup"
       >
-        <BackButton action={history.goBack} />
+        <BackButton action={navigateToBackButton} />
         <RowJust>
           <RowColumn>
             <Row>
@@ -157,10 +196,7 @@ const WalletType = ({ history, location }: AuthRouterParams) => {
         <BottomPart>
           <Link onClick={navigateToExplanation} text="WALLET SETUP GUIDE" />
           <Row>
-            <Link
-              onClick={() => history.push(AuthPath.Recover)}
-              text="RESTORE  WALLET"
-            />{' '}
+            <Link onClick={navigateToRestoreWallet} text="RESTORE  WALLET" />{' '}
             <Tooltip
               width={120}
               text="Locate a file or restore from 12/24 words"

--- a/app/screens/auth/Welcome.tsx
+++ b/app/screens/auth/Welcome.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { CorneredContainer } from '../../components/common';
 import { SubHeader } from '../../components/common/CorneredContainer';
 import { Button, Link, Tooltip } from '../../basicComponents';
@@ -91,7 +92,38 @@ const SubHeaderExt = styled(SubHeader)`
 `;
 
 const Welcome = ({ history }: AuthRouterParams) => {
-  const navigateToSetupGuide = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToSetupGuide = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Welcome',
+      data: {
+        action: 'Navigate to setup guide',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToExistingWallet = () => {
+    history.push(AuthPath.Recover);
+    captureReactBreadcrumb({
+      category: 'Welcome',
+      data: {
+        action: 'Navigate to open an existing wallet',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToSetupWallet = () => {
+    history.push(AuthPath.ConnectionType);
+    captureReactBreadcrumb({
+      category: 'Welcome',
+      data: {
+        action: 'Navigate to setup wallet',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <CorneredContainer width={760} height={400} header="WELCOME TO SPACEMESH">
@@ -128,7 +160,7 @@ const Welcome = ({ history }: AuthRouterParams) => {
         <Link onClick={navigateToSetupGuide} text="SETUP GUIDE" />
         <ComplexLink>
           <Link
-            onClick={() => history.push(AuthPath.Recover)}
+            onClick={navigateToExistingWallet}
             text="OPEN AN EXISTING WALLET"
           />
           <Tooltip
@@ -136,10 +168,7 @@ const Welcome = ({ history }: AuthRouterParams) => {
             text="Locate a file or restore from 12/24 words"
           />
           <ButtonMargin>
-            <Button
-              text="SETUP"
-              onClick={() => history.push(AuthPath.ConnectionType)}
-            />
+            <Button text="SETUP" onClick={navigateToSetupWallet} />
           </ButtonMargin>
         </ComplexLink>
       </BottomPart>

--- a/app/screens/auth/WordsRestore.tsx
+++ b/app/screens/auth/WordsRestore.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback, JSX } from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router';
 import { useLocation } from 'react-router-dom';
+import { captureReactBreadcrumb } from '../../sentry';
 import { BackButton } from '../../components/common';
 import {
   WrapperWith2SideBars,
@@ -83,6 +84,13 @@ const WordsRestore = () => {
       (acc, val, idx) => R.adjust(index + idx, R.always(val), acc),
       words
     );
+    captureReactBreadcrumb({
+      category: 'Words Restore',
+      data: {
+        action: 'Input change',
+      },
+      level: 'info',
+    });
 
     setWords(newWords);
     setHasError(false);
@@ -110,7 +118,21 @@ const WordsRestore = () => {
       });
     } else {
       setHasError(true);
+      captureReactBreadcrumb({
+        category: 'Words Restore',
+        data: {
+          action: 'Restore with words with error',
+        },
+        level: 'info',
+      });
     }
+    captureReactBreadcrumb({
+      category: 'Words Restore',
+      data: {
+        action: 'Restore with words with validate state',
+      },
+      level: 'info',
+    });
   }, [words, history, setHasError]);
 
   const handleKeyUp = useCallback(
@@ -125,6 +147,13 @@ const WordsRestore = () => {
   const nextInput = (index: number) => {
     const next = Math.max(0, Math.min(WORDS_AMOUNT, index + 1));
     inputRefs.current[next]?.focus();
+    captureReactBreadcrumb({
+      category: 'Words Restore',
+      data: {
+        action: 'Next input',
+      },
+      level: 'info',
+    });
   };
 
   useEffect(() => {
@@ -134,8 +163,16 @@ const WordsRestore = () => {
     };
   }, [handleKeyUp]);
 
-  const navigateTo12WordRestoreGuide = () =>
+  const navigateToWordRestoreGuide = () => {
     window.open(ExternalLinks.RestoreMnemoGuide);
+    captureReactBreadcrumb({
+      category: 'Words Restore',
+      data: {
+        action: 'Navigate to words restore guide',
+      },
+      level: 'info',
+    });
+  };
 
   const renderInputs = () => {
     const is24WordsMode = WORDS_AMOUNT !== DEFAULT_RESTORE_WORDS_AMOUNT;
@@ -163,6 +200,16 @@ const WordsRestore = () => {
 
   const isDoneDisabled = !isDoneEnabled();
 
+  const resetErrorWords = () => {
+    setHasError(false);
+    captureReactBreadcrumb({
+      category: 'Words Restore',
+      data: {
+        action: 'Reset error Words',
+      },
+      level: 'info',
+    });
+  };
   return (
     <WrapperWith2SideBars
       width={800}
@@ -174,7 +221,7 @@ const WordsRestore = () => {
       {renderInputs()}
       <BottomSection>
         <Link
-          onClick={navigateTo12WordRestoreGuide}
+          onClick={navigateToWordRestoreGuide}
           text={'WORDS BACKUP GUIDE'}
         />
         <Button
@@ -185,9 +232,7 @@ const WordsRestore = () => {
       </BottomSection>
       {hasError && (
         <ErrorPopup
-          onClick={() => {
-            setHasError(false);
-          }}
+          onClick={resetErrorWords}
           text={`this ${WORDS_AMOUNT} words phrase in incorrect, please try again`}
           style={{ bottom: 15, left: 185 }}
         />

--- a/app/screens/backup/BackupOptions.tsx
+++ b/app/screens/backup/BackupOptions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { RouteComponentProps } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { backupWallet } from '../../redux/wallet/actions';
 import {
   WrapperWith2SideBars,
@@ -76,6 +77,13 @@ const BackupOptions = ({ history }: RouteComponentProps) => {
 
   const navigateTo12WordsBackup = () => {
     history.push(BackupPath.Mnemonics);
+    captureReactBreadcrumb({
+      category: 'Backup Options',
+      data: {
+        action: 'Navigate to FILE BACKUP',
+      },
+      level: 'info',
+    });
   };
 
   const handleBackupWallet = async () => {
@@ -83,9 +91,25 @@ const BackupOptions = ({ history }: RouteComponentProps) => {
     if (filePath) {
       history.push(BackupPath.File, { filePath });
     }
+    captureReactBreadcrumb({
+      category: 'Backup Options',
+      data: {
+        action: 'Click file backup navigate to 12 words',
+      },
+      level: 'info',
+    });
   };
 
-  const openBackupGuide = () => window.open(ExternalLinks.BackupGuide);
+  const openBackupGuide = () => {
+    window.open(ExternalLinks.BackupGuide);
+    captureReactBreadcrumb({
+      category: 'Backup Options',
+      data: {
+        action: 'Navigate backup guide',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <Wrapper>

--- a/app/screens/backup/FileBackup.tsx
+++ b/app/screens/backup/FileBackup.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { RouteComponentProps } from 'react-router-dom';
 import { StaticContext } from 'react-router';
+import { captureReactBreadcrumb } from '../../sentry';
 import { WrapperWith2SideBars, Button, Link } from '../../basicComponents';
 import { eventsService } from '../../infra/eventsService';
 import { MainPath } from '../../routerPaths';
@@ -37,13 +38,36 @@ const FileBackup = ({
 >) => {
   const showBackupFile = () => {
     eventsService.showFileInFolder({ filePath: location.state.filePath });
+    captureReactBreadcrumb({
+      category: 'File Backup',
+      data: {
+        action: 'Show backup file',
+      },
+      level: 'info',
+    });
   };
 
   const backToWalletRoot = () => {
     history.push(MainPath.Wallet);
+    captureReactBreadcrumb({
+      category: 'File Backup',
+      data: {
+        action: 'Back to wallet root',
+      },
+      level: 'info',
+    });
   };
 
-  const openBackupGuide = () => window.open(ExternalLinks.BackupGuide);
+  const openBackupGuide = () => {
+    window.open(ExternalLinks.BackupGuide);
+    captureReactBreadcrumb({
+      category: 'File Backup',
+      data: {
+        action: 'Open backup guide',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <WrapperWith2SideBars

--- a/app/screens/backup/TestMe.tsx
+++ b/app/screens/backup/TestMe.tsx
@@ -8,6 +8,8 @@ import {
 } from 'react-beautiful-dnd';
 import { useLocation } from 'react-router-dom';
 import { useHistory } from 'react-router';
+
+import { captureReactBreadcrumb } from '../../sentry';
 import {
   WrapperWith2SideBars,
   Button,
@@ -230,12 +232,38 @@ const TestMe = (props: Props) => {
     getTestWords(mnemonic, TEST_WORDS_AMOUNT, MNEMONIC_LENGTH)
   );
 
-  const resetTest = () =>
+  const resetTest = () => {
     setTestWords(getTestWords(mnemonic, TEST_WORDS_AMOUNT, MNEMONIC_LENGTH));
+    captureReactBreadcrumb({
+      category: 'Test me',
+      data: {
+        action: 'Reset test',
+      },
+      level: 'info',
+    });
+  };
 
-  const openBackupGuide = () => window.open(ExternalLinks.BackupGuide);
+  const openBackupGuide = () => {
+    window.open(ExternalLinks.BackupGuide);
+    captureReactBreadcrumb({
+      category: 'Test me',
+      data: {
+        action: 'Open backup guide',
+      },
+      level: 'info',
+    });
+  };
 
-  const navigateToWallet = () => history.push(WalletPath.Overview);
+  const navigateToWallet = () => {
+    history.push(WalletPath.Overview);
+    captureReactBreadcrumb({
+      category: 'Test me',
+      data: {
+        action: 'Click navigate to wallet',
+      },
+      level: 'info',
+    });
+  };
 
   const getWordByIndex = (i: number) =>
     Object.entries(testWords).find(([_, { index }]) => index === i)?.[0];
@@ -261,6 +289,13 @@ const TestMe = (props: Props) => {
         ...testWords[draggableId],
         index: newIndex,
       },
+    });
+    captureReactBreadcrumb({
+      category: 'Test me',
+      data: {
+        action: 'Render drag and drop area',
+      },
+      level: 'info',
     });
   };
 

--- a/app/screens/backup/WordsBackup.tsx
+++ b/app/screens/backup/WordsBackup.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
+import { captureReactBreadcrumb } from '../../sentry';
 import { WrapperWith2SideBars, Button, Link } from '../../basicComponents';
 import { eventsService } from '../../infra/eventsService';
 import { smColors } from '../../vars';
@@ -111,9 +112,23 @@ const WordsBackup = ({
   const navigateToTestMe = () => {
     if (nextButtonHandler) {
       nextButtonHandler(mnemonic);
+      captureReactBreadcrumb({
+        category: 'Twelve Words Backup',
+        data: {
+          action: 'Navigate to wallet step',
+        },
+        level: 'info',
+      });
       return;
     }
     history.push(BackupPath.TestMnemonics, { mnemonic });
+    captureReactBreadcrumb({
+      category: 'Twelve Words Backup',
+      data: {
+        action: 'Navigate to test mnemonic',
+      },
+      level: 'info',
+    });
   };
 
   const copyWords = async () => {
@@ -125,13 +140,36 @@ const WordsBackup = ({
 
     await navigator.clipboard.writeText(mnemonicWithNumbers);
     setIsCopied(true);
+    captureReactBreadcrumb({
+      category: 'Twelve Words Backup',
+      data: {
+        action: 'Copy 12 words',
+      },
+      level: 'info',
+    });
   };
 
   const printWords = () => {
     eventsService.print({ content: wordsPrint });
+    captureReactBreadcrumb({
+      category: 'Twelve Words Backup',
+      data: {
+        action: 'Print 12 words',
+      },
+      level: 'info',
+    });
   };
 
-  const openBackupGuide = () => window.open(ExternalLinks.BackupGuide);
+  const openBackupGuide = () => {
+    window.open(ExternalLinks.BackupGuide);
+    captureReactBreadcrumb({
+      category: 'Twelve Words Backup',
+      data: {
+        action: 'Open Backup Guide',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <WrapperWith2SideBars

--- a/app/screens/contacts/Contacts.tsx
+++ b/app/screens/contacts/Contacts.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
+import { captureReactBreadcrumb } from '../../sentry';
 import {
   CreateNewContact,
   CreatedNewContact,
@@ -309,6 +310,13 @@ const Contacts = ({ history }: RouteComponentProps) => {
     e.stopPropagation();
     setAddressToAdd(contact.address);
     setShowCreateNewContactModal(true);
+    captureReactBreadcrumb({
+      category: 'Contacts',
+      data: {
+        action: 'Add new contact modal',
+      },
+      level: 'info',
+    });
   };
 
   const createdNewContact = () => {
@@ -318,20 +326,48 @@ const Contacts = ({ history }: RouteComponentProps) => {
     newContactCreatedTimeOut = setTimeout(() => {
       setIsNewContactCreated(false);
     }, 10000);
+    captureReactBreadcrumb({
+      category: 'Contacts',
+      data: {
+        action: 'Create new contact',
+      },
+      level: 'info',
+    });
   };
 
   const cancelCreateNewContact = () => {
     setAddressToAdd('');
     setShowCreateNewContactModal(false);
     setIsNewContactCreated(false);
+    captureReactBreadcrumb({
+      category: 'Contacts',
+      data: {
+        action: 'Cancel create new contact',
+      },
+      level: 'info',
+    });
   };
 
   const navigateToSendCoins = ({ contact }: { contact: Contact }) => {
     history.push(WalletPath.SendCoins, { contact });
+    captureReactBreadcrumb({
+      category: 'Contacts',
+      data: {
+        action: 'Navigate to Send Coins',
+      },
+      level: 'info',
+    });
   };
 
   const handleEditButton = (contact: Contact) => {
     setContactEditing(contact);
+    captureReactBreadcrumb({
+      category: 'Contacts',
+      data: {
+        action: 'Edit button',
+      },
+      level: 'info',
+    });
   };
 
   const deleteContact = async ({
@@ -343,6 +379,13 @@ const Contacts = ({ history }: RouteComponentProps) => {
   }) => {
     await dispatch(removeFromContacts({ password, contact }));
     setContactToDelete(null);
+    captureReactBreadcrumb({
+      category: 'Contacts',
+      data: {
+        action: 'Delete contact',
+      },
+      level: 'info',
+    });
   };
 
   const renderLastUsedContacts = () => {
@@ -431,6 +474,14 @@ const Contacts = ({ history }: RouteComponentProps) => {
 
   const renderContacts = () => {
     const filteredContacts = contacts.filter(contactFilter);
+    captureReactBreadcrumb({
+      category: 'Contacts',
+      data: {
+        action: 'Render contacts',
+      },
+      level: 'info',
+    });
+
     if (filteredContacts.length === 0) {
       return (
         <ContactText>{`No contacts matching criteria "${searchTerm}" found`}</ContactText>
@@ -491,6 +542,17 @@ const Contacts = ({ history }: RouteComponentProps) => {
     );
   };
 
+  const searchContacts = ({ value }) => {
+    setTmpSearchTerm(value);
+    captureReactBreadcrumb({
+      category: 'Contacts',
+      data: {
+        action: 'Search contacts',
+      },
+      level: 'info',
+    });
+  };
+
   return (
     <WrapperWith2SideBars width={1000} height={520} header="CONTACTS">
       <SearchWrapper>
@@ -500,9 +562,7 @@ const Contacts = ({ history }: RouteComponentProps) => {
           value={tmpSearchTerm}
           type="text"
           placeholder="Search contacts"
-          onChange={({ value }) => {
-            setTmpSearchTerm(value);
-          }}
+          onChange={searchContacts}
           onChangeDebounced={({ value }) => {
             setSearchTerm(value.toString());
           }}

--- a/app/screens/main/Main.tsx
+++ b/app/screens/main/Main.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import { Route, Switch, useLocation, useHistory } from 'react-router-dom';
 import styled, { DefaultTheme, useTheme } from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import { logout } from '../../redux/auth/actions';
 import { Logo } from '../../components/common';
 import {
@@ -186,6 +187,13 @@ const Main = () => {
   const handleLogOut = () => {
     history.push(AuthPath.Unlock, { isLoggedOut: true });
     dispatch(logout());
+    captureReactBreadcrumb({
+      category: 'Main',
+      data: {
+        action: 'Navigate to logout',
+      },
+      level: 'info',
+    });
   };
 
   const isActive = (route: string) => {
@@ -222,6 +230,39 @@ const Main = () => {
 
   const bgColor = theme.color.primary;
   const bntStyle = { marginRight: 15, marginTop: 10 };
+
+  const navigateToSettings = () => {
+    handleNavRoute(MainPath.Settings);
+    captureReactBreadcrumb({
+      category: 'Main',
+      data: {
+        action: 'Navigate to settings',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToGetSmesh = () => {
+    handleOpenLink(ExternalLinks.GetCoinGuide);
+    captureReactBreadcrumb({
+      category: 'Main',
+      data: {
+        action: 'Navigate to GET SMESH',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToHelp = () => {
+    handleOpenLink(ExternalLinks.Help);
+    captureReactBreadcrumb({
+      category: 'Main',
+      data: {
+        action: 'Navigate to Help',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <Wrapper>
@@ -279,7 +320,7 @@ const Main = () => {
           <NavBarPart>
             <TooltipWrapper>
               <SecondaryButton
-                onClick={() => handleNavRoute(MainPath.Settings)}
+                onClick={navigateToSettings}
                 img={settings}
                 imgHeight={25}
                 imgWidth={25}
@@ -293,7 +334,7 @@ const Main = () => {
             </TooltipWrapper>
             <TooltipWrapper>
               <SecondaryButton
-                onClick={() => handleOpenLink(ExternalLinks.GetCoinGuide)}
+                onClick={navigateToGetSmesh}
                 img={getCoins}
                 imgHeight={25}
                 imgWidth={25}
@@ -307,7 +348,7 @@ const Main = () => {
             </TooltipWrapper>
             <TooltipWrapper>
               <SecondaryButton
-                onClick={() => handleOpenLink(ExternalLinks.Help)}
+                onClick={navigateToHelp}
                 img={help}
                 imgHeight={25}
                 imgWidth={25}

--- a/app/screens/modal/NoInternetConnection.tsx
+++ b/app/screens/modal/NoInternetConnection.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { Button } from '../../basicComponents';
 import Modal from '../../components/common/Modal';
 import useNavigatorOnLine from '../../hooks/useNavigatorOnLine';
@@ -30,6 +31,16 @@ const NoInternetConnection = () => {
   if (isOnline || isIgnore) {
     return null;
   }
+  const handleSetIgnore = () => {
+    setIgnore(true);
+    captureReactBreadcrumb({
+      category: 'No Internet Connection',
+      data: {
+        action: 'Click button set ignore',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <ReactPortal modalId="no-internet-connection">
@@ -46,7 +57,7 @@ const NoInternetConnection = () => {
           Just click &quot;Ignore&quot; and proceed.
         </ErrorMessage>
         <ButtonsWrapper>
-          <Button onClick={() => setIgnore(true)} text="IGNORE" />
+          <Button onClick={handleSetIgnore} text="IGNORE" />
         </ButtonsWrapper>
       </Modal>
     </ReactPortal>

--- a/app/screens/modal/WriteFilePermissionError.tsx
+++ b/app/screens/modal/WriteFilePermissionError.tsx
@@ -5,6 +5,7 @@ import {
   WarningType,
   WriteFilePermissionWarningKind,
 } from '../../../shared/warning';
+import { captureReactBreadcrumb } from '../../sentry';
 import { Button } from '../../basicComponents';
 import Modal from '../../components/common/Modal';
 import { eventsService } from '../../infra/eventsService';
@@ -62,6 +63,13 @@ const WriteFilePermissionError = () => {
     eventsService.showFileInFolder({
       filePath: filePermissionError.payload.filePath,
     });
+    captureReactBreadcrumb({
+      category: 'Write File Permission Error',
+      data: {
+        action: 'Click button show file',
+      },
+      level: 'info',
+    });
   };
 
   const isCriticalError =
@@ -72,6 +80,13 @@ const WriteFilePermissionError = () => {
 
   const handleDismiss = () => {
     dispatch(omitWarning(filePermissionError));
+    captureReactBreadcrumb({
+      category: 'Write File Permission Error',
+      data: {
+        action: 'Dismiss file',
+      },
+      level: 'info',
+    });
   };
 
   const subheader = getSubheader(filePermissionError.payload.kind);

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import { eventsService } from '../../infra/eventsService';
 import { NetworkStatus } from '../../components/NetworkStatus';
 import {
@@ -126,11 +127,26 @@ const Network = ({ history }) => {
     // In case if Node restarts earlier the component will be
     // re-rendered and Restart button will disappear
     setRestarting(false);
+    captureReactBreadcrumb({
+      category: 'Network',
+      data: {
+        action: 'Click button node restart',
+      },
+      level: 'info',
+    });
   }, []);
 
   const requestSwitchApiProvider = () => {
     history.push(AuthPath.ConnectToAPI);
+    captureReactBreadcrumb({
+      category: 'Network',
+      data: {
+        action: 'Click button switch API provider',
+      },
+      level: 'info',
+    });
   };
+
   const isShowMissingLibsMessage = [
     NodeErrorType.OPEN_CL_NOT_INSTALLED,
     NodeErrorType.REDIST_NOT_INSTALLED,
@@ -267,6 +283,17 @@ const Network = ({ history }) => {
     </DetailsWrap>
   );
 
+  const navigateChooseNetwork = () => {
+    goToSwitchNetwork(history, isWalletMode);
+    captureReactBreadcrumb({
+      category: 'Network',
+      data: {
+        action: 'Click button choose the network',
+      },
+      level: 'info',
+    });
+  };
+
   const renderNoNetwork = () => (
     <DetailsWrap>
       <DetailsRow>
@@ -274,7 +301,7 @@ const Network = ({ history }) => {
           text="CHOOSE THE NETWORK"
           width={180}
           isPrimary
-          onClick={() => goToSwitchNetwork(history, isWalletMode)}
+          onClick={navigateChooseNetwork}
         />
       </DetailsRow>
     </DetailsWrap>
@@ -282,6 +309,13 @@ const Network = ({ history }) => {
 
   const openLogFile = () => {
     eventsService.showFileInFolder({ isLogFile: true });
+    captureReactBreadcrumb({
+      category: 'Network',
+      data: {
+        action: 'Click button browse log file',
+      },
+      level: 'info',
+    });
   };
 
   return (

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
-
+import { captureReactBreadcrumb } from '../../sentry';
 import { SmesherIntro, SmesherLog } from '../../components/node';
 import {
   WrapperWith2SideBars,
@@ -428,6 +428,18 @@ const Node = ({ history, location }: Props) => {
         </LineWrap>
       );
     });
+
+  const navigateDataDirectory = () => {
+    eventsService.showFileInFolder({ filePath: posDataPath });
+    captureReactBreadcrumb({
+      category: 'Node',
+      data: {
+        action: 'Navigate to data directory',
+      },
+      level: 'info',
+    });
+  };
+
   const getTableDataB = (): RowData[] => {
     const progress =
       ((numLabelsWritten * smesherConfig.bitsPerLabel) /
@@ -471,11 +483,7 @@ const Node = ({ history, location }: Props) => {
       ],
       [
         'Data Directory',
-        <PosDirLink
-          onClick={() =>
-            eventsService.showFileInFolder({ filePath: posDataPath })
-          }
-        >
+        <PosDirLink onClick={navigateDataDirectory}>
           <PosFolderIcon />
           <PathDir>{posDataPath}</PathDir>
         </PosDirLink>,
@@ -500,14 +508,46 @@ const Node = ({ history, location }: Props) => {
 
   const handlePauseSmeshing = async () => {
     setIsActionButtonLoading(true);
+    captureReactBreadcrumb({
+      category: 'Node',
+      data: {
+        action: 'Button pause POST data generation is active',
+      },
+      level: 'info',
+    });
     await dispatch(pauseSmeshing());
     setIsActionButtonLoading(false);
+    captureReactBreadcrumb({
+      category: 'Node',
+      data: {
+        action: 'Button pause POST data generation is not active',
+      },
+      level: 'info',
+    });
   };
-  const handleResumeSmeshing = async () => {
-    setIsActionButtonLoading(true);
-    await dispatch(resumeSmeshing());
-    setIsActionButtonLoading(false);
+
+  const handleResumeSmeshing = () => {
+    dispatch(resumeSmeshing());
+    captureReactBreadcrumb({
+      category: 'Node',
+      data: {
+        action: 'Click button resume smeshing',
+      },
+      level: 'info',
+    });
   };
+
+  const handleEdit = () => {
+    history.push(MainPath.SmeshingSetup, { modifyPostData: true });
+    captureReactBreadcrumb({
+      category: 'Node',
+      data: {
+        action: 'Click button edit',
+      },
+      level: 'info',
+    });
+  };
+
   const renderNodeDashboard = () => {
     // TODO: Refactor screen and Node Dashboard
     //       to avoid excessive re-rendering of the whole screen
@@ -539,11 +579,7 @@ const Node = ({ history, location }: Props) => {
             <ButtonWrapper>
               <Button
                 isDisabled={isActionButtonDisabled}
-                onClick={() => {
-                  history.push(MainPath.SmeshingSetup, {
-                    modifyPostData: true,
-                  });
-                }}
+                onClick={handleEdit}
                 img={posDirectoryWhite}
                 text="EDIT"
                 isPrimary={false}
@@ -607,7 +643,16 @@ const Node = ({ history, location }: Props) => {
   };
 
   const buttonHandler = () => {
-    history.push(MainPath.SmeshingSetup);
+    history.push(MainPath.SmeshingSetup, {
+      modifyPostData: true,
+    });
+    captureReactBreadcrumb({
+      category: 'Node',
+      data: {
+        action: 'Click button setup proof of space',
+      },
+      level: 'info',
+    });
   };
 
   const renderMainSection = () => {
@@ -650,15 +695,38 @@ const Node = ({ history, location }: Props) => {
     return renderNodeDashboard();
   };
 
-  const navigateToExplanation = () => window.open(ExternalLinks.SetupGuide);
+  const navigateToExplanation = () => {
+    window.open(ExternalLinks.SetupGuide);
+    captureReactBreadcrumb({
+      category: 'Node',
+      data: {
+        action: 'Navigate to smesher guide',
+      },
+      level: 'info',
+    });
+  };
 
   const handleSetupSmesher = () => {
     eventsService.switchApiProvider(curNet).catch((err) => {
       console.error(err); // eslint-disable-line no-console
       dispatch(setUiError(err));
+      captureReactBreadcrumb({
+        category: 'Node',
+        data: {
+          action: `Click button setup smesher error: ${err}`,
+        },
+        level: 'info',
+      });
     });
 
     history.push(AuthPath.Unlock, { redirect: MainPath.Smeshing });
+    captureReactBreadcrumb({
+      category: 'Node',
+      data: {
+        action: 'Click button setup smesher',
+      },
+      level: 'info',
+    });
   };
 
   const renderWalletOnlyMode = () => {
@@ -673,7 +741,7 @@ const Node = ({ history, location }: Props) => {
         <Row>
           <RowText color={smColors.darkOrange} weight={400}>
             <IconSmesher src={posSmesherOrange} />
-            Click on the setup semsher button below to start using a local
+            Click on the setup smesher button below to start using a local
             managed full Spacemesh p2p node and to smesh.
           </RowText>
         </Row>

--- a/app/screens/node/NodeSetup.tsx
+++ b/app/screens/node/NodeSetup.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
+import { captureReactBreadcrumb } from '../../sentry';
 import { deletePosData, startSmeshing } from '../../redux/smesher/actions';
 import { CorneredContainer, BackButton } from '../../components/common';
 import {
@@ -191,17 +192,44 @@ const NodeSetup = ({ history, location }: Props) => {
         threads,
       })
     );
+    captureReactBreadcrumb({
+      category: 'Node Setup',
+      data: {
+        action: 'Render setup and init mining',
+      },
+      level: 'info',
+    });
 
     if ((done as unknown) as boolean) {
       history.push(MainPath.Smeshing, { showIntro: true });
+      captureReactBreadcrumb({
+        category: 'Node Setup',
+        data: {
+          action: 'Done setup and init mining',
+        },
+        level: 'info',
+      });
     }
   };
-
   const handleNextAction = () => {
     if (mode !== SetupMode.Summary) {
       setMode(mode + 1);
+      captureReactBreadcrumb({
+        category: 'Node Setup',
+        data: {
+          action: 'Navigate to next action mode',
+        },
+        level: 'info',
+      });
     } else {
       setupAndInitMining();
+      captureReactBreadcrumb({
+        category: 'Node Setup',
+        data: {
+          action: 'Navigate to next action when done setup and init mining',
+        },
+        level: 'info',
+      });
     }
   };
 
@@ -220,14 +248,45 @@ const NodeSetup = ({ history, location }: Props) => {
     await dispatch(deletePosData());
     setIsDeleting(false);
     history.push('/main/wallet/');
+    captureReactBreadcrumb({
+      category: 'Node Setup',
+      data: {
+        action: 'Delete Pos Data',
+      },
+      level: 'info',
+    });
   };
 
   const handlePrevAction = () => {
     if (mode === SetupMode.Modify) {
       history.replace(MainPath.Smeshing);
+      captureReactBreadcrumb({
+        category: 'Node Setup',
+        data: {
+          action: 'Navigate back to smeshing',
+        },
+        level: 'info',
+      });
     } else {
       setMode(mode - 1);
+      captureReactBreadcrumb({
+        category: 'Node Setup',
+        data: {
+          action: 'Navigate back button mode',
+        },
+        level: 'info',
+      });
     }
+  };
+  const handleSkipAction = () => {
+    history.push(MainPath.Wallet);
+    captureReactBreadcrumb({
+      category: 'Node Setup',
+      data: {
+        action: 'Skip action',
+      },
+      level: 'info',
+    });
   };
 
   const renderRightSection = () => {
@@ -249,7 +308,7 @@ const NodeSetup = ({ history, location }: Props) => {
             freeSpace={freeSpace}
             setFreeSpace={setFreeSpace}
             status={status}
-            skipAction={() => history.push(MainPath.Smeshing)}
+            skipAction={handleSkipAction}
           />
         );
       case SetupMode.Profiler: {

--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
 import { Element, scroller } from 'react-scroll';
+import { captureReactBreadcrumb } from '../../sentry';
 import {
   updateWalletName,
   createNewAccount,
@@ -196,6 +197,17 @@ class Settings extends Component<Props, State> {
       nameWalletError,
     } = this.state;
 
+    const switchNetwork = () => {
+      goToSwitchNetwork(history, isWalletOnly, true);
+      captureReactBreadcrumb({
+        category: 'Settings',
+        data: {
+          action: 'Click button remove API',
+        },
+        level: 'info',
+      });
+    };
+
     return (
       <Wrapper>
         <SideMenu items={categories} />
@@ -236,9 +248,7 @@ class Settings extends Component<Props, State> {
                 upperPart={[
                   <Text key={1}>Read our&nbsp;</Text>,
                   <Link
-                    onClick={() =>
-                      this.externalNavigation(ExternalLinks.Disclaimer)
-                    }
+                    onClick={this.navigateToDisclaimer}
                     text="disclaimer"
                     key={2}
                   />,
@@ -250,9 +260,7 @@ class Settings extends Component<Props, State> {
                 isUpperPartLeftText
                 upperPartRight={
                   <Button
-                    onClick={() =>
-                      this.externalNavigation(ExternalLinks.UserGuide)
-                    }
+                    onClick={this.navigateToUserGuide}
                     text="GUIDE"
                     width={180}
                   />
@@ -294,9 +302,7 @@ class Settings extends Component<Props, State> {
                 upperPartLeft={`${netName} (${genesisID})`}
                 upperPartRight={
                   <Button
-                    onClick={() =>
-                      goToSwitchNetwork(history, isWalletOnly, true)
-                    }
+                    onClick={switchNetwork}
                     text="SWITCH NETWORK"
                     width={180}
                   />
@@ -592,11 +598,7 @@ class Settings extends Component<Props, State> {
         {showModal && (
           <Modal header="Error" subHeader={'number must be >= 1024'}>
             <ButtonsWrapper>
-              <Button
-                onClick={() => this.setState({ showModal: false })}
-                isPrimary
-                text="OK"
-              />
+              <Button onClick={this.closeErrorMsg} isPrimary text="OK" />
             </ButtonsWrapper>
           </Modal>
         )}
@@ -640,12 +642,36 @@ class Settings extends Component<Props, State> {
     setClientSettingsTheme(index.toString());
     // @ts-ignore
     switchSkin(index.toString());
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Set skin',
+      },
+      level: 'info',
+    });
   };
 
-  restoreFrom12Mnemonic = () => this.goTo(AuthPath.RecoverFromMnemonics);
+  restoreFrom12Mnemonic = () => {
+    this.goTo(AuthPath.RecoverFromMnemonics);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Navigate to restore from 12 mnemonics',
+      },
+      level: 'info',
+    });
+  };
 
-  restoreFrom24Mnemonic = () =>
+  restoreFrom24Mnemonic = () => {
     this.goTo(AuthPath.RecoverFromMnemonics, { wordsAmount: 24 });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Navigate to restore from 24 mnemonics',
+      },
+      level: 'info',
+    });
+  };
 
   cancelEditingAccountDisplayName = ({ index }: { index: number }) => {
     const { accounts } = this.props;
@@ -656,6 +682,13 @@ class Settings extends Component<Props, State> {
       editedAccountIndex: -1,
       accountDisplayNames: updatedAccountDisplayNames,
     });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Cancel editing display name',
+      },
+      level: 'info',
+    });
   };
 
   startEditingAccountDisplayName = ({ index }: { index: number }) => {
@@ -664,26 +697,92 @@ class Settings extends Component<Props, State> {
       this.cancelEditingAccountDisplayName({ index: editedAccountIndex });
     }
     this.setState({ editedAccountIndex: index });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Start editing display name',
+      },
+      level: 'info',
+    });
   };
 
   openLogFile = () => {
     eventsService.showFileInFolder({ isLogFile: true });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button view logs',
+      },
+      level: 'info',
+    });
   };
 
   toggleSignMessageModal = ({ index }: { index: number }) => {
     this.setState({ signMessageModalAccountIndex: index });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Sign message modal',
+      },
+      level: 'info',
+    });
+  };
+
+  closeErrorMsg = () => {
+    this.setState({ showModal: false });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Close error msg',
+      },
+      level: 'info',
+    });
   };
 
   lockWallet = (redirect: AuthPath) => {
     eventsService.closeWallet();
     this.goTo(redirect);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Local Wallet',
+      },
+      level: 'info',
+    });
   };
 
-  closeWallet = () => this.lockWallet(AuthPath.Unlock);
+  closeWallet = () => {
+    this.lockWallet(AuthPath.Unlock);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button log out',
+      },
+      level: 'info',
+    });
+  };
 
-  createNewWallet = () => this.lockWallet(AuthPath.ConnectionType);
+  createNewWallet = () => {
+    this.lockWallet(AuthPath.ConnectionType);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button Create new wallet',
+      },
+      level: 'info',
+    });
+  };
 
-  openWalletFile = () => this.goTo(AuthPath.RecoverFromFile);
+  openWalletFile = () => {
+    this.goTo(AuthPath.RecoverFromFile);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button open wallet file',
+      },
+      level: 'info',
+    });
+  };
 
   saveEditedAccountDisplayName = ({ index }: { index: number }) => {
     const { accountDisplayNames } = this.state;
@@ -700,6 +799,13 @@ class Settings extends Component<Props, State> {
         });
       },
     });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Save edited account display name',
+      },
+      level: 'info',
+    });
   };
 
   editAccountDisplayName = ({
@@ -713,6 +819,13 @@ class Settings extends Component<Props, State> {
     const updatedAccountDisplayNames = [...accountDisplayNames];
     updatedAccountDisplayNames[index] = value;
     this.setState({ accountDisplayNames: updatedAccountDisplayNames });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Edit account display name',
+      },
+      level: 'info',
+    });
   };
 
   toggleAutoStart = async () => {
@@ -722,24 +835,92 @@ class Settings extends Component<Props, State> {
       const { setUiError } = this.props;
       // @ts-ignore
       setUiError(new Error(res.error));
+      captureReactBreadcrumb({
+        category: 'Settings',
+        data: {
+          action: `Click button toggle auto start / error: ${res.error}`,
+        },
+        level: 'info',
+      });
     }
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button toggle auto start',
+      },
+      level: 'info',
+    });
   };
 
   externalNavigation = (to: ExternalLinks) => window.open(to);
 
-  navigateToWalletBackup = () => this.goTo(MainPath.BackupWallet);
+  navigateToDisclaimer = () => {
+    this.externalNavigation(ExternalLinks.Disclaimer);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click disclaimer link',
+      },
+      level: 'info',
+    });
+  };
 
-  navigateToWalletRestore = () => this.goTo(AuthPath.Recover);
+  navigateToUserGuide = () => {
+    this.externalNavigation(ExternalLinks.UserGuide);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button navigate to user guide',
+      },
+      level: 'info',
+    });
+  };
+
+  navigateToWalletBackup = () => {
+    this.goTo(MainPath.BackupWallet);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button navigate to wallet backup',
+      },
+      level: 'info',
+    });
+  };
+
+  navigateToWalletRestore = () => {
+    this.goTo(AuthPath.Recover);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Navigate to wallet restore',
+      },
+      level: 'info',
+    });
+  };
 
   cleanAllAppDataAndSettings = async () => {
     localStorage.clear();
     eventsService.wipeOut();
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button wipe out',
+      },
+      level: 'info',
+    });
   };
 
   deleteWallet = async () => {
     const { currentWalletPath } = this.props;
     localStorage.clear();
     await eventsService.deleteWalletFile(currentWalletPath);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button delete wallet',
+      },
+      level: 'info',
+    });
   };
 
   cancelEditingWalletDisplayName = () => {
@@ -747,6 +928,13 @@ class Settings extends Component<Props, State> {
     this.setState({
       walletDisplayName: displayName,
       canEditDisplayName: false,
+    });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click link cancel edit wallet display name',
+      },
+      level: 'info',
     });
   };
 
@@ -775,17 +963,39 @@ class Settings extends Component<Props, State> {
       // @ts-ignore
       updateWalletName({ displayName: walletDisplayName });
     }
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click link save edit wallet display name',
+      },
+      level: 'info',
+    });
   };
 
-  startEditingWalletDisplayName = () =>
+  startEditingWalletDisplayName = () => {
     this.setState({ canEditDisplayName: true });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button edit wallet display name',
+      },
+      level: 'info',
+    });
+  };
 
-  editWalletDisplayName = ({ value }: { value: string }) =>
+  editWalletDisplayName = ({ value }: { value: string }) => {
     this.setState({ walletDisplayName: value });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Edit wallet display name',
+      },
+      level: 'info',
+    });
+  };
 
   createNewAccountWrapper = () => {
     const { createNewAccount } = this.props;
-
     this.setState({
       showPasswordModal: true,
       passwordModalSubmitAction: ({ password }: { password: string }) => {
@@ -795,6 +1005,13 @@ class Settings extends Component<Props, State> {
         this.goTo(MainPath.Wallet);
       },
     });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button add account',
+      },
+      level: 'info',
+    });
   };
 
   switchToLocalNode = () => {
@@ -803,18 +1020,46 @@ class Settings extends Component<Props, State> {
     switchApiProvider().catch((err) => {
       console.error(err); // eslint-disable-line no-console
       setUiError(err);
+      captureReactBreadcrumb({
+        category: 'Settings',
+        data: {
+          action: `Switch to local node error: ${err}`,
+        },
+        level: 'info',
+      });
     });
     this.goTo(AuthPath.Unlock);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Unlocked local node',
+      },
+      level: 'info',
+    });
   };
 
   switchToRemoteApi = () => {
     const { genesisID } = this.props;
     this.goTo(AuthPath.ConnectToAPI, { genesisID });
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Click button switch to wallet only',
+      },
+      level: 'info',
+    });
   };
 
   goTo = (redirect: RouterPath, state?: unknown) => {
     const { history } = this.props;
     history.push(redirect, state);
+    captureReactBreadcrumb({
+      category: 'Settings',
+      data: {
+        action: 'Navigate to state smeshing',
+      },
+      level: 'info',
+    });
   };
 }
 

--- a/app/screens/transactions/Transactions.tsx
+++ b/app/screens/transactions/Transactions.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import useVirtual from 'react-cool-virtual';
+import { captureReactBreadcrumb } from '../../sentry';
 import { MainPath } from '../../routerPaths';
 import { BackButton } from '../../components/common';
 import {
@@ -226,13 +227,37 @@ const Transactions = ({ history }: RouteComponentProps) => {
       totalReceived: totalCoins.received,
     };
   };
-
   const handleCompleteAction = () => {
     setAddressToAdd('');
+    captureReactBreadcrumb({
+      category: 'Transactions',
+      data: {
+        action: 'Complete actions when create new contact',
+      },
+      level: 'info',
+    });
   };
 
   const handlePress = ({ index }: { index: number }) => {
     setSelectedTimeSpan(index);
+    captureReactBreadcrumb({
+      category: 'Transactions',
+      data: {
+        action: 'View time spans',
+      },
+      level: 'info',
+    });
+  };
+
+  const handleTxFilter = ({ index }) => {
+    setTxFilter(index);
+    captureReactBreadcrumb({
+      category: 'Transactions',
+      data: {
+        action: 'View transaction Filter',
+      },
+      level: 'info',
+    });
   };
 
   const filterLastDays = (txs: (TxView | RewardView)[], days = 1) => {
@@ -242,12 +267,38 @@ const Transactions = ({ history }: RouteComponentProps) => {
       (tx) => (tx.timestamp && tx.timestamp >= startDate) || !tx.timestamp
     );
   };
-
   const cancelCreatingNewContact = () => {
     setAddressToAdd('');
+    captureReactBreadcrumb({
+      category: 'Transactions',
+      data: {
+        action: 'Cancel create new contact',
+      },
+      level: 'info',
+    });
   };
 
-  const navigateToGuide = () => window.open(ExternalLinks.WalletGuide);
+  const navigateToGuide = () => {
+    window.open(ExternalLinks.WalletGuide);
+    captureReactBreadcrumb({
+      category: 'Transactions',
+      data: {
+        action: 'Navigate to transaction guide',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToBackup = () => {
+    history.replace(MainPath.Wallet);
+    captureReactBreadcrumb({
+      category: 'Transactions',
+      data: {
+        action: 'Navigate to backup',
+      },
+      level: 'info',
+    });
+  };
 
   const filteredTransactions = filterLastDays(
     transactions,
@@ -266,11 +317,7 @@ const Transactions = ({ history }: RouteComponentProps) => {
 
   return (
     <Wrapper>
-      <BackButton
-        action={() => history.replace(MainPath.Wallet)}
-        width={7}
-        height={10}
-      />
+      <BackButton action={navigateToBackup} />
       <WrapperWith2SideBars
         width={680}
         header="TRANSACTION LOG"
@@ -279,7 +326,7 @@ const Transactions = ({ history }: RouteComponentProps) => {
         <FilterDropDownWrapper>
           <DropDown
             data={TX_FILTERS}
-            onClick={({ index }) => setTxFilter(index)}
+            onClick={handleTxFilter}
             selectedItemIndex={txFilter}
             rowHeight={40}
             bold

--- a/app/screens/wallet/Overview.tsx
+++ b/app/screens/wallet/Overview.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
+import { captureReactBreadcrumb } from '../../sentry';
 import { LatestTransactions } from '../../components/transactions';
 import { BoldText, Button, Link } from '../../basicComponents';
 import { sendIcon, requestIcon } from '../../assets/images';
@@ -66,13 +67,26 @@ const Overview = ({ history }: RouteComponentProps) => {
     (state: RootState) =>
       state.smesher.postSetupState === PostSetupState.STATE_IN_PROGRESS
   );
-
   const navigateToSpawnAccount = async () => {
     history.push(WalletPath.SpawnAccount);
+    captureReactBreadcrumb({
+      category: 'Overview',
+      data: {
+        action: 'Navigate to spawn account',
+      },
+      level: 'info',
+    });
   };
 
   const navigateToSendCoins = () => {
     history.push(WalletPath.SendCoins);
+    captureReactBreadcrumb({
+      category: 'Overview',
+      data: {
+        action: 'Navigate to send coins',
+      },
+      level: 'info',
+    });
   };
 
   const navigateToRequestCoins = () => {
@@ -80,13 +94,36 @@ const Overview = ({ history }: RouteComponentProps) => {
       account,
       isSmesherActive: isCreatingPosData || isSmeshing,
     });
+    captureReactBreadcrumb({
+      category: 'Overview',
+      data: {
+        action: 'Navigate to request coins',
+      },
+      level: 'info',
+    });
   };
 
   const navigateToAllTransactions = () => {
     history.push(MainPath.Transactions);
+    captureReactBreadcrumb({
+      category: 'Overview',
+      data: {
+        action: 'Navigate to all transactions',
+      },
+      level: 'info',
+    });
   };
 
-  const navigateToWalletGuide = () => window.open(ExternalLinks.WalletGuide);
+  const navigateToWalletGuide = () => {
+    window.open(ExternalLinks.WalletGuide);
+    captureReactBreadcrumb({
+      category: 'Overview',
+      data: {
+        action: 'Navigate to WALLET GUIDE',
+      },
+      level: 'info',
+    });
+  };
 
   const pendingSpawnTx = txs.find(
     (tx) =>

--- a/app/screens/wallet/RequestCoins.tsx
+++ b/app/screens/wallet/RequestCoins.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { RouteComponentProps } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { captureReactBreadcrumb } from '../../sentry';
 import CopyButton from '../../basicComponents/CopyButton';
 import { Link, Button, BoldText } from '../../basicComponents';
 import { smColors } from '../../vars';
@@ -92,14 +93,60 @@ const RequestCoins = ({ history, location }: Props) => {
   } = location;
   const netowrkTabBotUrl = useSelector(getNetworkTapBotDiscordURL);
   const [isCopied, setIsCopied] = useState<boolean>(false);
-
   const navigateToNodeSetup = () => {
     history.push(MainPath.SmeshingSetup);
+    captureReactBreadcrumb({
+      category: 'Request Coins',
+      data: {
+        action: 'Click link set up smeshing',
+      },
+      level: 'info',
+    });
   };
 
-  const navigateToGuide = () => window.open(ExternalLinks.GetCoinGuide);
+  const navigateToGuide = () => {
+    window.open(ExternalLinks.GetCoinGuide);
+    captureReactBreadcrumb({
+      category: 'Request Coins',
+      data: {
+        action: 'Click link request SMH guide',
+      },
+      level: 'info',
+    });
+  };
 
-  const navigateToTap = () => window.open(netowrkTabBotUrl);
+  const navigateToTap = () => {
+    window.open(netowrkTabBotUrl);
+    captureReactBreadcrumb({
+      category: 'Request Coins',
+      data: {
+        action: 'Click link testnet tap',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToCopy = (val) => {
+    setIsCopied(Boolean(val));
+    captureReactBreadcrumb({
+      category: 'Request Coins',
+      data: {
+        action: 'Click copy button',
+      },
+      level: 'info',
+    });
+  };
+
+  const navigateToDone = () => {
+    history.replace(MainPath.Wallet);
+    captureReactBreadcrumb({
+      category: 'Request Coins',
+      data: {
+        action: 'Click done button',
+      },
+      level: 'info',
+    });
+  };
 
   return (
     <Wrapper>
@@ -114,7 +161,7 @@ const RequestCoins = ({ history, location }: Props) => {
         <CopyButton
           value={account.address}
           hideCopyIcon={isCopied}
-          onClick={(val) => setIsCopied(Boolean(val))}
+          onClick={navigateToCopy}
         >
           <AddressWrapper>
             <AddressText>{account.address}</AddressText>
@@ -149,7 +196,7 @@ const RequestCoins = ({ history, location }: Props) => {
       )}
       <Footer>
         <Link onClick={navigateToGuide} text="REQUEST SMH GUIDE" />
-        <Button onClick={() => history.replace(MainPath.Wallet)} text="DONE" />
+        <Button onClick={navigateToDone} text="DONE" />
       </Footer>
     </Wrapper>
   );

--- a/app/screens/wallet/SendCoins.tsx
+++ b/app/screens/wallet/SendCoins.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { SingleSigTemplate } from '@spacemesh/sm-codec';
+import { captureReactBreadcrumb } from '../../sentry';
 import { sendTransaction } from '../../redux/wallet/actions';
 import {
   TxParams,
@@ -108,14 +109,27 @@ const SendCoins = ({ history, location }: Props) => {
       setMode(2);
     }
   };
-
   const handleSendTransaction = async () => {
     const result = await dispatch(
       sendTransaction({ receiver: address, amount, fee, note })
     );
+    captureReactBreadcrumb({
+      category: 'Send coins',
+      data: {
+        action: 'Send transaction',
+      },
+      level: 'info',
+    });
     if (result?.id) {
       setMode(3);
       setTxId(result.id);
+      captureReactBreadcrumb({
+        category: 'Send coins',
+        data: {
+          action: 'Navigate to transaction send',
+        },
+        level: 'info',
+      });
     }
   };
 

--- a/app/screens/wallet/Vault.tsx
+++ b/app/screens/wallet/Vault.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import {
   NewVault,
   VaultType,
@@ -66,29 +67,71 @@ const Vault = ({ history }: RouteComponentProps) => {
     }));
     setAccountsOption(objOption);
   }, [accounts, balances, setAccountsOption]);
-
   const handleChangeVaultName = ({ value }: { value: string }) => {
     setName(value);
+    captureReactBreadcrumb({
+      category: 'Vault',
+      data: {
+        action: 'Change vault name',
+      },
+      level: 'info',
+    });
   };
 
   const handleChangeType = ({ value }: { value: string }) => {
     setType(value);
+    captureReactBreadcrumb({
+      category: 'Vault',
+      data: {
+        action: 'Change vault type',
+      },
+      level: 'info',
+    });
   };
 
   const saveAndFinish = () => {
     dispatch(setCurrentMode(0));
+    captureReactBreadcrumb({
+      category: 'Vault',
+      data: {
+        action: 'Click link save and finish later',
+      },
+      level: 'info',
+    });
   };
 
   const handleModeUp = () => {
     dispatch(setCurrentMode(vaultMode + 1));
+    captureReactBreadcrumb({
+      category: 'Vault',
+      data: {
+        action: 'Click button mode up',
+      },
+      level: 'info',
+    });
   };
 
   const selectAccountIndex = ({ index }: { index: number }) => {
     setMasterAccountIndex(index);
+    captureReactBreadcrumb({
+      category: 'Vault',
+      data: {
+        action: 'Select account index',
+      },
+      level: 'info',
+    });
   };
 
-  const navigateToVaultSetup = () =>
+  const navigateToVaultSetup = () => {
     window.open('https://product.spacemesh.io/#/smapp_vaults');
+    captureReactBreadcrumb({
+      category: 'Vault',
+      data: {
+        action: 'Navigate to vault setup guide',
+      },
+      level: 'info',
+    });
+  };
 
   const Steps = new Map();
 

--- a/app/screens/wallet/Wallet.tsx
+++ b/app/screens/wallet/Wallet.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Redirect, Route, Switch, RouteComponentProps } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
+import { captureReactBreadcrumb } from '../../sentry';
 import routes from '../../routes';
 import { MainPath } from '../../routerPaths';
 import { AccountsOverview } from '../../components/wallet';
@@ -80,13 +81,28 @@ const Wallet = ({ history, location }: RouteComponentProps) => {
   const vaultMode = useSelector((state: RootState) => state.wallet.vaultMode);
   const dispatch = useDispatch();
 
+  throw Error('test');
   const navigateToBackup = () => {
     history.push(MainPath.BackupWallet);
+    captureReactBreadcrumb({
+      category: 'Wallet',
+      data: {
+        action: 'Navigate to backup',
+      },
+      level: 'info',
+    });
   };
 
   const handleModeBack = () => {
     if (vaultMode === 0) history.goBack();
     else dispatch(setCurrentMode(vaultMode - 1));
+    captureReactBreadcrumb({
+      category: 'Wallet',
+      data: {
+        action: 'Navigate to back button',
+      },
+      level: 'info',
+    });
   };
 
   const hasBackButton = location.pathname.includes('vault');

--- a/app/sentry.ts
+++ b/app/sentry.ts
@@ -19,11 +19,13 @@ export const init = (history) =>
     dsn: process.env.SENTRY_DSN,
     environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
     enabled: true,
+    dist: 'production',
     debug: process.env.SENTRY_LOG_LEVEL === 'debug',
     attachStacktrace: true,
     maxValueLength: 25000,
     tracesSampleRate: parseFloat(process.env.TRACES_SAMPLE_RATE || '1.0'),
     integrations: [
+      // @ts-ignore
       new BrowserTracing({
         routingInstrumentation: reactRouterV5Instrumentation(
           history,


### PR DESCRIPTION
It closes #1063 

- [x] add breadcrumbs
- [ ] clean up cyle deps , detected in the eslint job.
- [ ] map the release js files with Sentry issue, to track the correct place of the exception. Right now working correctly only for Node ( desktop folder )
- [ ] remove the IP address from the issue/feedback
- [ ] add class names to each style, to track Click on the class name, not a short name of the styled components class. Right now we have a short name, and in each release the class name is different 
- [ ] add more information for breadcrumbs where it is possible, like error: err 