### PR TITLE
Fix CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ Additionally:
 
 ## CLI-tools
 These tools are created for debugging and development purposes.
-They are not supposed to be used in the production (on a real and valuable data).
-So use it on your own risk.
+They are not supposed to be used in the production (on real and valuable data).
+So use it at your own risk.
 
 ### `yarn script:composeTx`
 Compose the transaction (and sign if needed).
@@ -226,5 +226,5 @@ For example, if you need to export private keys or mnemonics.
 ### `yarn script:addViewAccount`
 Add a public key to the wallet file.
 It makes it possible to track someone else transactions and rewards.
-Pay attention that Smapp does not fully support such kind of accounts.
-So in case you will try to sign a message or publish a transaction — unhandled exceptions will occur.
+Pay attention that Smapp does not fully support such kinds of accounts.
+So in case you try to sign a message or publish a transaction — unhandled exceptions will occur.

--- a/README.md
+++ b/README.md
@@ -207,3 +207,24 @@ Additionally:
   Where `{GENESIS_ID}` is first 8 chars from the HexString. Eg `7c8cef2b`
 
 - Check if the incoming connections aren’t blocked for go-spacemesh
+
+## CLI-tools
+These tools are created for debugging and development purposes.
+They are not supposed to be used in the production (on a real and valuable data).
+So use it on your own risk.
+
+### `yarn script:composeTx`
+Compose the transaction (and sign if needed).
+
+### `yarn script:decomposeTx`
+Decompose the transaction (byte array) to the human-readable structure (JSON)
+
+### `yarn script:readSecrets`
+Read secrets from the wallet file.
+For example, if you need to export private keys or mnemonics.
+
+### `yarn script:addViewAccount`
+Add a public key to the wallet file.
+It makes it possible to track someone else transactions and rewards.
+Pay attention that Smapp does not fully support such kind of accounts.
+So in case you will try to sign a message or publish a transaction — unhandled exceptions will occur.

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -37,7 +37,8 @@ import NodeService, {
   StatusStreamHandler,
 } from './NodeService';
 import SmesherManager from './SmesherManager';
-import { createDebouncePool, getSpawnErrorReason, isEmptyDir } from './utils';
+import { createDebouncePool, getSpawnErrorReason } from './utils';
+import { isEmptyDir } from './fsUtils';
 import { NODE_CONFIG_FILE } from './main/constants';
 import {
   DEFAULT_GRPC_PRIVATE_PORT,

--- a/desktop/SmesherMetadataUtils.ts
+++ b/desktop/SmesherMetadataUtils.ts
@@ -4,7 +4,7 @@ import {
   isFileExists,
   readFileAsync,
   writeFileAsync,
-} from './utils';
+} from './fsUtils';
 
 interface SmesherMetadata {
   smeshingStart?: number;

--- a/desktop/fsUtils.ts
+++ b/desktop/fsUtils.ts
@@ -1,0 +1,26 @@
+import util from 'util';
+import fs from 'fs';
+import { F_OK } from 'constants';
+
+export const readFileAsync = util.promisify(fs.readFile);
+
+export const writeFileAsync = util.promisify(fs.writeFile);
+export const deleteFileAsync = util.promisify(fs.unlink);
+
+export const isFileExists = (filePath: string) =>
+  fs.promises
+    .access(filePath, F_OK)
+    .then(() => true)
+    .catch(() => false);
+
+export const isEmptyDir = async (path: string) => {
+  try {
+    const fsp = fs.promises;
+    const directory = await fsp.opendir(path);
+    const entry = await directory.read();
+    await directory.close();
+    return entry === null;
+  } catch (error) {
+    return false;
+  }
+};

--- a/desktop/main/Networks.ts
+++ b/desktop/main/Networks.ts
@@ -1,20 +1,11 @@
-import { hash } from '@spacemesh/sm-codec';
 import { app } from 'electron';
 import { Network, NodeConfig, PublicService } from '../../shared/types';
-import { toHexString } from '../../shared/utils';
+import { generateGenesisID } from '../../shared/utils';
 import { getStandaloneNetwork, isTestMode } from '../testMode';
 import { fetchJSON, patchQueryString } from '../utils';
 import { getEnvInfo } from '../envinfo';
 import { isDevNet } from '../envModes';
 import { toPublicService } from './utils';
-
-//
-// Assertions
-//
-
-export const generateGenesisID = (genesisTime: string, extraData: string) => {
-  return `${toHexString(hash(genesisTime + extraData)).substring(0, 40)}`;
-};
 
 export const generateGenesisIDFromConfig = (nodeConfig: NodeConfig) => {
   if (

--- a/desktop/main/Wallet.ts
+++ b/desktop/main/Wallet.ts
@@ -28,8 +28,9 @@ import {
   listWallets,
   loadRawWallet,
   loadRawWallets,
+  getWalletFileName,
 } from './walletFile';
-import { getLocalNodeConnectionConfig, getWalletFileName } from './utils';
+import { getLocalNodeConnectionConfig } from './utils';
 import sendPromptToRenderer from './sendPromptToRenderer';
 
 const list = async () => {

--- a/desktop/main/utils.ts
+++ b/desktop/main/utils.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import readFromBottom from 'fs-reverse';
 import { app, BrowserWindow, Notification } from 'electron';
-import { isFileExists } from '../utils';
+import { isFileExists } from '../fsUtils';
 import { PublicService, SocketAddress } from '../../shared/types';
 import { USERDATA_DIR } from './constants';
 
@@ -114,7 +114,3 @@ export const toPublicService = (
   name: netName,
   ...toSocketAddress(url),
 });
-
-// to lower case and replace spaces with underscores
-export const getWalletFileName = (walletName: string) =>
-  walletName.toLowerCase().replaceAll(/\s/g, '_');

--- a/desktop/main/walletFile.ts
+++ b/desktop/main/walletFile.ts
@@ -37,9 +37,8 @@ import {
   KDF_ITERATIONS,
 } from '../aes-gcm';
 import FileEncryptionService from '../fileEncryptionService'; // TODO: Remove it in next release
-import { isFileExists } from '../utils';
+import { isFileExists } from '../fsUtils';
 import { getISODate } from '../../shared/datetime';
-import { getWalletFileName } from './utils';
 
 export const WRONG_PASSWORD_MESSAGE = 'Wrong password';
 
@@ -64,6 +63,9 @@ export const defaultizeWalletSecrets = (
   mnemonic: '',
   ...secrets,
 });
+
+export const getWalletFileName = (walletName: string) =>
+  walletName.toLowerCase().replaceAll(/\s/g, '_');
 
 //
 // Encryption
@@ -319,3 +321,4 @@ export const listWallets = async (
     ...(await listWalletsInDirectory(walletsDir)),
   ]);
 };
