### PR TITLE
Add link to POS proving docs on PosProfiler screen

### DIFF
--- a/app/components/node/PoSProfiler.tsx
+++ b/app/components/node/PoSProfiler.tsx
@@ -6,10 +6,12 @@ import {
   Input,
   Button,
   ColorStatusIndicator,
+  Link,
 } from '../../basicComponents';
 import { constrain, formatBytes } from '../../infra/utils';
 import { ipcConsts, smColors } from '../../vars';
 import { BenchmarkRequest, BenchmarkResponse } from '../../../shared/types';
+import { ExternalLinks } from '../../../shared/constants';
 import { eventsService } from '../../infra/eventsService';
 import PoSFooter, { PoSFooterProps } from './PoSFooter';
 
@@ -186,6 +188,9 @@ const getStatusColor = (status: BenchmarkStatus) => {
   }
 };
 
+const navigateToExplanation = () =>
+  window.open(ExternalLinks.PosProvingDocumentation);
+
 const PoSProfiler = ({
   nextAction,
   numUnitSize,
@@ -286,7 +291,13 @@ const PoSProfiler = ({
       <Row>
         <Text>
           Smesher should be able to generate PoS proof in time. To choose proper
-          options for proof generation — run the benchmark and follow the hints.
+          options for proof generation —&nbsp;
+          <Link
+            onClick={navigateToExplanation}
+            text="read the documentation"
+            style={{ display: 'inline' }}
+          />
+          &nbsp;and run the benchmark.
         </Text>
       </Row>
       <Row>

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -43,6 +43,7 @@ export enum ExternalLinks {
   OpenCLWindowsInstallGuide = 'https://sasview.org/docs/old_docs/4.1.2/user/opencl_installation.html',
   OpenCLUbuntuInstallGuide = 'https://saturncloud.io/blog/how-to-install-cudaopencl-on-ubuntu-installed-on-a-usb-drive/#installing-opencl',
   GithubSMAppIssuePage = 'https://github.com/spacemeshos/smapp/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=',
+  PosProvingDocumentation = 'https://github.com/spacemeshos/wiki/wiki/Smesher-Guide#fine-tuning-proving',
 }
 
 export const BITS_PER_LABEL = 128;


### PR DESCRIPTION
No issue.

![image](https://github.com/spacemeshos/smapp/assets/1897530/4533c581-ad45-4545-82f4-6fa269294be9)

It leads to https://github.com/spacemeshos/wiki/wiki/Smesher-Guide#fine-tuning-proving