### PR TITLE
Tweak handle statuses and errors

### DIFF
--- a/app/components/NetworkStatus/NetworkStatus.tsx
+++ b/app/components/NetworkStatus/NetworkStatus.tsx
@@ -42,6 +42,8 @@ const getStartupStatusText = (startupStatus: NodeStartupState, atxsCount) => {
       return 'Running database migrations...';
     case NodeStartupState.InitializingTortoise:
       return 'Initializing Tortoise...';
+    case NodeStartupState.InitializedTortoise:
+      return 'Waiting for Node readiness...';
     case NodeStartupState.PreparingCache:
       return 'Preparing node cache...';
     case NodeStartupState.Vacuuming:

--- a/app/screens/modal/CannotFetchConfigsError.tsx
+++ b/app/screens/modal/CannotFetchConfigsError.tsx
@@ -65,7 +65,7 @@ const CannotFetchConfigsError = () => {
 
   return (
     <ReactPortal modalId="spacemesh-folder-permission">
-      <Modal header="Error" subHeader={subheader} width={600} height={450}>
+      <Modal header="Error" subHeader={subheader} width={600} height={480}>
         <ErrorMessage>
           <RedText>
             Error occured during downloading the file:{'\n'}

--- a/app/screens/modal/GenericModal.tsx
+++ b/app/screens/modal/GenericModal.tsx
@@ -68,11 +68,7 @@ const GenericModal = () => {
             <ButtonNew
               key={ix}
               isPrimary={btn.primary || false}
-              onClick={
-                btn.action === 'close'
-                  ? () => close()
-                  : handleButtonClick(btn.action)
-              }
+              onClick={handleButtonClick(btn.action)}
               text={btn.label}
             />
           ))}

--- a/app/screens/node/Node.tsx
+++ b/app/screens/node/Node.tsx
@@ -270,7 +270,7 @@ const SmesherStatus = ({
         </SmesherId>
       </>
     ))}
