### PR TITLE
Make wallet file guards less strict

### DIFF
--- a/shared/types/guards.ts
+++ b/shared/types/guards.ts
@@ -63,7 +63,7 @@ export const isWalletGCMEncrypted = (a: any): a is WalletSecretsEncryptedGCM =>
   typeof a.cipherParams?.iv === 'string' &&
   a.kdf === 'PBKDF2' &&
   typeof a.kdfparams?.dklen === 'number' &&
-  a.kdfparams?.hash === 'SHA-512' &&
+  typeof a.kdfparams?.hash === 'string' &&
   typeof a.kdfparams?.iterations === 'number' &&
   typeof a.kdfparams?.salt === 'string';
 
@@ -76,14 +76,10 @@ export const isWalletSecrets = (a: any): a is WalletSecrets =>
   Boolean(a && a.mnemonic && a.accounts && a.contacts);
 
 export const isWalletMeta = (meta: WalletMeta) =>
-  typeof meta.displayName === 'string' &&
-  typeof meta.created === 'string' &&
-  typeof meta.remoteApi === 'string' &&
-  typeof meta.type === 'string';
+  typeof meta.displayName === 'string' && typeof meta.created === 'string';
 
 export const isWalletFile = (wallet: any): wallet is WalletFile =>
   wallet &&
   isWalletMeta(wallet.meta) &&
-  isWalletSecretsEncrypted(wallet.crypto) &&
   (isWalletGCMEncrypted(wallet.crypto) ||
     isWalletLegacyEncrypted(wallet.crypto));


### PR DESCRIPTION
We have a report from one User that the wallet file created by `smcli` cannot be opened due to new more strict wallet file validation. This PR makes this validation less strict:
- do not require optional fields
- check `crypto.kdfparams.hash` to be a string, instead of being `SHA-512`. In the future we may check this field for some specific values (such as `'SHA-256' | 'SHA-512'`), but seems we have a small bug in smcli https://github.com/spacemeshos/smcli/issues/98 — so we may become more strict and reuse this field in decryption only after fixing the issue (and most likely we will need to some mechanism to update older wallet files). Or just keep using `SHA-512` without other options...