### PR TITLE
Prepare Smapp for support go-spacemesh v1.4.0

### DIFF
--- a/app/redux/smesher/reducer.ts
+++ b/app/redux/smesher/reducer.ts
@@ -20,7 +20,7 @@ import {
 } from './actions';
 
 const initialState = {
-  smesherId: '',
+  smesherIds: [],
   isSmeshingStarted: false,
   postSetupProviders: [] as PostSetupProviders[],
   coinbase: '',
@@ -52,7 +52,7 @@ const reducer = (state: SmesherState = initialState, action: CustomAction) => {
       const {
         payload: {
           config,
-          smesherId,
+          smesherIds,
           isSmeshingStarted,
           postSetupState,
           numLabelsWritten,
@@ -68,7 +68,7 @@ const reducer = (state: SmesherState = initialState, action: CustomAction) => {
       return {
         ...state,
         config,
-        smesherId,
+        smesherIds,
         numUnits,
         maxFileSize,
         numLabelsWritten,

--- a/app/screens/modal/GenericModal.tsx
+++ b/app/screens/modal/GenericModal.tsx
@@ -8,6 +8,7 @@ import {
   GENERIC_MODAL_DEFAULTS,
   GenericModalOpts,
 } from '../../../shared/genericModal';
+import formatMessage from '../../infra/formatMessage';
 
 const Message = styled.pre`
   flex-grow: 1;
@@ -60,12 +61,13 @@ const GenericModal = () => {
 
   return (
     <Modal header={opts.title} width={600} height={360}>
-      <Message>{opts.message}</Message>
+      <Message>{formatMessage(opts.message)}</Message>
       {opts.buttons.length > 0 && (
         <ButtonNewGroup>
           {opts.buttons.map((btn, ix) => (
             <ButtonNew
               key={ix}
+              isPrimary={btn.primary || false}
               onClick={
                 btn.action === 'close'
                   ? () => close()

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -252,19 +252,24 @@ const ERR_MESSAGE_NODE_ERROR =
   'The Node is not syncing. Please check the Network tab';
 
 const SmesherStatus = ({
-  smesherId,
+  smesherIds,
   status,
   networkName,
 }: {
-  smesherId: HexString;
+  smesherIds: HexString[];
   status: NodeStatus | null;
   networkName: string;
 }) => (
   <SubHeader>
     Smesher
-    <SmesherId>
-      <Address type={AddressType.SMESHER} address={smesherId} isHex />
-    </SmesherId>
+    {smesherIds.map((smesherID, idx) => (
+      <>
+        {idx > 0 && ', '}
+        <SmesherId key={`smesher_${smesherID}`}>
+          <Address type={AddressType.SMESHER} address={smesherID} isHex />
+        </SmesherId>
+      </>
+    ))}
     is&nbsp;
     <StatusSpan status={status}> {status ? 'ONLINE' : ' OFFLINE'} </StatusSpan>
     &nbsp;on {networkName}.
@@ -302,7 +307,9 @@ const Node = ({ history, location }: Props) => {
   const nodeError = useSelector((state: RootState) => state.node.error);
   const status = useSelector((state: RootState) => state.node.status);
   const networkName = useSelector((state: RootState) => state.network.netName);
-  const smesherId = useSelector((state: RootState) => state.smesher.smesherId);
+  const smesherIds = useSelector(
+    (state: RootState) => state.smesher.smesherIds
+  );
   const coinbase = useSelector((state: RootState) => state.smesher.coinbase);
   const posDataPath = useSelector((state: RootState) => state.smesher.dataDir);
   const smesherConfig = useSelector((state: RootState) => state.smesher.config);
@@ -432,13 +439,20 @@ const Node = ({ history, location }: Props) => {
         `${postProvingOpts.nonces} nonces | ${postProvingOpts.threads} CPU threads`,
       ],
       [
-        'Smesher ID',
-        <Address
-          key="smesherId"
-          type={AddressType.SMESHER}
-          address={smesherId}
-          isHex
-        />,
+        'Smesher IDs',
+        <>
+          {smesherIds.map((smesherId, idx) => (
+            <>
+              {idx > 0 && ', '}
+              <Address
+                key={`smesher_${smesherId}`}
+                type={AddressType.SMESHER}
+                address={smesherId}
+                isHex
+              />
+            </>
+          ))}
+        </>,
       ],
     ];
   };
@@ -563,7 +577,7 @@ const Node = ({ history, location }: Props) => {
       return (
         <>
           <SmesherStatus
-            smesherId={smesherId}
+            smesherIds={smesherIds}
             status={status}
             networkName={networkName}
           />

--- a/app/screens/node/NodeEventActivityRow.tsx
+++ b/app/screens/node/NodeEventActivityRow.tsx
@@ -3,8 +3,8 @@ import { NodeEvent } from '../../../shared/types';
 import ErrorMessage from '../../basicComponents/ErrorMessage';
 import { getEventType, toHexString } from '../../../shared/utils';
 import { CustomTimeAgo } from '../../basicComponents';
-import { getNodeEventStage } from './nodeEventUtils';
 import Address, { AddressType } from '../../components/common/Address';
+import { getNodeEventStage } from './nodeEventUtils';
 
 const withTime = (str: string, now: number, wait?: number) =>
   !wait ? (

--- a/app/screens/node/NodeEventActivityRow.tsx
+++ b/app/screens/node/NodeEventActivityRow.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { NodeEvent } from '../../../shared/types';
 import ErrorMessage from '../../basicComponents/ErrorMessage';
-import { getEventType } from '../../../shared/utils';
+import { getEventType, toHexString } from '../../../shared/utils';
 import { CustomTimeAgo } from '../../basicComponents';
 import { getNodeEventStage } from './nodeEventUtils';
+import Address, { AddressType } from '../../components/common/Address';
 
 const withTime = (str: string, now: number, wait?: number) =>
   !wait ? (
@@ -35,6 +36,12 @@ const getEventErrorMessage = (event: NodeEvent) => {
   }
 };
 
+const ensureSmesherIdType = (s: string | Buffer | Uint8Array | undefined) => {
+  if (!s) return null;
+  if (typeof s === 'string') return s;
+  return toHexString(s);
+};
+
 export default (event: NodeEvent) => {
   if (event && event.failure) {
     return <ErrorMessage>{getEventErrorMessage(event)}</ErrorMessage>;
@@ -43,8 +50,19 @@ export default (event: NodeEvent) => {
     return 'Node is connecting...';
   }
   switch (getEventType(event)) {
-    case 'initStart':
-      return 'Started PoS data initialization';
+    case 'initStart': {
+      const smesherId = ensureSmesherIdType(event.initStart?.smesher);
+      if (!smesherId) {
+        return 'Started PoS data initialization';
+      } else {
+        return (
+          <>
+            Started PoS data initialization for
+            <Address type={AddressType.SMESHER} address={smesherId} isHex />
+          </>
+        );
+      }
+    }
     case 'initComplete':
       return 'Completed PoS data initialization';
     case 'initFailed':
@@ -66,10 +84,32 @@ export default (event: NodeEvent) => {
         event.poetWaitProof?.wait
       );
     }
-    case 'postStart':
-      return "Generating PoST proof for the PoET's challenge";
-    case 'postComplete':
-      return 'Finished generating PoST proof';
+    case 'postStart': {
+      const smesherId = ensureSmesherIdType(event.postStart?.smesher);
+      if (!smesherId) {
+        return "Generating PoST proof for the PoET's challenge";
+      } else {
+        return (
+          <>
+            Generating PoST proof for the PoET&apos;s challenge for
+            <Address type={AddressType.SMESHER} address={smesherId} isHex />
+          </>
+        );
+      }
+    }
+    case 'postComplete': {
+      const smesherId = ensureSmesherIdType(event.postComplete?.smesher);
+      if (!smesherId) {
+        return 'Finished generating PoST proof';
+      } else {
+        return (
+          <>
+            Finished generating PoST proof for
+            <Address type={AddressType.SMESHER} address={smesherId} isHex />
+          </>
+        );
+      }
+    }
     case 'atxPublished':
       return 'Published activation. Waiting for the next epoch';
     case 'eligibilities':

--- a/app/types/redux.ts
+++ b/app/types/redux.ts
@@ -56,7 +56,7 @@ export interface WalletState {
 }
 
 export interface SmesherState {
-  smesherId: string;
+  smesherIds: string[];
   isSmeshingStarted: boolean;
   postSetupProviders: PostSetupProvider[];
   coinbase: string;

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -4,7 +4,7 @@ import { PassThrough, Writable } from 'stream';
 import { createInterface } from 'readline';
 import fse from 'fs-extra';
 import { spawn } from 'cross-spawn';
-import { BrowserWindow, dialog, ipcMain } from 'electron';
+import { BrowserWindow, dialog, ipcMain, shell } from 'electron';
 import { debounce } from 'throttle-debounce';
 import rotator from 'logrotate-stream';
 import { Subject } from 'rxjs';
@@ -68,7 +68,11 @@ import {
   showGenericModal,
   showGenericPrompt,
 } from './main/sendGenericModals';
-import { loadNodeConfig } from './main/NodeConfig';
+import {
+  getCustomNodeConfigPath,
+  loadCustomNodeConfig,
+  loadNodeConfig,
+} from './main/NodeConfig';
 
 const logger = Logger({ className: 'NodeManager' });
 
@@ -476,6 +480,59 @@ class NodeManager extends AbstractManager {
     }
   };
 
+  // Check for outdated property in config
+  // and display a popup that requires changes in the custom config
+  // before the node can start
+  // https://github.com/spacemeshos/go-spacemesh/blob/v1.4.0-alpha.1/CHANGELOG.md#configjson
+  checkOutdatedConfig = async () => {
+    const customCfg = await loadCustomNodeConfig(this.genesisID);
+    if (!customCfg.main?.['poet-server']) {
+      return true;
+    }
+
+    const customCfgPath = getCustomNodeConfigPath(this.genesisID);
+    const RETRY_START_NODE_ACTION = 'RETRY_START_NODE_ACTION';
+    const SHOW_CONFIG_FILE_ACTION = 'SHOW_CONFIG_FILE_ACTION';
+
+    const showPopup = () => {
+      showGenericModal(this.mainWindow.webContents, {
+        title: 'You have outdated config',
+        message: [
+          'In go-spacemesh v1.4.0 was a breaking change in the config file. Smapp found that you have used the custom configuration for PoET servers, and now you need to update it to make the Node starts.',
+          '',
+          'Please, follow the <a href="https://github.com/spacemeshos/go-spacemesh/blob/v1.4.0-alpha.1/CHANGELOG.md#configjson">recommendations</a> in the changelog.',
+          'And then click "Retry".',
+        ].join('\n'),
+        buttons: [
+          { label: 'Retry', action: RETRY_START_NODE_ACTION, primary: true },
+          { label: 'Reveal config file', action: SHOW_CONFIG_FILE_ACTION },
+        ],
+      });
+
+      return new Promise<boolean>((resolve) => {
+        ipcMain.once(ipcConsts.GENERIC_MODAL_BTN_PRESS, (_, eventName) => {
+          if (eventName === RETRY_START_NODE_ACTION) {
+            this.checkOutdatedConfig()
+              .then(resolve)
+              .catch((err) => {
+                logger.error('checkOutdatedConfig.Retry', err);
+              });
+          }
+          if (eventName === SHOW_CONFIG_FILE_ACTION) {
+            shell.showItemInFolder(customCfgPath);
+            // Show popup again because any button closes popup
+            showPopup()
+              .then(resolve)
+              .catch((err) => {
+                logger.error('checkOutdatedConfig.ShowFile', err);
+              });
+          }
+        });
+      });
+    };
+    return showPopup();
+  };
+
   startNode = async (skipQuicksync = false) => {
     logger.log(
       'startNode',
@@ -486,7 +543,7 @@ class NodeManager extends AbstractManager {
     if (this.isNodeRunning()) return true;
     this.sendNodeStatus(DEFAULT_NODE_STATUS);
     this.$_nodeStatus.reset();
-
+    await this.checkOutdatedConfig();
     const cfg = await loadNodeConfig();
     if (!skipQuicksync && isMainNetConfig(cfg)) {
       const qsStatus = await this.runQuicksyncCheck();

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -498,7 +498,7 @@ class NodeManager extends AbstractManager {
       showGenericModal(this.mainWindow.webContents, {
         title: 'You have outdated config',
         message: [
-          'In go-spacemesh v1.4.0 was a breaking change in the config file. Smapp found that you have used the custom configuration for PoET servers, and now you need to update it to make the Node starts.',
+          'In go-spacemesh v1.4.0 there was a breaking change in the config file. Smapp found that you have used the custom configuration for PoET servers, and now you need to update it to make the Node start.',
           '',
           'Please, follow the <a href="https://github.com/spacemeshos/go-spacemesh/blob/v1.4.0-alpha.1/CHANGELOG.md#configjson">recommendations</a> in the changelog.',
           'And then click "Retry".',

--- a/desktop/SmesherManager.ts
+++ b/desktop/SmesherManager.ts
@@ -70,12 +70,12 @@ class SmesherManager extends AbstractManager {
     return config.smeshing || {};
   };
 
-  getSmesherId = async () => {
-    const res = await this.smesherService.getSmesherID();
+  getSmesherIds = async () => {
+    const res = await this.smesherService.getSmesherIDs();
     if (res.error) {
       throw res.error;
     }
-    return res.smesherId;
+    return res.smesherIds;
   };
 
   getCurrentDataDir = async (genesisID: HexString) => {
@@ -126,7 +126,7 @@ class SmesherManager extends AbstractManager {
       }
     }
 
-    const { smesherId } = await this.smesherService.getSmesherID();
+    const { smesherIds } = await this.smesherService.getSmesherIDs();
     const {
       postSetupState,
       numLabelsWritten,
@@ -141,7 +141,7 @@ class SmesherManager extends AbstractManager {
 
     const data: IPCSmesherStartupData = {
       config,
-      smesherId: smesherId || '',
+      smesherIds,
       isSmeshingStarted,
       postSetupState,
       numLabelsWritten,

--- a/desktop/SmesherService.ts
+++ b/desktop/SmesherService.ts
@@ -1,9 +1,10 @@
 import { ProtoGrpcType } from '../proto/smesher';
 import { PostSetupStatusStreamResponse__Output } from '../proto/spacemesh/v1/PostSetupStatusStreamResponse';
-import { SmesherIDResponse__Output } from '../proto/spacemesh/v1/SmesherIDResponse';
+import { SmesherIDsResponse__Output } from '../proto/spacemesh/v1/SmesherIDsResponse';
 
 import {
   DeviceType,
+  HexString,
   PostSetupOpts,
   PostSetupState,
   PostSetupStatus,
@@ -133,15 +134,16 @@ class SmesherService extends NetServiceFactory<
       .then(this.normalizeServiceResponse)
       .catch(this.normalizeServiceError({}));
 
-  getSmesherID = () =>
-    this.callServiceWithRetries('SmesherID', {})
-      .then((response: SmesherIDResponse__Output) => {
-        return {
-          smesherId: toHexString(response.publicKey),
-        };
-      })
+  getSmesherIDs = (): Promise<{
+    error: Error | null;
+    smesherIds: HexString[];
+  }> =>
+    this.callServiceWithRetries('SmesherIDs', {})
+      .then((response: SmesherIDsResponse__Output) => ({
+        smesherIds: response.publicKeys.map(toHexString),
+      }))
       .then(this.normalizeServiceResponse)
-      .catch(this.normalizeServiceError({ smesherId: '' }));
+      .catch(this.normalizeServiceError({ smesherIds: [] }));
 
   getCoinbase = (): Promise<{ error: Error | null; coinbase: string }> =>
     this.callServiceWithRetries('Coinbase', {})

--- a/desktop/main/reactions/syncToRenderer.ts
+++ b/desktop/main/reactions/syncToRenderer.ts
@@ -25,6 +25,7 @@ import {
   NodeVersionAndBuild,
   Wallet,
   NodeEvent,
+  HexString,
 } from '../../../shared/types';
 import { ConfigStore } from '../../storeService';
 import { MINUTE } from '../../../shared/constants';
@@ -118,7 +119,7 @@ export default (
   $currentLayer: Observable<number>,
   $rootHash: Observable<string>,
   $nodeVersion: Observable<NodeVersionAndBuild>,
-  $smesherId: Observable<string>,
+  $smesherIds: Observable<HexString[]>,
   $nodeEvents: Observable<NodeEvent>,
   $hrp: Observable<string>
 ) => {
@@ -133,7 +134,7 @@ export default (
     networkView($currentNetwork, $currentNodeConfig),
     $networks.pipe(map(R.objOf('networks'))),
     $nodeVersion.pipe(map(R.objOf('node'))),
-    $smesherId.pipe(map((smesherId) => ({ smesher: { smesherId } }))),
+    $smesherIds.pipe(map((smesherIds) => ({ smesher: { smesherIds } }))),
     $nodeEvents.pipe(
       distinct(getNodeEventKey),
       scan((acc, next) => [...acc, next].slice(-1000), <NodeEvent[]>[]),

--- a/desktop/main/sources/smesherInfo.ts
+++ b/desktop/main/sources/smesherInfo.ts
@@ -94,7 +94,7 @@ const syncSmesherInfo = (
     share()
   );
 
-  const $smesherId = combineLatest([
+  const $smesherIds = combineLatest([
     $isLocalNode,
     $managers,
     $isWalletActivated,
@@ -102,14 +102,11 @@ const syncSmesherInfo = (
     switchMap(([isLocalNode, managers]) =>
       from(
         (async () => {
-          if (!isLocalNode) return '';
+          if (!isLocalNode) return [];
           if (await managers.node.getNodeStatus()) {
-            const smesherId = await managers.smesher
-              .getSmesherId()
-              .catch(() => '');
-            return smesherId || '';
+            return managers.smesher.getSmesherIds().catch(() => []);
           }
-          throw new Error('getSmesherId(): Can not reach the Node');
+          throw new Error('getSmesherIds(): Can not reach the Node');
         })()
       )
     ),
@@ -158,7 +155,7 @@ const syncSmesherInfo = (
   );
 
   return {
-    $smesherId,
+    $smesherIds,
     $coinbase,
     $smeshingStarted,
     $smeshingSetupState,

--- a/desktop/main/startApp.ts
+++ b/desktop/main/startApp.ts
@@ -165,7 +165,7 @@ const startApp = (): AppStore => {
   } = loadNetworkData();
 
   const {
-    $smesherId,
+    $smesherIds,
     $smeshingStarted,
     $smeshingSetupState,
     $nodeEvents,
@@ -260,7 +260,7 @@ const startApp = (): AppStore => {
       $currentLayer,
       $rootHash,
       $nodeVersion,
-      $smesherId,
+      $smesherIds,
       $nodeEvents,
       $hrp
     ),

--- a/proto/admin_types.proto
+++ b/proto/admin_types.proto
@@ -68,22 +68,26 @@ message EventPostServiceStopped {}
 
 message EventPostStart {
   bytes challenge = 1;
+  bytes smesher = 2;
 }
 
 message EventPostComplete {
   bytes challenge = 1;
+  bytes smesher = 2;
 }
 
 message EventPoetWaitRound {
   uint32 current = 1;
   uint32 publish = 2;
   google.protobuf.Duration wait = 3;
+  google.protobuf.Timestamp until = 4;
 }
 
 message EventPoetWaitProof {
   uint32 publish = 1;
   uint32 target = 2;
   google.protobuf.Duration wait = 3;
+  google.protobuf.Timestamp until = 4;
 }
 
 message EventAtxPubished {
@@ -91,6 +95,7 @@ message EventAtxPubished {
   uint32 target = 2;
   bytes id = 3;
   google.protobuf.Duration wait = 4;
+  google.protobuf.Timestamp until = 5;
 }
 
 message EventEligibilities {
@@ -113,19 +118,19 @@ message EventProposal {
 }
 
 message EventMalfeasance {
-    MalfeasanceProof proof = 1;
+  MalfeasanceProof proof = 1;
 }
 
 message EventStreamRequest {}
 
 message ConnectionInfo {
-    string address = 1;
-  	google.protobuf.Duration uptime = 2;
-    bool outbound = 3;
+  string address = 1;
+  google.protobuf.Duration uptime = 2;
+  bool outbound = 3;
 }
 
 message PeerInfo {
-    string id = 1;
-    repeated ConnectionInfo connections = 2;
-    repeated string tags = 4;
+  string id = 1;
+  repeated ConnectionInfo connections = 2;
+  repeated string tags = 4;
 }

--- a/proto/smesher.proto
+++ b/proto/smesher.proto
@@ -37,6 +37,14 @@ service SmesherService {
         option (google.api.http) = {
             post: "/v1/smesher/smesherid"
         };
+        option deprecated = true; // will return empty response in v1.4.x
+    }
+
+    // Get the Smesher IDs managed by the node
+    rpc SmesherIDs (google.protobuf.Empty) returns (SmesherIDsResponse) {
+        option (google.api.http) = {
+            post: "/v1/smesher/smesherids"
+        };
     }
 
     // Get the current coinbase

--- a/proto/smesher.ts
+++ b/proto/smesher.ts
@@ -53,6 +53,7 @@ export interface ProtoGrpcType {
       SimpleInt: MessageTypeDefinition
       SimpleString: MessageTypeDefinition
       SmesherIDResponse: MessageTypeDefinition
+      SmesherIDsResponse: MessageTypeDefinition
       SmesherId: MessageTypeDefinition
       SmesherService: SubtypeConstructor<typeof grpc.Client, _spacemesh_v1_SmesherServiceClient> & { service: _spacemesh_v1_SmesherServiceDefinition }
       StartSmeshingRequest: MessageTypeDefinition

--- a/proto/smesher_types.proto
+++ b/proto/smesher_types.proto
@@ -53,6 +53,10 @@ message SmesherIDResponse {
     bytes public_key = 1;
 }
 
+message SmesherIDsResponse {
+    repeated bytes public_keys = 1;
+}
+
 message CoinbaseResponse {
     AccountId account_id = 1;
 }

--- a/proto/smesher_types.ts
+++ b/proto/smesher_types.ts
@@ -51,6 +51,7 @@ export interface ProtoGrpcType {
       SimpleInt: MessageTypeDefinition
       SimpleString: MessageTypeDefinition
       SmesherIDResponse: MessageTypeDefinition
+      SmesherIDsResponse: MessageTypeDefinition
       SmesherId: MessageTypeDefinition
       StartSmeshingRequest: MessageTypeDefinition
       StartSmeshingResponse: MessageTypeDefinition

--- a/proto/spacemesh/v1/EventAtxPubished.ts
+++ b/proto/spacemesh/v1/EventAtxPubished.ts
@@ -1,12 +1,14 @@
 // Original file: proto/admin_types.proto
 
 import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../google/protobuf/Duration';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../google/protobuf/Timestamp';
 
 export interface EventAtxPubished {
   'current'?: (number);
   'target'?: (number);
   'id'?: (Buffer | Uint8Array | string);
   'wait'?: (_google_protobuf_Duration | null);
+  'until'?: (_google_protobuf_Timestamp | null);
 }
 
 export interface EventAtxPubished__Output {
@@ -14,4 +16,5 @@ export interface EventAtxPubished__Output {
   'target': (number);
   'id': (Buffer);
   'wait': (_google_protobuf_Duration__Output | null);
+  'until': (_google_protobuf_Timestamp__Output | null);
 }

--- a/proto/spacemesh/v1/EventPoetWaitProof.ts
+++ b/proto/spacemesh/v1/EventPoetWaitProof.ts
@@ -1,15 +1,18 @@
 // Original file: proto/admin_types.proto
 
 import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../google/protobuf/Duration';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../google/protobuf/Timestamp';
 
 export interface EventPoetWaitProof {
   'publish'?: (number);
   'target'?: (number);
   'wait'?: (_google_protobuf_Duration | null);
+  'until'?: (_google_protobuf_Timestamp | null);
 }
 
 export interface EventPoetWaitProof__Output {
   'publish': (number);
   'target': (number);
   'wait': (_google_protobuf_Duration__Output | null);
+  'until': (_google_protobuf_Timestamp__Output | null);
 }

--- a/proto/spacemesh/v1/EventPoetWaitRound.ts
+++ b/proto/spacemesh/v1/EventPoetWaitRound.ts
@@ -1,15 +1,18 @@
 // Original file: proto/admin_types.proto
 
 import type { Duration as _google_protobuf_Duration, Duration__Output as _google_protobuf_Duration__Output } from '../../google/protobuf/Duration';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../google/protobuf/Timestamp';
 
 export interface EventPoetWaitRound {
   'current'?: (number);
   'publish'?: (number);
   'wait'?: (_google_protobuf_Duration | null);
+  'until'?: (_google_protobuf_Timestamp | null);
 }
 
 export interface EventPoetWaitRound__Output {
   'current': (number);
   'publish': (number);
   'wait': (_google_protobuf_Duration__Output | null);
+  'until': (_google_protobuf_Timestamp__Output | null);
 }

--- a/proto/spacemesh/v1/EventPostComplete.ts
+++ b/proto/spacemesh/v1/EventPostComplete.ts
@@ -3,8 +3,10 @@
 
 export interface EventPostComplete {
   'challenge'?: (Buffer | Uint8Array | string);
+  'smesher'?: (Buffer | Uint8Array | string);
 }
 
 export interface EventPostComplete__Output {
   'challenge': (Buffer);
+  'smesher': (Buffer);
 }

--- a/proto/spacemesh/v1/EventPostStart.ts
+++ b/proto/spacemesh/v1/EventPostStart.ts
@@ -3,8 +3,10 @@
 
 export interface EventPostStart {
   'challenge'?: (Buffer | Uint8Array | string);
+  'smesher'?: (Buffer | Uint8Array | string);
 }
 
 export interface EventPostStart__Output {
   'challenge': (Buffer);
+  'smesher': (Buffer);
 }

--- a/proto/spacemesh/v1/MalfeasanceProof.ts
+++ b/proto/spacemesh/v1/MalfeasanceProof.ts
@@ -10,6 +10,7 @@ export enum _spacemesh_v1_MalfeasanceProof_MalfeasanceType {
   MALFEASANCE_ATX = 1,
   MALFEASANCE_BALLOT = 2,
   MALFEASANCE_HARE = 3,
+  MALFEASANCE_POST_INDEX = 4,
 }
 
 export interface MalfeasanceProof {

--- a/proto/spacemesh/v1/SmesherIDsResponse.ts
+++ b/proto/spacemesh/v1/SmesherIDsResponse.ts
@@ -1,0 +1,10 @@
+// Original file: proto/smesher_types.proto
+
+
+export interface SmesherIDsResponse {
+  'publicKeys'?: (Buffer | Uint8Array | string)[];
+}
+
+export interface SmesherIDsResponse__Output {
+  'publicKeys': (Buffer)[];
+}

--- a/proto/spacemesh/v1/SmesherService.ts
+++ b/proto/spacemesh/v1/SmesherService.ts
@@ -18,6 +18,7 @@ import type { SetCoinbaseResponse as _spacemesh_v1_SetCoinbaseResponse, SetCoinb
 import type { SetMinGasRequest as _spacemesh_v1_SetMinGasRequest, SetMinGasRequest__Output as _spacemesh_v1_SetMinGasRequest__Output } from '../../spacemesh/v1/SetMinGasRequest';
 import type { SetMinGasResponse as _spacemesh_v1_SetMinGasResponse, SetMinGasResponse__Output as _spacemesh_v1_SetMinGasResponse__Output } from '../../spacemesh/v1/SetMinGasResponse';
 import type { SmesherIDResponse as _spacemesh_v1_SmesherIDResponse, SmesherIDResponse__Output as _spacemesh_v1_SmesherIDResponse__Output } from '../../spacemesh/v1/SmesherIDResponse';
+import type { SmesherIDsResponse as _spacemesh_v1_SmesherIDsResponse, SmesherIDsResponse__Output as _spacemesh_v1_SmesherIDsResponse__Output } from '../../spacemesh/v1/SmesherIDsResponse';
 import type { StartSmeshingRequest as _spacemesh_v1_StartSmeshingRequest, StartSmeshingRequest__Output as _spacemesh_v1_StartSmeshingRequest__Output } from '../../spacemesh/v1/StartSmeshingRequest';
 import type { StartSmeshingResponse as _spacemesh_v1_StartSmeshingResponse, StartSmeshingResponse__Output as _spacemesh_v1_StartSmeshingResponse__Output } from '../../spacemesh/v1/StartSmeshingResponse';
 import type { StopSmeshingRequest as _spacemesh_v1_StopSmeshingRequest, StopSmeshingRequest__Output as _spacemesh_v1_StopSmeshingRequest__Output } from '../../spacemesh/v1/StopSmeshingRequest';
@@ -119,6 +120,15 @@ export interface SmesherServiceClient extends grpc.Client {
   smesherId(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDResponse__Output) => void): grpc.ClientUnaryCall;
   smesherId(argument: _google_protobuf_Empty, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDResponse__Output) => void): grpc.ClientUnaryCall;
   
+  SmesherIDs(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDsResponse__Output) => void): grpc.ClientUnaryCall;
+  SmesherIDs(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDsResponse__Output) => void): grpc.ClientUnaryCall;
+  SmesherIDs(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDsResponse__Output) => void): grpc.ClientUnaryCall;
+  SmesherIDs(argument: _google_protobuf_Empty, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDsResponse__Output) => void): grpc.ClientUnaryCall;
+  smesherIDs(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDsResponse__Output) => void): grpc.ClientUnaryCall;
+  smesherIDs(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDsResponse__Output) => void): grpc.ClientUnaryCall;
+  smesherIDs(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDsResponse__Output) => void): grpc.ClientUnaryCall;
+  smesherIDs(argument: _google_protobuf_Empty, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_SmesherIDsResponse__Output) => void): grpc.ClientUnaryCall;
+  
   StartSmeshing(argument: _spacemesh_v1_StartSmeshingRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_StartSmeshingResponse__Output) => void): grpc.ClientUnaryCall;
   StartSmeshing(argument: _spacemesh_v1_StartSmeshingRequest, metadata: grpc.Metadata, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_StartSmeshingResponse__Output) => void): grpc.ClientUnaryCall;
   StartSmeshing(argument: _spacemesh_v1_StartSmeshingRequest, options: grpc.CallOptions, callback: (error?: grpc.ServiceError, result?: _spacemesh_v1_StartSmeshingResponse__Output) => void): grpc.ClientUnaryCall;
@@ -162,6 +172,8 @@ export interface SmesherServiceHandlers extends grpc.UntypedServiceImplementatio
   
   SmesherID: grpc.handleUnaryCall<_google_protobuf_Empty__Output, _spacemesh_v1_SmesherIDResponse>;
   
+  SmesherIDs: grpc.handleUnaryCall<_google_protobuf_Empty__Output, _spacemesh_v1_SmesherIDsResponse>;
+  
   StartSmeshing: grpc.handleUnaryCall<_spacemesh_v1_StartSmeshingRequest__Output, _spacemesh_v1_StartSmeshingResponse>;
   
   StopSmeshing: grpc.handleUnaryCall<_spacemesh_v1_StopSmeshingRequest__Output, _spacemesh_v1_StopSmeshingResponse>;
@@ -180,6 +192,7 @@ export interface SmesherServiceDefinition extends grpc.ServiceDefinition {
   SetCoinbase: MethodDefinition<_spacemesh_v1_SetCoinbaseRequest, _spacemesh_v1_SetCoinbaseResponse, _spacemesh_v1_SetCoinbaseRequest__Output, _spacemesh_v1_SetCoinbaseResponse__Output>
   SetMinGas: MethodDefinition<_spacemesh_v1_SetMinGasRequest, _spacemesh_v1_SetMinGasResponse, _spacemesh_v1_SetMinGasRequest__Output, _spacemesh_v1_SetMinGasResponse__Output>
   SmesherID: MethodDefinition<_google_protobuf_Empty, _spacemesh_v1_SmesherIDResponse, _google_protobuf_Empty__Output, _spacemesh_v1_SmesherIDResponse__Output>
+  SmesherIDs: MethodDefinition<_google_protobuf_Empty, _spacemesh_v1_SmesherIDsResponse, _google_protobuf_Empty__Output, _spacemesh_v1_SmesherIDsResponse__Output>
   StartSmeshing: MethodDefinition<_spacemesh_v1_StartSmeshingRequest, _spacemesh_v1_StartSmeshingResponse, _spacemesh_v1_StartSmeshingRequest__Output, _spacemesh_v1_StartSmeshingResponse__Output>
   StopSmeshing: MethodDefinition<_spacemesh_v1_StopSmeshingRequest, _spacemesh_v1_StopSmeshingResponse, _spacemesh_v1_StopSmeshingRequest__Output, _spacemesh_v1_StopSmeshingResponse__Output>
 }

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -126,6 +126,7 @@ message MalfeasanceProof {
         MALFEASANCE_ATX = 1;
         MALFEASANCE_BALLOT = 2;
         MALFEASANCE_HARE = 3;
+        MALFEASANCE_POST_INDEX = 4;
     }
     MalfeasanceType kind = 3;
     string debug_info = 4;

--- a/shared/genericModal.ts
+++ b/shared/genericModal.ts
@@ -3,6 +3,7 @@ import { PickOptionalPropsOf } from './types/utils';
 export interface GenericButtonOpts {
   label: string;
   action: string | 'close';
+  primary?: boolean;
 }
 
 export interface GenericModalOpts {

--- a/shared/types/node.ts
+++ b/shared/types/node.ts
@@ -87,7 +87,8 @@ export interface NodeConfig {
   main: {
     'layer-duration': string; // "120s"
     'layers-per-epoch': number;
-    'poet-server'?: Array<string>;
+    'poet-server'?: Array<string>; // Outdated since v1.4.0
+    'poet-servers'?: Array<{ address: string; pubkey: string }>;
     'network-hrp'?: string;
     [k: string]: any;
   };

--- a/shared/types/smesher.ts
+++ b/shared/types/smesher.ts
@@ -61,7 +61,7 @@ export interface PostSetupStatus {
 export interface IPCSmesherStartupData {
   // TODO: Get rid of empty Record when we get rid of mixing erros and data (`normalizeServiceError`)
   config: SmesherConfig | Record<string, never>;
-  smesherId: string;
+  smesherIds: string[];
   postSetupState: PostSetupState;
   isSmeshingStarted: boolean;
   numLabelsWritten: number;


### PR DESCRIPTION
### It includes:
- Update API (v1) to use a new `SmesherIDs` endpoint instead of a deprecated `SmesherID`
- Display more than one SmesherID on the Smesher screen
- Display SmesherID in Node events
- Display a special Popup about outdated config (due to https://github.com/spacemeshos/go-spacemesh/blob/v1.4.0-alpha.1/CHANGELOG.md#configjson) before running the Node
   <video src="https://github.com/spacemeshos/smapp/assets/1897530/f95052dc-a9f6-4e69-8a5d-8d43b361a55f" controls>Your browser does not support the video tag.</video>


### Out of scope:
- Display synced activations amount
   It requires some changes to support more than one version of API at the same time. So I moved it out to another branch.

### How to test
1. Check out the branch
2. Download go-sm [v1.4.0-alpha.1](https://github.com/spacemeshos/go-spacemesh/releases/tag/v1.4.0-alpha.1) and put in `node/{mac|windows|linux}` directory
3. Specify `"api": {}` in your custom config.
    Once it is released, we will update the config in the discovery service and you won't need it.
4. Run Smapp: `yarn && yarn start`