### PR TITLE
Display "syncing atxs" and "syncing malicious proofs" statuses

### DIFF
--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 import { NodeStartupState, NodeStatus } from '../../../shared/types';
-import { ProgressBar, ColorStatusIndicator } from '../../basicComponents';
+import {
+  ProgressBar,
+  ColorStatusIndicator,
+  Tooltip,
+} from '../../basicComponents';
 import { constrain } from '../../infra/utils';
 import { smColors } from '../../vars';
 
@@ -39,6 +43,19 @@ const getStartupStatusText = (startupStatus: NodeStartupState) => {
       return 'Starting GRPC server...';
     case NodeStartupState.VerifyingLayers:
       return 'Tortoise verifying layers...';
+    case NodeStartupState.SyncingAtxs:
+      return (
+        <>
+          Syncing Activations...
+          <Tooltip
+            width={200}
+            marginTop={-2}
+            text="This process may take hours and consume CPU. Please, wait for it."
+          />
+        </>
+      );
+    case NodeStartupState.SyncingMaliciousProofs:
+      return 'Syncing Malicious Proofs...';
     default:
     case NodeStartupState.Ready:
       return 'Connecting to Node...';
@@ -66,7 +83,11 @@ const NetworkStatus = ({
   };
 
   const getSyncProgress = () => {
-    if (!status || status.topLayer === 0) {
+    if (
+      !status ||
+      status.topLayer === 0 ||
+      startupStatus !== NodeStartupState.Ready
+    ) {
       return (
         <ProgressLabel>{getStartupStatusText(startupStatus)}</ProgressLabel>
       );

--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -50,7 +50,7 @@ const getStartupStatusText = (startupStatus: NodeStartupState) => {
           <Tooltip
             width={200}
             marginTop={-2}
-            text="This process may take hours and consume CPU. Please, wait for it."
+            text="This process is expected to take up to a few hours and you will see CPU usage increase during this time. Please be patient."
           />
         </>
       );

--- a/shared/types/states.ts
+++ b/shared/types/states.ts
@@ -16,5 +16,7 @@ export enum NodeStartupState {
   Vacuuming,
   VerifyingLayers,
   StartingGRPC,
+  SyncingAtxs,
+  SyncingMaliciousProofs,
   Ready,
 }


### PR DESCRIPTION
No issue.

But we have a lot of reports of confused people that they're thinking that their Node got stuck when actually it is syncing activations, which may take hours especially if they are syncing from scratch.

Now there will be "Syncing activations..." status instead of "Syncing 8063/35636".
In the future, when we have activations API we may add also a number of synced activations next to it.
