### PR TITLE
Do not run quicksync check by interval and disable button only if node is synced

### DIFF
--- a/app/redux/node/selectors.ts
+++ b/app/redux/node/selectors.ts
@@ -10,3 +10,8 @@ export const isQuicksyncEnabled = (state: RootState) => {
   const nodeStatus = state.node.status;
   return isMainNet(state) && (!nodeStatus || !nodeStatus?.isSynced);
 };
+
+export const isNodeLayersBehind = (delta: number) => (state: RootState) => {
+  const nodeStatus = state.node.status;
+  return !nodeStatus || nodeStatus.topLayer - delta > nodeStatus.syncedLayer;
+};

--- a/app/redux/node/selectors.ts
+++ b/app/redux/node/selectors.ts
@@ -6,12 +6,7 @@ export const getNodeStartupState = (state: RootState) =>
   state.node.startupStatus;
 export const getNodeError = (state: RootState) => state.node.error;
 
-export const isQuicksyncAvailable = (state: RootState) => {
-  const quicksync = state.node.quicksyncStatus;
-  return (
-    isMainNet(state) &&
-    (!quicksync ||
-      (quicksync.current - 100 > quicksync.db &&
-        quicksync.available > quicksync.db))
-  );
+export const isQuicksyncEnabled = (state: RootState) => {
+  const nodeStatus = state.node.status;
+  return isMainNet(state) && (!nodeStatus || !nodeStatus?.isSynced);
 };

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -36,6 +36,7 @@ import {
   getNodeError,
   getNodeStartupState,
   getNodeStatus,
+  isNodeLayersBehind,
   isQuicksyncEnabled,
 } from '../../redux/node/selectors';
 import QuicksyncLink from '../../basicComponents/QuicksyncLink';
@@ -104,7 +105,10 @@ const Network = ({ history }) => {
   const startupStatus = useSelector(getNodeStartupState);
   const status = useSelector(getNodeStatus);
   const nodeError = useSelector(getNodeError);
-  const quicksyncAvailable = useSelector(isQuicksyncEnabled);
+  const quicksyncAvailable = useSelector(
+    (state: RootState) =>
+      isQuicksyncEnabled(state) && isNodeLayersBehind(100)(state)
+  );
   const genesisID = useSelector(
     (state: RootState) => state.network.genesisID || ''
   );

--- a/app/screens/network/Network.tsx
+++ b/app/screens/network/Network.tsx
@@ -36,7 +36,7 @@ import {
   getNodeError,
   getNodeStartupState,
   getNodeStatus,
-  isQuicksyncAvailable,
+  isQuicksyncEnabled,
 } from '../../redux/node/selectors';
 import QuicksyncLink from '../../basicComponents/QuicksyncLink';
 
@@ -104,7 +104,7 @@ const Network = ({ history }) => {
   const startupStatus = useSelector(getNodeStartupState);
   const status = useSelector(getNodeStatus);
   const nodeError = useSelector(getNodeError);
-  const quicksyncAvailable = useSelector(isQuicksyncAvailable);
+  const quicksyncAvailable = useSelector(isQuicksyncEnabled);
   const genesisID = useSelector(
     (state: RootState) => state.network.genesisID || ''
   );

--- a/app/screens/settings/Settings.tsx
+++ b/app/screens/settings/Settings.tsx
@@ -37,7 +37,7 @@ import { getGenesisID, getNetworkName } from '../../redux/network/selectors';
 import { AuthPath, MainPath, RouterPath } from '../../routerPaths';
 import { setClientSettingsTheme } from '../../theme';
 import { validationWalletName } from '../auth/Validation';
-import { isQuicksyncAvailable } from '../../redux/node/selectors';
+import { isQuicksyncEnabled } from '../../redux/node/selectors';
 
 const Wrapper = styled.div`
   display: flex;
@@ -820,7 +820,7 @@ const mapStateToProps = (state: RootState) => ({
   walletFiles: state.wallet.walletFiles?.map(({ path }) => path) || [],
   currentWalletPath: state.wallet.currentWalletPath,
   isMainNet: state.network.isMainNet,
-  isQuicksyncAvailable: isQuicksyncAvailable(state),
+  isQuicksyncAvailable: isQuicksyncEnabled(state),
   genesisTime: state.network.genesisTime,
   rootHash: state.network.rootHash,
   build: state.node.build,

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -314,7 +314,7 @@ class NodeManager extends AbstractManager {
             `Latest layer in the trusted state: ${qsStatus.available}`,
             `Current layer in the network: ${qsStatus.current}`,
             '',
-            'We recommend you to keep using your local state.',
+            'Your node is nearly synced. We recommend you to keep using your local state.',
             'Do you want to download the trusted state anyway?',
           ].join('\n'),
           confirmTitle: 'Download anyway!',

--- a/shared/quicksync.ts
+++ b/shared/quicksync.ts
@@ -1,0 +1,7 @@
+import { QuicksyncStatus } from './types/quicksync';
+
+export const isQuicksyncAvailable = (status: QuicksyncStatus) =>
+  status.available > status.db;
+
+export const isLocalStateFarBehind = (status: QuicksyncStatus, delta: number) =>
+  status.current - delta > status.db;

--- a/shared/types/quicksync.ts
+++ b/shared/types/quicksync.ts
@@ -1,5 +1,4 @@
 export interface QuicksyncStatus {
-  synced: boolean;
   db: number;
   current: number;
   available: number;


### PR DESCRIPTION
- The behaviour on the Smapp startup is not changed: it will propose to quick sync if local state is more than 1/2 epoch behind.
- Smapp won't run quicksync check every 1 hour
- When User hits the "Run quicksync" button on the Settings page — it will run quicksync check and then show prompt:
   - If < 100 layers behind — that quick sync is not recommended, but User can force download it,
   - if > 100 layers behind — the same prompt as before,
- Smapp will disable the Quick sync button on Settings page only if the node is started (API) and synced
- Smapp will show "Run quicksync?" on Networks page only if it has unknown node status or syncedLayer is more than 100 layers behind the topLayer.