### PR TITLE
Update @spacemesh/ed25519-bip32 dependency to v0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ ct-libc/
 .vscode
 /desktop/dist
 /desktop/bip32_bg.wasm
+/desktop/index_bg.wasm
 key.bin

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -38,6 +38,7 @@ export default {
       NODE_ENV: 'production'
     }),
     new webpack.IgnorePlugin({ resourceRegExp: /^\.\/wordlists\/(?!english)/, contextRegExp: /bip39\/src$/ }),
-  ]
+    new webpack.IgnorePlugin({ resourceRegExp: /index_bg\.wasm$/, contextRegExp: /bip32/ }),
+  ],
 };
 

--- a/desktop/main/bip32-key-derivation.ts
+++ b/desktop/main/bip32-key-derivation.ts
@@ -1,4 +1,4 @@
-import { derive_key } from '@spacemesh/ed25519-bip32';
+import { derive_key } from '@spacemesh/ed25519-bip32/node';
 
 export default class Bip32KeyDerivation {
   static COIN_TYPE = 540;

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "@grpc/proto-loader": "0.6.2",
     "@reduxjs/toolkit": "^1.9.5",
     "@spacemesh/address-wasm": "^0.2.0",
-    "@spacemesh/ed25519-bip32": "^0.1.0",
+    "@spacemesh/ed25519-bip32": "^0.2.1",
     "@spacemesh/sm-codec": "^0.4.1",
     "auto-launch": "^5.0.6",
     "bip39": "3.0.3",

--- a/scripts/packagerScript.ts
+++ b/scripts/packagerScript.ts
@@ -53,7 +53,7 @@ const getBuildOptions = ({ target }) => {
         'desktop/main.prod.js',
         'desktop/main.prod.js.map',
         'desktop/wasm_exec.js',
-        'desktop/bip32_bg.wasm',
+        'desktop/index_bg.wasm',
         'desktop/config.json',
         'package.json',
         'vendor/',
@@ -163,10 +163,10 @@ const getBuildOptions = ({ target }) => {
 };
 
 const preBuild = async () => {
-  // Copy bip32_bg.wasm to /desktop/bip32_bg.wasm
+  // Copy index_bg.wasm to /desktop/index_bg.wasm
   await fs.copyFile(
-    path.join(__dirname, '../node_modules/@spacemesh/ed25519-bip32/gen/bip32_bg.wasm'),
-    path.join(__dirname, '../desktop/bip32_bg.wasm')
+    path.join(__dirname, '../node_modules/@spacemesh/ed25519-bip32/node/index_bg.wasm'),
+    path.join(__dirname, '../desktop/index_bg.wasm')
   );
 
   return true;

--- a/tests/desktop/bip32.spec.ts
+++ b/tests/desktop/bip32.spec.ts
@@ -1,0 +1,17 @@
+import { derive_key } from '@spacemesh/ed25519-bip32/node';
+
+describe('ed25519-bip32/derive_key', () => {
+  it('deriveKey', () => {
+    const seed = new Uint8Array(64).fill(0);
+    const seed2 = new Uint8Array(64).fill(1);
+
+    const keypair0 = derive_key(seed, "m/44'/540'/0'/0'/0'");
+    const keypair01 = derive_key(seed, "m/44'/540'/0'/0'/0'");
+    const keypair2 = derive_key(seed, "m/44'/540'/0'/0'/2'");
+    const keypair3 = derive_key(seed2, "m/44'/540'/0'/0'/0'");
+
+    expect(keypair0).toEqual(keypair01);
+    expect(keypair0).not.toEqual(keypair2);
+    expect(keypair0).not.toEqual(keypair3);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2541,10 +2541,10 @@
   resolved "https://registry.yarnpkg.com/@spacemesh/address-wasm/-/address-wasm-0.2.1.tgz#ae6468eb9a9063b3bd33c662966aba1dcd36444f"
   integrity sha512-YsQiZ4edwUts4rwJpYGxpkQgleKjzNyyi626ep03saCCxN4/yksSh5Gn987QS6KxWJlNufZM1KHnUq4+Kasr5g==
 
-"@spacemesh/ed25519-bip32@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@spacemesh/ed25519-bip32/-/ed25519-bip32-0.1.0.tgz#cbdaaa4c8606ff834a95d0434d49b57a5689ce82"
-  integrity sha512-paXkpc5Vj/XoSPGYtUyoqmc4TOfw735udx+HtIGmxhnCQaW3ar0zFOKm9ACPqsM0BF5AbSea5th3uxRmqFpcag==
+"@spacemesh/ed25519-bip32@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@spacemesh/ed25519-bip32/-/ed25519-bip32-0.2.1.tgz#f622616060fb477b1fbc5d1292ff21993927a3b2"
+  integrity sha512-wwB9FHotFBc1IqYLNZRXt9jZIm7K4gWap4EaotEGeoRLvVJNR/J63TXZBEsHhPrMOWTC2yAcxi6GC47bxsYOhA==
 
 "@spacemesh/sm-codec@^0.4.1":
   version "0.4.1"


### PR DESCRIPTION
Just switched to the version of library that supports both NodeJS and Browser environment
Library is published to NPM but have to be also updated in sapcemesh-sdk repo (I have changed it in the archived repo) :)