### PR TITLE
Fix: display informative node errors

### DIFF
--- a/app/basicComponents/ErrorMessage.tsx
+++ b/app/basicComponents/ErrorMessage.tsx
@@ -16,7 +16,7 @@ const ErrorMessage = styled.span<ErrorMessageProps>`
   overflow: hidden;
   text-align: ${({ align }) => align || 'left'};
   ${({ compact }) =>
-    compact && '-webkit-line-clamp: 2; -webkit-box-orient: vertical;'}
+    compact && '-webkit-line-clamp: 5; -webkit-box-orient: vertical;'}
 `;
 
 ErrorMessage.defaultProps = {

--- a/app/redux/node/reducer.ts
+++ b/app/redux/node/reducer.ts
@@ -1,6 +1,5 @@
 import { NodeStartupState } from '../../../shared/types';
 import type { NodeState, CustomAction } from '../../types';
-import { LOGOUT } from '../auth/actions';
 import { IPC_BATCH_SYNC, reduceChunkList } from '../ipcBatchSync';
 import {
   SET_NODE_ERROR,
@@ -41,8 +40,6 @@ const reducer = (state: NodeState = initialState, action: CustomAction) => {
       } = action;
       return { ...state, version, build };
     }
-    case LOGOUT:
-      return initialState;
     case IPC_BATCH_SYNC:
       return reduceChunkList(['store', 'node'], action.payload, state);
     default:

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -297,7 +297,7 @@ const Network = ({ history }) => {
           {nodeError && (
             <>
               <ErrorMessage compact>
-                {nodeError.msg || nodeError.stackTrace}
+                {nodeError.msg || nodeError.stackTrace}{' '}
                 {nodeError?.type === NodeErrorType.OPEN_CL_NOT_INSTALLED && (
                   <>
                     {isWindows && (
@@ -311,7 +311,7 @@ const Network = ({ history }) => {
                       <Link
                         style={{ display: 'inline-block' }}
                         onClick={navigateToUbuntuOpenCLInstallationGuide}
-                        text="OPEN CL INSTALLATION GUIDE."
+                        text="OPEN CL INSTALLATION GUIDE"
                       />
                     )}
                   </>
@@ -320,14 +320,14 @@ const Network = ({ history }) => {
                   <Link
                     style={{ display: 'inline-block' }}
                     onClick={navigateToRedistInstallationGuide}
-                    text="REDIST INSTALLATION GUIDE."
+                    text="REDIST INSTALLATION GUIDE"
                   />
                 )}
                 {nodeError?.type === NodeErrorType.NOT_SPECIFIED && (
                   <Link
                     style={{ display: 'inline-block' }}
                     onClick={() => setOpenCheckListModal(true)}
-                    text="OPEN CHECKLIST."
+                    text="OPEN CHECKLIST"
                   />
                 )}
               </ErrorMessage>

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -323,16 +323,12 @@ const Network = ({ history }) => {
                     text="REDIST INSTALLATION GUIDE."
                   />
                 )}
-                {(isShowMissingLibsMessage ||
-                  nodeError?.type === NodeErrorType.NOT_SPECIFIED) && (
-                  <ErrorMessage compact>
-                    WE HAVE A CHECKLIST THAT CAN HELP YOU DETECT THE ISSUE.{' '}
-                    <Link
-                      style={{ display: 'inline-block' }}
-                      onClick={() => setOpenCheckListModal(true)}
-                      text="OPEN CHECKLIST."
-                    />
-                  </ErrorMessage>
+                {nodeError?.type === NodeErrorType.NOT_SPECIFIED && (
+                  <Link
+                    style={{ display: 'inline-block' }}
+                    onClick={() => setOpenCheckListModal(true)}
+                    text="OPEN CHECKLIST."
+                  />
                 )}
               </ErrorMessage>
             </>

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -86,7 +86,7 @@ export enum SmeshingSetupState {
 }
 
 const NEW_APP_SESSION_REGEXP = /App version:/gm;
-const FATAL_REGEXP = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{4})\sFATAL\s/gm;
+const FATAL_REGEXP = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{4})\s(FATAL|PANIC)\s/gm;
 
 class NodeManager extends AbstractManager {
   private nodeService: NodeService;

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -85,6 +85,7 @@ export enum SmeshingSetupState {
   ViaRestart = 2,
 }
 
+const NEW_APP_SESSION_REGEXP = /App version:/gm;
 const FATAL_REGEXP = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{4})\sFATAL\s/gm;
 
 class NodeManager extends AbstractManager {
@@ -143,7 +144,16 @@ class NodeManager extends AbstractManager {
         100
       );
 
-      const fatalErrorLine = lastLines.find((line) => FATAL_REGEXP.test(line));
+      const sessionStartLineIndex = lastLines.findIndex((line) =>
+        NEW_APP_SESSION_REGEXP.test(line)
+      );
+      const lastLinesFromSession = lastLines.slice(
+        0,
+        sessionStartLineIndex > 0 ? sessionStartLineIndex : Infinity
+      );
+      const fatalErrorLine = lastLinesFromSession.find((line) =>
+        FATAL_REGEXP.test(line)
+      );
 
       if (!fatalErrorLine) {
         const installedLibs = await checkRequiredLibs();

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -611,6 +611,7 @@ class NodeManager extends AbstractManager {
       logger.error('Node Process close', code, signal);
       this.nodeLogStream?.end();
       this.pushToErrorPool({ type: 'Exit', code, signal });
+      this.nodeProcess = null;
     });
   };
 

--- a/desktop/main/reactions/handleSmesherIpc.ts
+++ b/desktop/main/reactions/handleSmesherIpc.ts
@@ -1,10 +1,6 @@
 import { from, Subject, switchMap, withLatestFrom } from 'rxjs';
 import { ipcConsts } from '../../../app/vars';
-import {
-  NodeConfig,
-  PostProvingOpts,
-  PostSetupOpts,
-} from '../../../shared/types';
+import { PostProvingOpts, PostSetupOpts } from '../../../shared/types';
 import { SmeshingSetupState } from '../../NodeManager';
 import Logger from '../../logger';
 import { Managers } from '../app.types';
@@ -15,21 +11,19 @@ const logger = Logger({ className: 'handleSmesherIpc' });
 const startSmeshing = (
   managers: Managers,
   opts: PostSetupOpts,
-  provingOpts: PostProvingOpts,
-  $nodeConfig: Subject<NodeConfig>
-) => wrapResult(managers.node.startSmeshing(opts, provingOpts, $nodeConfig));
+  provingOpts: PostProvingOpts
+) => wrapResult(managers.node.startSmeshing(opts, provingOpts));
 
 export default (
   $managers: Subject<Managers>,
-  $smeshingSetupState: Subject<SmeshingSetupState>,
-  $nodeConfig: Subject<NodeConfig>
+  $smeshingSetupState: Subject<SmeshingSetupState>
 ) => {
   const startSmeshingRequest = fromIPC<[PostSetupOpts, PostProvingOpts]>(
     ipcConsts.SMESHER_START_SMESHING
   ).pipe(
     withLatestFrom($managers),
     switchMap(([[opts, provingOpts], managers]) =>
-      from(startSmeshing(managers, opts, provingOpts, $nodeConfig))
+      from(startSmeshing(managers, opts, provingOpts))
     )
   );
 

--- a/desktop/main/startApp.ts
+++ b/desktop/main/startApp.ts
@@ -237,7 +237,7 @@ const startApp = (): AppStore => {
     // Ensure smeshing-proving-opts settings valid and exists in the node-config file
     ensureProvingOpts($wallet, $nodeConfig, $warnings),
     // Handle Start Smeshing request
-    handleSmesherIpc($managers, $smeshingSetupState, $nodeConfig),
+    handleSmesherIpc($managers, $smeshingSetupState),
     // Handle show file
     handleShowFile($currentNetwork),
     // IPC Reactions

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -114,16 +114,20 @@ export const isEmptyDir = async (path: string) => {
  */
 export const createDebouncePool = <T extends unknown>(
   delay: number,
-  callback: (errors: T[]) => void
+  callback: (errors: T[], resetPool: () => void) => void
 ) => {
   let bucket: T[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const resetPool = () => {
+    bucket = [];
+  };
 
   return (error: T) => {
     bucket = [...bucket, error];
     timer && clearTimeout(timer);
     timer = setTimeout(() => {
-      callback(bucket);
+      callback(bucket, resetPool);
       bucket = [];
     }, delay);
   };


### PR DESCRIPTION
No issue.

### It fixes:
1. It displays an actual error message from the node's logs.
    The regression was introduced in https://github.com/spacemeshos/smapp/pull/1491
2. It displays not only FATAL messages but also PANICs
3. If there is a very short app session (less than 100 messages) — we filter out only the latest app session from the logs, to avoid displaying old FATALs/PANICs in case the node was killed (stopped without FATALs/PANICs in the logs).
4. Get rid of excessive 20 seconds of waiting before restarting the crashed node (by dropping the reference to the exited node process).

### How to test:
There are a few different cases:
1. Run Smapp, and kill the node.
    Expected: the default "unexpected exited" message
2. Change the time in `%AppData%/node-data/7c8cef2b/genesis.json` — you'll get a fatal error at the very beginning of the node start
     Expected: the error message from the log (FATAL)
3. Corrupt something in your PoS data metadata file
     Expected: the error message from the log (PANIC)
4. Try to run it on Windows without OpenCL or C++ Reddist installed
    Expected: the error message about missing libraries
