### PR TITLE
dont run pr-build for draft PRs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,9 +3,11 @@ name: PR Build
 on:
  workflow_dispatch:
  pull_request:
+   types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build-and-upload:
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.image }}
 
     strategy:


### PR DESCRIPTION
It might eliminate unnecessary costs generated by these runs