### PR TITLE
Fix misleading error on long startup

### DIFF
--- a/app/redux/node/actions.ts
+++ b/app/redux/node/actions.ts
@@ -4,12 +4,15 @@ import {
   NodeStatus,
   NodeVersionAndBuild,
 } from '../../../shared/types';
+import { eventsService } from '../../infra/eventsService';
+import { AppThDispatch } from '../../types';
 
 export const SET_NODE_VERSION_AND_BUILD = 'SET_NODE_VERSION_AND_BUILD';
 export const SET_NODE_STATUS = 'SET_NODE_STATUS';
 export const SET_NODE_ERROR = 'SET_NODE_ERROR';
 
 export const SET_STARTUP_STATUS = 'SET_STARTUP_STATUS';
+export const RESTART_NODE = 'RESTART_NODE';
 
 export const setNodeStatus = (status: NodeStatus) => ({
   type: SET_NODE_STATUS,
@@ -29,3 +32,8 @@ export const setNodeStartupStatus = (payload: NodeStartupState) => ({
   type: SET_STARTUP_STATUS,
   payload,
 });
+
+export const restartNode = () => (dispatch: AppThDispatch) => {
+  dispatch({ type: 'RESTART_NODE' });
+  eventsService.restartNode();
+};

--- a/app/redux/node/reducer.ts
+++ b/app/redux/node/reducer.ts
@@ -2,13 +2,14 @@ import { NodeStartupState } from '../../../shared/types';
 import type { NodeState, CustomAction } from '../../types';
 import { IPC_BATCH_SYNC, reduceChunkList } from '../ipcBatchSync';
 import {
+  RESTART_NODE,
   SET_NODE_ERROR,
   SET_NODE_STATUS,
   SET_NODE_VERSION_AND_BUILD,
   SET_STARTUP_STATUS,
 } from './actions';
 
-const initialState = {
+const initialState: NodeState = {
   startupStatus: NodeStartupState.Starting,
   status: null,
   version: '',
@@ -16,6 +17,7 @@ const initialState = {
   port: '',
   error: null,
   dataPath: '',
+  isRestarting: false,
 };
 
 const reducer = (state: NodeState = initialState, action: CustomAction) => {
@@ -26,13 +28,18 @@ const reducer = (state: NodeState = initialState, action: CustomAction) => {
         ...state,
         status,
         error: null,
+        isRestarting: false,
       };
     }
     case SET_STARTUP_STATUS:
       return { ...state, startupStatus: action.payload };
     case SET_NODE_ERROR: {
       const error = action.payload;
-      return { ...state, error };
+      return {
+        ...state,
+        error,
+        isRestarting: false,
+      };
     }
     case SET_NODE_VERSION_AND_BUILD: {
       const {
@@ -40,6 +47,8 @@ const reducer = (state: NodeState = initialState, action: CustomAction) => {
       } = action;
       return { ...state, version, build };
     }
+    case RESTART_NODE:
+      return { ...state, isRestarting: true };
     case IPC_BATCH_SYNC:
       return reduceChunkList(['store', 'node'], action.payload, state);
     default:

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useState } from 'react';
-import { useSelector } from 'react-redux';
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { eventsService } from '../../infra/eventsService';
 import { NetworkStatus } from '../../components/NetworkStatus';
@@ -18,7 +18,6 @@ import ErrorMessage from '../../basicComponents/ErrorMessage';
 import SubHeader from '../../basicComponents/SubHeader';
 import { goToSwitchNetwork } from '../../routeUtils';
 import { AuthPath } from '../../routerPaths';
-import { delay } from '../../../shared/utils';
 import Address from '../../components/common/Address';
 import {
   getFirstLayerInEpochFn,
@@ -32,6 +31,7 @@ import {
   isWindows as isWindowsSelector,
 } from '../../redux/ui/selectors';
 import ErrorCheckListModal from '../modal/ErrorCheckListModal';
+import { restartNode } from '../../redux/node/actions';
 
 const Container = styled.div`
   display: flex;
@@ -117,16 +117,12 @@ const Network = ({ history }) => {
     (state: RootState) => state.network.genesisTime
   );
   const remoteApi = useSelector(getRemoteApi);
-  const [isRestarting, setRestarting] = useState(false);
 
-  const requestNodeRestart = useCallback(async () => {
-    setRestarting(true);
-    await eventsService.restartNode();
-    await delay(60 * 1000);
-    // In case if Node restarts earlier the component will be
-    // re-rendered and Restart button will disappear
-    setRestarting(false);
-  }, []);
+  const isRestarting = useSelector(
+    (state: RootState) => state.node.isRestarting
+  );
+  const dispatch = useDispatch();
+  const requestNodeRestart = () => dispatch(restartNode());
 
   const requestSwitchApiProvider = () => {
     history.push(AuthPath.ConnectToAPI);

--- a/app/types/redux.ts
+++ b/app/types/redux.ts
@@ -33,6 +33,7 @@ export interface NodeState {
   error: NodeError | null;
   port: string;
   dataPath: string;
+  isRestarting: boolean;
 }
 
 export interface WalletState {

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -56,6 +56,7 @@ import {
   checkRequiredLibs,
   requiredLibsCrashErrors,
 } from './checkRequiredLibs';
+import NodeStartupStateStore from './main/nodeStartupStateStore';
 
 const logger = Logger({ className: 'NodeManager' });
 
@@ -427,6 +428,7 @@ class NodeManager extends AbstractManager {
   sendNodeStartupState = (status?: NodeStartupState) => {
     if (status) {
       this.nodeStartupState = status;
+      NodeStartupStateStore.setStatus(status);
     }
     this.mainWindow.webContents.send(
       ipcConsts.N_M_NODE_STARTUP_STATUS,

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -726,7 +726,10 @@ class NodeManager extends AbstractManager {
   sendNodeStatus: StatusStreamHandler = debounce(1000, (status: NodeStatus) => {
     logger.log('sendNodeStatus', status);
     this.$_nodeStatus.next(status);
-    this.mainWindow.webContents.send(ipcConsts.N_M_SET_NODE_STATUS, status);
+    if (this.nodeProcess) {
+      // Send the status only if Node process in up
+      this.mainWindow.webContents.send(ipcConsts.N_M_SET_NODE_STATUS, status);
+    }
   });
 
   sendNodeError: ErrorStreamHandler = debounce(200, async (error) => {

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -110,7 +110,7 @@ class NodeManager extends AbstractManager {
 
   private isRestarting = false;
 
-  private nodeStartupState: NodeStartupState = NodeStartupState.Starting;
+  private nodeStartupState: NodeStartupState = NodeStartupState.NotRunning;
 
   private pushToErrorPool = createDebouncePool<ErrorPoolObject>(
     100,
@@ -632,6 +632,7 @@ class NodeManager extends AbstractManager {
     this.nodeProcess.on('close', (code, signal) => {
       logger.error('Node Process close', code, signal);
       this.nodeLogStream?.end();
+      this.sendNodeStartupState(NodeStartupState.NotRunning);
       this.pushToErrorPool({ type: 'Exit', code, signal });
       this.nodeProcess = null;
     });

--- a/desktop/NodeService.ts
+++ b/desktop/NodeService.ts
@@ -14,6 +14,7 @@ import { DEFAULT_NODE_STATUS } from '../shared/constants';
 import NetServiceFactory from './NetServiceFactory';
 import Logger from './logger';
 import { getLocalNodeConnectionConfig } from './main/utils';
+import NodeStartupStateStore from './main/nodeStartupStateStore';
 
 const PROTO_PATH = 'proto/node.proto';
 
@@ -125,6 +126,11 @@ class NodeService extends NetServiceFactory<ProtoGrpcType, 'NodeService'> {
         errCount = 0;
       },
       () => {
+        if (!NodeStartupStateStore.isReady()) {
+          // Do nothing if Node is not ready
+          return;
+        }
+
         if (errCount === 5) {
           errorHandler(NODE_NOT_RESPONDING_ERROR);
         } else if (errCount === 3) {

--- a/desktop/main/nodeStartupStateStore.ts
+++ b/desktop/main/nodeStartupStateStore.ts
@@ -1,0 +1,15 @@
+import { NodeStartupState } from '../../shared/types';
+
+export default class NodeStartupStateStore {
+  private static status: NodeStartupState = NodeStartupState.Starting;
+
+  static setStatus = (status: NodeStartupState) => {
+    NodeStartupStateStore.status = status;
+    return status;
+  };
+
+  static getStatus = () => NodeStartupStateStore.status;
+
+  static isReady = () =>
+    NodeStartupStateStore.status === NodeStartupState.Ready;
+}

--- a/shared/types/states.ts
+++ b/shared/types/states.ts
@@ -11,6 +11,7 @@ export interface NetworkState {
 }
 
 export enum NodeStartupState {
+  NotRunning = 'NotRunning',
   Starting = 'Starting',
   Compacting = 'Compacting',
   Vacuuming = 'Vacuuming',


### PR DESCRIPTION
It is related to already closed #1474

The bug:
- When Node does migration (so GRPC API is not responding for a long time) Smapp displays the error that it cannot connect to the Node and proposes to Restart, which does not make any sense.
- Also I've tweaked the behavior of the "Restart" button to make it correspond better to an actual state:
   - Changing screens won't drop "Restarting..." status anymore,
   - It displays an actual state faster (once it is Restarted it will display a startup status)