### PR TITLE
Fix #1273 - balance shown truncated, not rounded

### DIFF
--- a/app/infra/utils.ts
+++ b/app/infra/utils.ts
@@ -81,8 +81,14 @@ export enum CoinUnits {
   Smidge = 'Smidge',
 }
 
+// Truncates a number to a specified number of decimal places without rounding
+const truncateToDecimalPlaces = (num: number, decimalPlaces: number) => {
+  const numPower = 10 ** decimalPlaces;
+  return Math.floor(num * numPower) / numPower;
+};
+
 const packValueAndUnit = (value: number, unit: string) => ({
-  value: parseFloat(value.toFixed(3)).toString(),
+  value: value.toString(),
   unit,
 });
 
@@ -94,11 +100,12 @@ export const toSmidge = (smh: number) => Math.round(smh * 10 ** 9);
 export const parseSmidge = (amount: number) => {
   // If amount is "falsy" (0 | undefined | null)
   if (!amount) return packValueAndUnit(0, CoinUnits.SMH);
-  // Show `23.053 SMH` for big amount
-  else if (amount >= 10 ** 9)
-    return packValueAndUnit(toSMH(amount), CoinUnits.SMH);
-  // Or `6739412 Smidge` (without dot) for small amount
-  else if (!Number.isNaN(amount))
+  else if (amount >= 10 ** 9) {
+    // Truncate to 3 decimal places without rounding
+    const smhValue = truncateToDecimalPlaces(toSMH(amount), 3);
+    return packValueAndUnit(smhValue, CoinUnits.SMH);
+    // Or `6739412 Smidge` (without dot) for small amount
+  } else if (!Number.isNaN(amount))
     return packValueAndUnit(amount, CoinUnits.Smidge);
   // Show `0 SMH` for zero amount and NaN
   else return packValueAndUnit(0, CoinUnits.SMH);


### PR DESCRIPTION
it fixes #1273 
as far as I could test it without the standalone mode, it seems to work fine. I used the view-only wallet on Mainnet.