-    is&nbsp;
+    &nbsp;is&nbsp;
     <StatusSpan status={status}> {status ? 'ONLINE' : ' OFFLINE'} </StatusSpan>
     &nbsp;on {networkName}.
   </SubHeader>

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -679,6 +679,8 @@ class NodeManager extends AbstractManager {
         sendStatus(NodeStartupState.Vacuuming);
       } else if (line.includes('initializing tortoise')) {
         sendStatus(NodeStartupState.InitializingTortoise);
+      } else if (line.includes('tortoise initialized')) {
+        sendStatus(NodeStartupState.InitializedTortoise);
       } else if (line.includes('starting cache warmup')) {
         sendStatus(NodeStartupState.PreparingCache);
       } else if (line.includes('candidate layer is verified')) {

--- a/desktop/NodeManager.ts
+++ b/desktop/NodeManager.ts
@@ -34,7 +34,10 @@ import {
   isLocalStateFarBehind,
   isQuicksyncAvailable,
 } from '../shared/quicksync';
-import { QuicksyncStatus } from '../shared/types/quicksync';
+import {
+  PausedQuicksyncStatus,
+  QuicksyncStatus,
+} from '../shared/types/quicksync';
 import StoreService from './storeService';
 import Logger from './logger';
 import NodeService, {
@@ -42,7 +45,7 @@ import NodeService, {
   StatusStreamHandler,
 } from './NodeService';
 import SmesherManager from './SmesherManager';
-import { createDebouncePool, getSpawnErrorReason } from './utils';
+import { createDebouncePool, fetch, getSpawnErrorReason } from './utils';
 import { isEmptyDir } from './fsUtils';
 import { NODE_CONFIG_FILE } from './main/constants';
 import {
@@ -466,6 +469,7 @@ class NodeManager extends AbstractManager {
   runQuicksyncPrompt = async (qsStatus: QuicksyncStatus) => {
     try {
       hideGenericModal(this.mainWindow.webContents);
+
       const prompt = await showGenericPrompt(this.mainWindow.webContents, {
         title: 'Run a Quicksync?',
         message: [
@@ -485,6 +489,38 @@ class NodeManager extends AbstractManager {
       });
 
       if (prompt) {
+        if (qsStatus.paused) {
+          const downloaded = (
+            qsStatus.paused.downloaded /
+            (1024 * 1024)
+          ).toFixed(1);
+          const total = (qsStatus.paused.total / (1024 * 1024)).toFixed(1);
+          const percent = (
+            (qsStatus.paused.downloaded / qsStatus.paused.total) *
+            100
+          ).toFixed(2);
+
+          const resume = await showGenericPrompt(this.mainWindow.webContents, {
+            title: 'Resume interrupted quicksync?',
+            message: [
+              'You have an incomplete download:',
+              `Layer: ${qsStatus.paused.layer}`,
+              `Progress: ${downloaded} MB / ${total} MB (${percent}%)`,
+              '',
+              'Do you want to resume downloading it?',
+              `Or download from scratch for layer: ${qsStatus.available}?`,
+            ].join('\n'),
+            confirmTitle: 'Yes, resume',
+            cancelTitle: 'Download from scratch',
+          });
+          if (!resume) {
+            const { urlFile, downloadFile } = this.getQuicksyncFiles(
+              this.getNodeDataPath()
+            );
+            await fse.remove(urlFile);
+            await fse.remove(downloadFile);
+          }
+        }
         await this.runQuicksyncDownload();
       }
     } catch (err) {
@@ -717,13 +753,65 @@ class NodeManager extends AbstractManager {
       getShortGenesisId(this.genesisID)
     );
 
-  private runQuicksyncCheck = () => {
+  private getQuicksyncFiles = (nodeData: string) => {
+    return {
+      urlFile: path.resolve(nodeData, 'state.url'),
+      downloadFile: path.resolve(nodeData, 'state.download'),
+    };
+  };
+
+  private checkForPausedQuicksync = async (
+    nodeData: string
+  ): Promise<PausedQuicksyncStatus | null> => {
+    const { urlFile, downloadFile } = this.getQuicksyncFiles(nodeData);
+    try {
+      const exists = await fse.pathExists(downloadFile);
+      if (!exists) {
+        // Remove URL file if nothing was downloaded
+        if (await fse.pathExists(urlFile)) {
+          await fse.remove(urlFile);
+        }
+        // And return that there is nothing to resume downloading
+        return null;
+      }
+      const url = await fse.readFile(urlFile, 'utf-8');
+      const layer = parseInt(url.match(/(\d+)\.sql\.(zip|zst)$/i)?.[0] || '0');
+      const resp = await fetch(url, { method: 'HEAD' });
+      const contentLength = resp.headers.get('content-length');
+      if (!resp.ok || !contentLength) {
+        throw new Error(
+          `Cannot fetch the size of trusted state: ${url} (Response ${resp.status}). Dropping files and starting over.`
+        );
+      }
+      const total = parseInt(contentLength);
+      const stat = await fse.stat(downloadFile);
+      const downloaded = stat.size;
+      return {
+        layer,
+        downloaded,
+        total,
+      };
+    } catch (err) {
+      logger.error('checkForPausedQuicksync', err, { urlFile, downloadFile });
+      try {
+        await fse.remove(urlFile);
+        await fse.remove(downloadFile);
+      } catch (err) {
+        logger.error('checkForPausedQuicksync.removeFiles', err);
+      }
+      return null;
+    }
+  };
+
+  private runQuicksyncCheck = async () => {
     const bin = getQuicksyncPath();
+    const nodeDataDir = this.getNodeDataPath();
+    const paused = await this.checkForPausedQuicksync(nodeDataDir);
     return new Promise<QuicksyncStatus>((resolve, reject) => {
       const args = [
         'check',
         '--node-data',
-        this.getNodeDataPath(),
+        nodeDataDir,
         '--go-spacemesh-path',
         getNodePath(),
       ];
@@ -779,6 +867,7 @@ class NodeManager extends AbstractManager {
           db,
           current,
           available,
+          paused,
         };
 
         this.sendToMainWindow(ipcConsts.UPDATE_QUICKSYNC_STATUS, result);
@@ -788,12 +877,13 @@ class NodeManager extends AbstractManager {
     }).catch((err) => {
       logger.error('runQuicksyncCheck', err);
       // Fallback to default syncing
-      return {
-        synced: true,
+      const res: QuicksyncStatus = {
         db: 0,
         current: 0,
         available: 0,
+        paused: null,
       };
+      return res;
     });
   };
 

--- a/desktop/utils.ts
+++ b/desktop/utils.ts
@@ -45,7 +45,15 @@ export const fetch = async (url: string, options?: RequestInit) => {
 };
 
 export const fetchJSON = async (url: string) =>
-  fetch(url).then((res) => res.json());
+  fetch(url).then((res) => {
+    if (!res.ok) {
+      logger.error('fetchJSON', { url, status: res.status });
+      throw new Error(
+        `Cannot fetch ${url}.\nResponse status code: ${res.status}`
+      );
+    }
+    return res.json();
+  });
 
 export const fetchNodeConfig = async (
   url: string,
@@ -53,14 +61,12 @@ export const fetchNodeConfig = async (
 ): Promise<NodeConfig> =>
   isTestMode() && url === STANDALONE_GENESIS_EXTRA
     ? getTestModeNodeConfig()
-    : fetch(
+    : fetchJSON(
         patchQueryString(url, {
           ...(await getEnvInfo()),
           ...(prevHash ? { hash: prevHash } : {}),
         })
-      )
-        .then((res) => res.text())
-        .then((res) => JSON.parse(res));
+      );
 
 export const isNetError = (error: Error) => error.message.startsWith('net::');
 

--- a/shared/types/quicksync.ts
+++ b/shared/types/quicksync.ts
@@ -1,5 +1,12 @@
+export interface PausedQuicksyncStatus {
+  layer: number;
+  downloaded: number;
+  total: number;
+}
+
 export interface QuicksyncStatus {
   db: number;
   current: number;
   available: number;
+  paused: PausedQuicksyncStatus | null;
 }

--- a/shared/types/states.ts
+++ b/shared/types/states.ts
@@ -17,6 +17,7 @@ export enum NodeStartupState {
   Compacting = 'Compacting',
   RunningMigrations = 'RunningMigrations',
   InitializingTortoise = 'InitializingTortoise',
+  InitializedTortoise = 'InitializedTortoise',
   PreparingCache = 'PreparingCache',
   Vacuuming = 'Vacuuming',
   VerifyingLayers = 'VerifyingLayers',


### PR DESCRIPTION
It contains a few tweaks:

- Display "Waiting for Node readiness" after having "tortoise initialized" log message. It is expected to have such a state for a few seconds, but at least once we caught the case with the node getting stuck on this stage. To not confuse Users with misleading "initializing tortoise" I've introduced such a state. If you know a better name for this "stage" — let me know 🙏 

- Refactor code a bit to avoid the case of displaying an error "Object is destroyed" when Smapp is closing (a rare thing, hard to reproduce). Now all `webContent.send` calls happen in a special method and it checks for `isDestroyed()` before

- Do not parse non-200 responses from discovery service and show a proper error (with the response code) instead of misleading "Unexpected character '<'"
   <img width="660" alt="image" src="https://github.com/spacemeshos/smapp/assets/1897530/648033e3-b488-435d-bc22-76c86849cbbd">

- Ask the User if he wants to resume downloading an interrupted quicksync.
   <img width="660" alt="image" src="https://github.com/spacemeshos/smapp/assets/1897530/ce2b75b9-3963-4e3b-b304-038a1907ed4d">