### PR TITLE
 disclaimer hidden from GUI

### DIFF
--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -232,7 +232,7 @@ class Settings extends Component<Props, State> {
                 }
                 rowName="Wallet Auto Start"
               />
-              <SettingRow
+              {/* <SettingRow
                 upperPart={[
                   <Text key={1}>Read our&nbsp;</Text>,
                   <Link
@@ -244,7 +244,7 @@ class Settings extends Component<Props, State> {
                   />,
                 ]}
                 rowName="Legal"
-              />
+              /> */}
               <SettingRow
                 upperPartLeft="Learn more in our extensive user guide"
                 isUpperPartLeftText


### PR DESCRIPTION
Since we don’t have a proper link to add, I suggest hiding this part for now (it points to the very old testnet doc). 
Once the Legal Team provides an updated resource, we will be able to link a mainnet-related disclaimer.