+// to lower case and replace spaces with underscores

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -1,6 +1,3 @@
-import util from 'util';
-import fs from 'fs';
-import { F_OK } from 'constants';
 import cs from 'checksum';
 import electronFetch, { RequestInit } from 'electron-fetch';
 import { NodeConfig } from '../shared/types';
@@ -72,33 +69,6 @@ export const isNetError = (error: Error) => error.message.startsWith('net::');
 // --------------------------------------------------------
 
 export const isByteArray = (a: any): a is Uint8Array => a instanceof Uint8Array;
-
-// --------------------------------------------------------
-// FS Utils
-// --------------------------------------------------------
-
-export const readFileAsync = util.promisify(fs.readFile);
-
-export const writeFileAsync = util.promisify(fs.writeFile);
-export const deleteFileAsync = util.promisify(fs.unlink);
-
-export const isFileExists = (filePath: string) =>
-  fs.promises
-    .access(filePath, F_OK)
-    .then(() => true)
-    .catch(() => false);
-
-export const isEmptyDir = async (path: string) => {
-  try {
-    const fsp = fs.promises;
-    const directory = await fsp.opendir(path);
-    const entry = await directory.read();
-    await directory.close();
-    return entry === null;
-  } catch (error) {
-    return false;
-  }
-};
 
 /**
  * Creates a pool of objects T which will be collected

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "debug:tx": "ts-node ./scripts/composeTx.ts",
+    "debug:decomposeTx": "ts-node ./scripts/decomposeTx.ts",
     "debug:wallet": "ts-node ./scripts/readSecrets.ts",
     "debug:addViewAccount": "ts-node ./scripts/addViewOnlyAccount.ts"
   },

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "test": "jest",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "debug:tx": "ts-node ./scripts/composeTx.ts",
-    "debug:decomposeTx": "ts-node ./scripts/decomposeTx.ts",
-    "debug:wallet": "ts-node ./scripts/readSecrets.ts",
-    "debug:addViewAccount": "ts-node ./scripts/addViewOnlyAccount.ts"
+    "script:composeTx": "ts-node ./scripts/composeTx.ts",
+    "script:decomposeTx": "ts-node ./scripts/decomposeTx.ts",
+    "script:readSecrets": "ts-node ./scripts/readSecrets.ts",
+    "script:addViewAccount": "ts-node ./scripts/addViewOnlyAccount.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/composeTx.ts
+++ b/scripts/composeTx.ts
@@ -3,9 +3,8 @@ import Bech32 from '@spacemesh/address-wasm';
 import prompts from 'prompts';
 
 import { sign } from '../desktop/ed25519';
-import { fromHexString } from '../shared/utils';
+import { fromHexString, generateGenesisID } from '../shared/utils';
 import { SingleSigMethods } from '../shared/templateConsts';
-import { generateGenesisID } from "../desktop/main/Networks";
 
 (async () => {
   // Inputs

--- a/scripts/decomposeTx.ts
+++ b/scripts/decomposeTx.ts
@@ -1,0 +1,46 @@
+import * as sm from '@spacemesh/sm-codec';
+import prompts from 'prompts';
+import { SingleSigMethods } from '../shared/templateConsts';
+
+(async () => {
+  // Inputs
+  const inputs = await prompts([
+    {
+      type: 'select',
+      name: 'templateAddress',
+      message: 'Choose the template',
+      choices: [
+        { title: 'SingleSig', value: sm.SingleSigTemplate.key },
+      ],
+    },
+    {
+      type: prev => prev === sm.SingleSigTemplate.key ? 'select' : null,
+      name: 'method',
+      message: 'Choose the method',
+      choices: [
+        { title: 'SelfSpawn', value: SingleSigMethods.Spawn },
+        { title: 'Spend', value: SingleSigMethods.Spend },
+      ],
+    },
+    {
+      type: 'text',
+      name: 'rawTx',
+      message: 'Put here raw transaction (in format `0, 0, 0, 0, 0, 0, 227, ..., 23`)',
+    },
+  ], {
+    onCancel: () => {
+      console.log('Composing transaction cancelled');
+      process.exit(0);
+    }
+  });
+
+  // SCRIPT
+  const tpl = sm.TemplateRegistry.get(inputs.templateAddress, inputs.method);
+  const bytes = Uint8Array.from(
+    JSON.parse(
+      `[${inputs.rawTx.replace('[', '').replace(']', '')}]`
+    )
+  );
+
+  console.dir(tpl.decode(bytes), { depth: null, colors: true });
+})();

--- a/scripts/readSecrets.ts
+++ b/scripts/readSecrets.ts
@@ -1,7 +1,7 @@
 import prompts from 'prompts';
 import fs from 'fs';
-import { decryptWallet } from '../desktop/main/walletFile';
 import { WalletFile } from '../shared/types';
+import { decryptWallet } from '../desktop/main/walletFile';
 
 (async () => {
   console.log('Attention!');

--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import { hash } from '@spacemesh/sm-codec';
 import { Timestamp } from '@grpc/grpc-js/build/src/generated/google/protobuf/Timestamp';
 import { Event } from '../proto/spacemesh/v1/Event';
 import { Duration } from '../proto/google/protobuf/Duration';
@@ -138,6 +139,10 @@ export const getEventType = (event: NodeEvent): Event['details'] => {
   return eventType;
 };
 
+export const generateGenesisID = (genesisTime: string, extraData: string) => {
+  return `${toHexString(hash(genesisTime + extraData)).substring(0, 40)}`;
+};
+
 export const getShortGenesisId = (genesisID: HexString) =>
   genesisID.substring(0, 8);
 
@@ -149,3 +154,6 @@ export const isDebPackage = () =>
 
 export const isLinuxAppImage = () =>
   os.platform() === 'linux' && !!process.env.APPIMAGE;
+//
+// Assertions
+//

--- a/tests/desktop/Network.spec.ts
+++ b/tests/desktop/Network.spec.ts
@@ -1,4 +1,4 @@
-import { generateGenesisID } from '../../desktop/main/Networks';
+import { generateGenesisID } from 'shared/utils';
 
 describe('test Network util functions', () => {
   const genesisTime = '2022-11-20T20:00:00.498Z';

--- a/tests/shared/utils.spec.ts
+++ b/tests/shared/utils.spec.ts
@@ -1,18 +1,17 @@
-import { generateGenesisID } from 'shared/utils';
+import { generateGenesisID } from '../../shared/utils';
 
-describe('test Network util functions', () => {
+describe('generateGenesisID', () => {
   const genesisTime = '2022-11-20T20:00:00.498Z';
   const extraData = 'unique-testnet-identifier';
 
-  const expectedGenesisId = 'b92736fb23dfe78efe03c2c45fb638b9fe3afa70';
-
-  it('test for generateGenesisID', () => {
+  it('is pure & determenistic', () => {
     expect(generateGenesisID(genesisTime, extraData)).toEqual(
       generateGenesisID(genesisTime, extraData)
     );
-
+  });
+  it('works as expected', () => {
     expect(generateGenesisID(genesisTime, extraData)).toEqual(
-      expectedGenesisId
+      'b92736fb23dfe78efe03c2c45fb638b9fe3afa70'
     );
   });
 });


### PR DESCRIPTION
No issue.

I had a semi-ready branch that fixes CLI tools and adds one another.
There was a problem that some modules (with utility functions) were dependent on electron-specific stuff (like `app.getPath`). Now I moved some utility functions that are not electron-specific in better places to avoid such problems.

It does not affect Smapp anyhow.
But it makes it possible to use CLI-tools, which may be handy for debugging / development:

### `yarn script:composeTx`
Compose the transaction (and sign if needed).

### `yarn script:decomposeTx`
Decompose the transaction (byte array) to the human-readable structure (JSON)

### `yarn script:readSecrets`
Read secrets from the wallet file.
For example, if you need to export private keys or mnemonics.

### `yarn script:addViewAccount`
Add a public key to the wallet file.
It makes it possible to track someone else transactions and rewards.
Pay attention that Smapp does not fully support such kind of accounts.
So in case you will try to sign a message or publish a transaction — unhandled exceptions will occur.